### PR TITLE
Implement Pay Later messages in JS SDK v6 (5784)

### DIFF
--- a/modules/ppcp-sdk-v6/extensions.php
+++ b/modules/ppcp-sdk-v6/extensions.php
@@ -19,18 +19,20 @@ return array(
 	/**
 	 * Both SDKs claim the window.paypal global, so the v5 smart-button
 	 * script must not load on pages where the v6 SDK loads. On pages v6
-	 * owns (classic product/cart/checkout, block cart/checkout, and the
-	 * Add Payment Method page) every v5 surface consuming this service's
+	 * owns (classic product/cart/checkout/pay-now, block cart/checkout, and
+	 * the Add Payment Method page) every v5 surface consuming this service's
 	 * script_data() goes dark, including block card fields and the regular
 	 * block method: that is accepted migration-state breakage until their
-	 * own stories migrate them. On the pages v6 does not own (pay-now) the
-	 * v5 stack keeps running: the blocks, applepay, googlepay and axo
-	 * modules would break under a blanket disable.
+	 * own stories migrate them.
 	 *
 	 * The Add Payment Method page is v6-owned by the vaulting story: v6
 	 * renders the save button + card save fields there, so the v5
 	 * add-payment-method script is suppressed too (SavePaymentMethodsModule,
 	 * via woocommerce_paypal_payments_render_add_payment_method_assets).
+	 *
+	 * Pay Later messaging counts towards ownership too, so a classic page
+	 * with messaging enabled and no button hands over as well — see
+	 * SdkV6Manager::should_load_on_current_page().
 	 *
 	 * MIGRATION-PHASE ONLY: this per-page handoff exists so the site and
 	 * the test suites stay fully functional while the v6 migration

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -24,6 +24,7 @@ import { isWalletEnabled, WALLET_METHODS } from './wallets/walletRegistry';
 import { createOrder, fetchCartTotal } from './endpointsAdapter';
 import { initCardFields } from './cardFields/renderer';
 import { hasJQuery } from './utils/api';
+import { watchViewedTotal } from './utils/viewedTotal';
 import { setErrorLabels } from './utils/errorHandler';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
 import { debounce } from '@ppcp-blocks/Helper/debounce';
@@ -329,10 +330,24 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 		} );
 	}
 
+	/**
+	 * A product page prices the product on display, not the cart, so its
+	 * message tracks the product form — quantity and variation — through
+	 * the same watcher Apple Pay reads.
+	 */
+	function trackProductTotal() {
+		if ( 'product' !== config.page_context ) {
+			return;
+		}
+
+		watchViewedTotal( config, 'product' ).subscribe( updateMessagesAmount );
+	}
+
 	function initialRender() {
 		renderAll();
 		initCardFieldsSafely();
 		initMessagesSafely();
+		trackProductTotal();
 		syncPlaceOrderButton();
 	}
 
@@ -359,16 +374,6 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 				} );
 			}
 		);
-
-		// The product page has no cart events; WooCommerce announces the
-		// selected variation instead. Quantity and add-on driven changes are
-		// not covered — v5 gets those from the ppc-simulate-cart endpoint,
-		// which is part of the v5 button bundle this page no longer loads.
-		jQuery( document.body ).on( 'found_variation', ( event, variation ) => {
-			if ( variation?.display_price ) {
-				updateMessagesAmount( String( variation.display_price ) );
-			}
-		} );
 
 		// WC rebuilds #place_order on these too, and the selected method can
 		// change without a DOM rebuild, so re-sync the button on both.

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -26,12 +26,15 @@ import { initCardFields } from './cardFields/renderer';
 import { hasJQuery } from './utils/api';
 import { setErrorLabels } from './utils/errorHandler';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
+import { debounce } from '@ppcp-blocks/Helper/debounce';
 
 // The native WC submit button, labelled "Proceed to PayPal" for the PayPal
 // gateway. It is replaced by the v6 PayPal buttons while the PayPal gateway is
 // selected, but stays as the submit for cards and every other method.
 const PLACE_ORDER_SELECTOR = '#place_order';
 const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
+
+const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 
 ( function ( config ) {
 	'use strict';
@@ -74,6 +77,7 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	const sdkPageType = config.page_context || 'mini-cart';
 
 	let amount = config.amount;
+	let refreshPromise = Promise.resolve();
 	let eligibilityPromise = null;
 	const sessionPromises = {};
 	const renderPromises = {};
@@ -261,6 +265,31 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	}
 
 	/**
+	 * Serialises refreshEligibility() passes, same chain idiom as render().
+	 *
+	 * It is needed because the debounce coalesces events but cannot stop one pass
+     * starting while another awaits the network, and overlapping passes may leave the
+     * buttons on the older result.
+	 *
+	 * @return {Promise<void>} Resolves once this pass is done.
+	 */
+	function queueRefreshEligibility() {
+		refreshPromise = refreshPromise
+			.catch( () => {} )
+			.then( () => refreshEligibility() );
+
+		return refreshPromise.catch( ( error ) => {
+			// eslint-disable-next-line no-console
+			console.error( '[PPCP SDK v6]', error );
+		} );
+	}
+
+	const refreshEligibilityDebounced = debounce(
+		queueRefreshEligibility,
+		ELIGIBILITY_REFRESH_DEBOUNCE_MS
+	);
+
+	/**
 	 * Hides the native WC "Proceed to PayPal" button while the PayPal gateway
 	 * is selected — the v6 PayPal buttons stand in for it — and restores it for
 	 * cards (whose flow submits through it) and every other method. Re-run on
@@ -309,15 +338,11 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 			syncPlaceOrderButton
 		);
 
-		// Total-changing updates: eligibility must be re-checked too.
+		// Total-changing updates: eligibility must be re-checked too, and the
+		// message re-priced.
 		jQuery( document.body ).on(
-			'updated_cart_totals added_to_cart removed_from_cart',
-			() => {
-				refreshEligibility().catch( ( error ) => {
-					// eslint-disable-next-line no-console
-					console.error( '[PPCP SDK v6]', error );
-				} );
-			}
+			'updated_cart_totals added_to_cart removed_from_cart updated_checkout',
+			refreshEligibilityDebounced
 		);
 	}
 } )( window.wc_ppcp_sdk_v6 );

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -27,6 +27,11 @@ import { hasJQuery } from './utils/api';
 import { setErrorLabels } from './utils/errorHandler';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
 import { debounce } from '@ppcp-blocks/Helper/debounce';
+import {
+	initMessages,
+	renderMessages,
+	updateMessagesAmount,
+} from './messages/renderer';
 
 // The native WC submit button, labelled "Proceed to PayPal" for the PayPal
 // gateway. It is replaced by the v6 PayPal buttons while the PayPal gateway is
@@ -75,6 +80,8 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 	} );
 
 	const sdkPageType = config.page_context || 'mini-cart';
+
+	const messagesFollowCartTotal = 'product' !== config.page_context;
 
 	let amount = config.amount;
 	let refreshPromise = Promise.resolve();
@@ -240,6 +247,9 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 			: null;
 
 		amount = ( await fetchCartTotal( config ) ) || amount;
+		if ( messagesFollowCartTotal ) {
+			updateMessagesAmount( amount );
+		}
 		eligibilityPromise = null;
 		const current = await ensureEligibility();
 
@@ -312,9 +322,17 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 		setVisible( PLACE_ORDER_SELECTOR, ! isPayPalGateway, true );
 	}
 
+	function initMessagesSafely() {
+		initMessages( config, sdkPageType ).catch( ( error ) => {
+			// eslint-disable-next-line no-console
+			console.error( '[PPCP SDK v6]', error );
+		} );
+	}
+
 	function initialRender() {
 		renderAll();
 		initCardFieldsSafely();
+		initMessagesSafely();
 		syncPlaceOrderButton();
 	}
 
@@ -328,8 +346,29 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 		// DOM-replacing updates: wrappers arrive empty and need re-rendering.
 		jQuery( document.body ).on(
 			'updated_checkout wc_fragments_loaded wc_fragments_refreshed',
-			renderAll
+			() => {
+				renderAll();
+
+				// Messages are a separate pass: they target every
+				// .ppcp-messages placeholder rather than the button
+				// wrappers, and must survive refreshEligibility()'s wrapper
+				// blanking.
+				renderMessages( config, sdkPageType ).catch( ( error ) => {
+					// eslint-disable-next-line no-console
+					console.error( '[PPCP SDK v6]', error );
+				} );
+			}
 		);
+
+		// The product page has no cart events; WooCommerce announces the
+		// selected variation instead. Quantity and add-on driven changes are
+		// not covered — v5 gets those from the ppc-simulate-cart endpoint,
+		// which is part of the v5 button bundle this page no longer loads.
+		jQuery( document.body ).on( 'found_variation', ( event, variation ) => {
+			if ( variation?.display_price ) {
+				updateMessagesAmount( String( variation.display_price ) );
+			}
+		} );
 
 		// WC rebuilds #place_order on these too, and the selected method can
 		// change without a DOM rebuild, so re-sync the button on both.

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -29,6 +29,8 @@ import { V6EditorPreview } from './blocks/V6EditorPreview';
 import { FundingSources } from './utils/fundingSources';
 import { fundingSourceLabel } from './utils/fundingSourceLabel';
 import { minorUnitsToDecimal } from './utils/amount';
+import { initMessages, updateMessagesAmount } from './messages/renderer';
+import { watchBlockCartTotal } from './messages/cartTotalWatcher';
 
 const FUNDING_SOURCES = [
 	FundingSources.PAYPAL,
@@ -207,4 +209,23 @@ if ( config?.card_fields?.enabled && ! config.continuation ) {
 			showSaveOption: Boolean( config.card_fields.is_vaulting_enabled ),
 		},
 	} );
+}
+
+/**
+ * Pay Later messages on the block cart and checkout.
+ *
+ * Done at module scope: messaging needs only the config and the DOM, not eligibility
+ * or a session. Skipped in continuation mode, where the buyer has approved an
+ * order and sees the review instead.
+ *
+ * Placeholders arrive with the React tree, so the body observer that
+ * initMessages() installs is what actually fills them.
+ */
+if ( config?.messages?.enabled && ! config.continuation ) {
+	initMessages( config, config.page_context ).catch( ( error ) => {
+		// eslint-disable-next-line no-console
+		console.error( '[ppcp-sdk-v6] messages', error );
+	} );
+
+	watchBlockCartTotal( updateMessagesAmount );
 }

--- a/modules/ppcp-sdk-v6/resources/js/messages/cartTotalWatcher.js
+++ b/modules/ppcp-sdk-v6/resources/js/messages/cartTotalWatcher.js
@@ -1,0 +1,53 @@
+/**
+ * Watches the WooCommerce Blocks cart total for Pay Later messaging.
+ *
+ * Block-only, so it is kept out of `messages/renderer.js`: importing it there
+ * would put `@wordpress/data` in the `boot.js` graph and make every classic
+ * product, cart and checkout page depend on `wp-data` for a store it never
+ * reads.
+ *
+ * @package
+ */
+
+import { select, subscribe } from '@wordpress/data';
+
+import { minorUnitsToDecimal } from '../utils/amount';
+
+const CART_STORE_KEY = 'wc/store/cart';
+
+/**
+ * Reads the cart total as a decimal string.
+ *
+ * @return {string} The total, or '' when the store is unavailable.
+ */
+function readCartTotal() {
+	const totals = select( CART_STORE_KEY )?.getCartTotals?.();
+	if ( ! totals ) {
+		return '';
+	}
+
+	return minorUnitsToDecimal( totals.total_price, totals.currency_minor_unit );
+}
+
+/**
+ * Calls back whenever the block cart total changes.
+ *
+ * The store notifies on every mutation, most of which leave the total alone,
+ * so the callback fires only on an actual change.
+ *
+ * @param {(total: string) => void} onChange - Called with the new total.
+ * @return {Function} Unsubscribes the watcher.
+ */
+export function watchBlockCartTotal( onChange ) {
+	let lastTotal = readCartTotal();
+
+	return subscribe( () => {
+		const total = readCartTotal();
+		if ( ! total || total === lastTotal ) {
+			return;
+		}
+
+		lastTotal = total;
+		onChange( total );
+	} );
+}

--- a/modules/ppcp-sdk-v6/resources/js/messages/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/messages/renderer.js
@@ -1,0 +1,308 @@
+/**
+ * Renders Pay Later messages with the PayPal SDK v6 messages component.
+ *
+ * Fills every `.ppcp-messages` placeholder with a `<paypal-message>` element.
+ *
+ * Free of `@wordpress/*` imports: this is reachable from `boot.js`, and classic
+ * pages should not gain a WP dependency for it.
+ *
+ * @package
+ */
+
+import { loadSdkV6 } from '../sdkLoader';
+
+const MESSAGE_TAG_NAME = 'paypal-message';
+
+// Two guards, for two different problems. Idempotence reads the actual child,
+// because block pages replace the placeholder node during their client render
+// and a marker attribute would go with the old one. The WeakSet covers the
+// window where callers race across the awaited SDK load.
+let inFlight = new WeakSet();
+let watching = false;
+let rescanTimer = null;
+
+const RESCAN_DEBOUNCE_MS = 100;
+
+// Mapping of v5 placements from `data-pp-placement` of the Pay Later block.
+// `payment` is what the checkout block emits.
+const PLACEMENT_PAGE_TYPES = {
+	product: 'product-details',
+	'product-list': 'product-listing',
+	cart: 'cart',
+	payment: 'checkout',
+	checkout: 'checkout',
+	home: 'home',
+};
+
+// v5 styles from `data-pp-style-*`. Mirrors MessageStyleMapper.
+const LOGO_TYPES = {
+	primary: 'WORDMARK',
+	alternative: 'MONOGRAM',
+	inline: 'WORDMARK',
+	none: 'TEXT',
+};
+const LOGO_POSITIONS = { left: 'LEFT', right: 'RIGHT', top: 'TOP' };
+const TEXT_COLORS = {
+	black: 'BLACK',
+	white: 'WHITE',
+	monochrome: 'MONOCHROME',
+	grayscale: 'MONOCHROME',
+};
+
+const FONT_SIZE_MIN = 10;
+const FONT_SIZE_MAX = 16;
+
+let messagesInstance = null;
+let rendered = [];
+let latestAmount = null;
+
+/**
+ * Resets the module state. Test-only.
+ */
+export function resetMessages() {
+	messagesInstance = null;
+	rendered = [];
+	latestAmount = null;
+	inFlight = new WeakSet();
+	watching = false;
+	clearTimeout( rescanTimer );
+	rescanTimer = null;
+}
+
+/**
+ * Starts watching for placeholders and fills the ones already present.
+ *
+ * Observer first, so a placeholder inserted while the initial pass awaits the
+ * SDK still triggers a rescan.
+ *
+ * @param {Object} config      - The wc_ppcp_sdk_v6 config object.
+ * @param {string} sdkPageType - The page context for the shared SDK instance.
+ * @return {Promise<number>} How many messages the initial pass rendered.
+ */
+export async function initMessages( config, sdkPageType ) {
+    if ( ! config?.messages?.enabled || config.messages.is_hidden ) {
+        return 0;
+    }
+
+    watchForWrappers( config, sdkPageType );
+
+    return renderMessages( config, sdkPageType );
+}
+
+/**
+ * Clamps the v5 text size onto the range the v6 component accepts.
+ *
+ * @param {string} size - The configured text size.
+ * @return {string} A CSS length, or '' when the size is unusable.
+ */
+function fontSize( size ) {
+	const parsed = parseInt( size, 10 );
+	if ( Number.isNaN( parsed ) ) {
+		return '';
+	}
+
+	return `${ Math.max(
+		FONT_SIZE_MIN,
+		Math.min( FONT_SIZE_MAX, parsed )
+	) }px`;
+}
+
+/**
+ * Resolves the style for one placeholder.
+ *
+ * A wrapper's own `data-pp-style-*` wins over the page config: the Pay Later
+ * blocks are styled per block, not from the location settings.
+ *
+ * @param {Element} wrapper     - The placeholder element.
+ * @param {Object}  configStyle - The style from the localized config.
+ * @return {Object} The v6 style values.
+ */
+function styleFor( wrapper, configStyle ) {
+	const logoType = wrapper.getAttribute( 'data-pp-style-logo-type' );
+	if ( ! logoType ) {
+		return configStyle;
+	}
+
+	const position = wrapper.getAttribute( 'data-pp-style-logo-position' );
+
+	return {
+		logoType: LOGO_TYPES[ logoType ] || 'WORDMARK',
+		logoPosition:
+			'inline' === logoType
+				? 'INLINE'
+				: LOGO_POSITIONS[ position ] || 'LEFT',
+		textColor:
+			TEXT_COLORS[ wrapper.getAttribute( 'data-pp-style-text-color' ) ] ||
+			'BLACK',
+		fontSize: fontSize( wrapper.getAttribute( 'data-pp-style-text-size' ) ),
+	};
+}
+
+/**
+ * Resolves the v6 page type for one placeholder.
+ *
+ * @param {Element} wrapper - The placeholder element.
+ * @param {Object}  config  - The wc_ppcp_sdk_v6 config object.
+ * @return {string} The v6 page type.
+ */
+function pageTypeFor( wrapper, config ) {
+	const placement = wrapper.getAttribute( 'data-pp-placement' );
+
+	return PLACEMENT_PAGE_TYPES[ placement ] || config.messages.page_type;
+}
+
+/**
+ * Finds placeholders that still need a message.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {Element[]} The placeholders to fill.
+ */
+function wrappersNeedingMessage( config ) {
+	return Array.from(
+		document.querySelectorAll( config.messages.wrapper )
+	).filter(
+		( wrapper ) =>
+			! inFlight.has( wrapper ) &&
+			! wrapper.querySelector( MESSAGE_TAG_NAME )
+	);
+}
+
+/**
+ * Re-runs discovery on DOM changes.
+ *
+ * Observes document.body, not the placeholders: block pages replace those,
+ * which would leave an observer holding a detached node.
+ *
+ * @param {Object} config      - The wc_ppcp_sdk_v6 config object.
+ * @param {string} sdkPageType - The page context for the shared SDK instance.
+ */
+function watchForWrappers( config, sdkPageType ) {
+	if ( watching || ! document.body ) {
+		return;
+	}
+	watching = true;
+
+	new MutationObserver( () => {
+		clearTimeout( rescanTimer );
+		rescanTimer = setTimeout( () => {
+			renderMessages( config, sdkPageType ).catch( () => {} );
+		}, RESCAN_DEBOUNCE_MS );
+	} ).observe( document.body, { childList: true, subtree: true } );
+}
+
+/**
+ * Builds a message Web Component, not yet in the DOM.
+ *
+ * Every attribute must be set before insertion: the component reads them on
+ * connect.
+ *
+ * @param {Element} wrapper - The placeholder to build for.
+ * @param {Object}  config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string}  amount  - The amount to price.
+ * @return {Element} The configured element.
+ */
+function createMessage( wrapper, config, amount ) {
+	const style = styleFor( wrapper, config.messages.style );
+	const element = document.createElement( MESSAGE_TAG_NAME );
+
+	// Required: without it the component lays out but never fetches, leaving an
+	// empty one-line box.
+	element.setAttribute( 'auto-bootstrap', '' );
+
+	if ( amount ) {
+		element.setAttribute( 'amount', amount );
+	}
+	element.setAttribute( 'currency-code', config.currency );
+	element.setAttribute( 'page-type', pageTypeFor( wrapper, config ) );
+	element.setAttribute( 'logo-type', style.logoType );
+	element.setAttribute( 'logo-position', style.logoPosition );
+	element.setAttribute( 'text-color', style.textColor );
+
+	if ( style.fontSize ) {
+		element.style.setProperty(
+			'--paypal-message-font-size',
+			style.fontSize
+		);
+	}
+
+	return element;
+}
+
+/**
+ * Fills every unclaimed placeholder with a message, once.
+ *
+ * The SDK is only loaded when there is something to render, so a page with no
+ * placeholder never reaches the client-token endpoint — the same discipline
+ * boot.js applies to buttons.
+ *
+ * @param {Object} config      - The wc_ppcp_sdk_v6 config object.
+ * @param {string} sdkPageType - The page context for the shared SDK instance.
+ * @return {Promise<number>} How many messages were rendered.
+ */
+export async function renderMessages( config, sdkPageType ) {
+	if ( ! config?.messages?.enabled || config.messages.is_hidden ) {
+		return 0;
+	}
+
+	const wrappers = wrappersNeedingMessage( config );
+	if ( ! wrappers.length ) {
+		return 0;
+	}
+
+	// Before the first await: several callers race on a normal page load, and
+	// each would otherwise see the same unfilled wrapper.
+	wrappers.forEach( ( wrapper ) => inFlight.add( wrapper ) );
+
+	try {
+		const sdk = await loadSdkV6( config, sdkPageType );
+
+		if ( ! messagesInstance ) {
+			messagesInstance = sdk.createPayPalMessages( {
+				currencyCode: config.currency,
+			} );
+		}
+
+		const amount = currentAmount( config );
+
+		wrappers.forEach( ( wrapper ) => {
+			const element = createMessage( wrapper, config, amount );
+			wrapper.appendChild( element );
+			rendered.push( element );
+		} );
+	} finally {
+		// Released either way, so a later pass can pick these up.
+		wrappers.forEach( ( wrapper ) => inFlight.delete( wrapper ) );
+	}
+
+	return wrappers.length;
+}
+
+/**
+ * The amount messages should currently price.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {string} The amount.
+ */
+function currentAmount( config ) {
+	return latestAmount ?? config.messages.amount;
+}
+
+/**
+ * Re-prices every rendered message.
+ *
+ * Assigning `amount` re-renders in place. Detached elements are pruned, since
+ * WooCommerce replaces the cart and checkout DOM wholesale.
+ *
+ * @param {string} amount - The new amount.
+ */
+export function updateMessagesAmount( amount ) {
+	if ( ! amount ) {
+		return;
+	}
+
+	latestAmount = amount;
+	rendered = rendered.filter( ( element ) => element.isConnected );
+	rendered.forEach( ( element ) => {
+		element.amount = amount;
+	} );
+}

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -64,6 +64,9 @@ async function createInstance( config, context ) {
 		components.push( 'card-fields' );
 	}
 	components.push( ...walletSdkComponents( config ) );
+	if ( config.messages?.enabled ) {
+		components.push( 'paypal-messages' );
+	}
 
 	const sdkInstance = await window.paypal.createInstance( {
 		clientToken: tokenData.client_token,

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
@@ -89,4 +89,76 @@ describe( 'loadSdkV6', () => {
 			} )
 		);
 	} );
+
+	test( 'requests paypal-messages only when config.messages.enabled is true', async () => {
+		await loadSdkV6(
+			baseConfig( { messages: { enabled: true } } ),
+			'product'
+		);
+
+		expect( window.paypal.createInstance ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				components: expect.arrayContaining( [ 'paypal-messages' ] ),
+			} )
+		);
+	} );
+
+	test( 'omits paypal-messages when config.messages.enabled is false', async () => {
+		await loadSdkV6(
+			baseConfig( { messages: { enabled: false } } ),
+			'product'
+		);
+
+		expect( window.paypal.createInstance ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				components: expect.not.arrayContaining( [
+					'paypal-messages',
+				] ),
+			} )
+		);
+	} );
+
+	test( 'requests card-fields regardless of the messages setting', async () => {
+		await loadSdkV6(
+			baseConfig( {
+				card_fields: { enabled: true },
+				messages: { enabled: true },
+			} ),
+			'checkout'
+		);
+
+		expect( window.paypal.createInstance ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				components: expect.arrayContaining( [
+					'card-fields',
+					'paypal-messages',
+				] ),
+			} )
+		);
+	} );
+
+	test( 'shares one instance across concurrent callers: one createInstance call and one client-token fetch', async () => {
+		const config = baseConfig();
+
+		const first = loadSdkV6( config, 'cart' );
+		const second = loadSdkV6( config, 'checkout' );
+
+		const [ firstSdk, secondSdk ] = await Promise.all( [ first, second ] );
+
+		expect( firstSdk ).toBe( secondSdk );
+		expect( window.paypal.createInstance ).toHaveBeenCalledTimes( 1 );
+		expect( mockPostJson ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'uses the page type of the first caller for the shared instance', async () => {
+		const config = baseConfig();
+
+		const first = loadSdkV6( config, 'cart' );
+		const second = loadSdkV6( config, 'checkout' );
+		await Promise.all( [ first, second ] );
+
+		expect( window.paypal.createInstance ).toHaveBeenCalledWith(
+			expect.objectContaining( { pageType: 'cart' } )
+		);
+	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
@@ -66,6 +66,11 @@ jest.mock( '../messages/renderer', () => ( {
 	updateMessagesAmount: ( ...args ) => mockUpdateMessagesAmount( ...args ),
 } ) );
 
+const mockWatchViewedTotal = jest.fn();
+jest.mock( '../utils/viewedTotal', () => ( {
+	watchViewedTotal: ( ...args ) => mockWatchViewedTotal( ...args ),
+} ) );
+
 const WRAPPER_SELECTOR = '#ppcp-button-checkout';
 const MINI_CART_WRAPPER_SELECTOR = '#ppcp-mini-cart-button';
 
@@ -156,6 +161,10 @@ beforeEach( () => {
 	mockInitMessages.mockResolvedValue( 0 );
 	mockRenderMessages.mockResolvedValue( 0 );
 	mockFetchCartTotal.mockResolvedValue( '120.00' );
+	mockWatchViewedTotal.mockReturnValue( {
+		get: () => '',
+		subscribe: () => () => {},
+	} );
 } );
 
 afterEach( () => {
@@ -256,7 +265,7 @@ describe( 'boot', () => {
 			expect( mockUpdateMessagesAmount ).toHaveBeenCalledWith( '120.00' );
 		} );
 
-		test( 'updateMessagesAmount is not called on a product page, since a product page keeps pricing the product', async () => {
+		test( 'updateMessagesAmount is not called from the cart-refresh path on a product page, since a product page prices via the watcher instead', async () => {
 			buildDom();
 			boot( baseConfig( { page_context: 'product' } ) );
 			await flush();
@@ -306,15 +315,37 @@ describe( 'boot', () => {
 		} );
 	} );
 
-	describe( 'found_variation event', () => {
-		test( 'a variation with a display_price re-prices the message', async () => {
+	describe( 'product-page total watcher', () => {
+		test( 'subscribes to the shared watcher on a product page and forwards its pushes to the message amount', async () => {
+			let notify;
+			mockWatchViewedTotal.mockReturnValue( {
+				get: () => '',
+				subscribe: ( callback ) => {
+					notify = callback;
+					return () => {};
+				},
+			} );
+
 			buildDom();
 			boot( baseConfig( { page_context: 'product' } ) );
 			await flush();
 
-			global.jQuery.trigger( 'found_variation', { display_price: 42 } );
+			expect( mockWatchViewedTotal ).toHaveBeenCalledWith(
+				expect.objectContaining( { page_context: 'product' } ),
+				'product'
+			);
 
-			expect( mockUpdateMessagesAmount ).toHaveBeenCalledWith( '42' );
+			notify( '42.00' );
+
+			expect( mockUpdateMessagesAmount ).toHaveBeenCalledWith( '42.00' );
+		} );
+
+		test( 'never subscribes to the watcher off a product page', async () => {
+			buildDom();
+			boot( baseConfig( { page_context: 'checkout' } ) );
+			await flush();
+
+			expect( mockWatchViewedTotal ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
@@ -1,0 +1,320 @@
+const mockHasJQuery = jest.fn();
+jest.mock( '../utils/api', () => ( {
+	hasJQuery: () => mockHasJQuery(),
+} ) );
+
+const mockSetErrorLabels = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	setErrorLabels: ( ...args ) => mockSetErrorLabels( ...args ),
+} ) );
+
+const mockSetVisible = jest.fn();
+jest.mock( '@ppcp-button/Helper/Hiding', () => ( {
+	setVisible: ( ...args ) => mockSetVisible( ...args ),
+} ) );
+
+const mockLoadSdkV6 = jest.fn();
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+
+const mockCheckEligibility = jest.fn();
+jest.mock( '../eligibility', () => ( {
+	checkEligibility: ( ...args ) => mockCheckEligibility( ...args ),
+} ) );
+
+const mockCreateSession = jest.fn();
+jest.mock( '../sessions/createSession', () => ( {
+	createSession: ( ...args ) => mockCreateSession( ...args ),
+	SUPPORTED_METHODS: [ 'paypal', 'venmo', 'paylater' ],
+} ) );
+
+const mockRenderButtons = jest.fn();
+jest.mock( '../components/buttonRenderer', () => ( {
+	renderButtons: ( ...args ) => mockRenderButtons( ...args ),
+} ) );
+
+const mockRenderWallets = jest.fn();
+jest.mock( '../wallets/renderWallets', () => ( {
+	renderWallets: ( ...args ) => mockRenderWallets( ...args ),
+} ) );
+
+const mockIsWalletEnabled = jest.fn();
+jest.mock( '../wallets/walletRegistry', () => ( {
+	isWalletEnabled: ( ...args ) => mockIsWalletEnabled( ...args ),
+	WALLET_METHODS: [],
+} ) );
+
+const mockCreateOrder = jest.fn();
+const mockFetchCartTotal = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	createOrder: ( ...args ) => mockCreateOrder( ...args ),
+	fetchCartTotal: ( ...args ) => mockFetchCartTotal( ...args ),
+} ) );
+
+const mockInitCardFields = jest.fn();
+jest.mock( '../cardFields/renderer', () => ( {
+	initCardFields: ( ...args ) => mockInitCardFields( ...args ),
+} ) );
+
+const mockInitMessages = jest.fn();
+const mockRenderMessages = jest.fn();
+const mockUpdateMessagesAmount = jest.fn();
+jest.mock( '../messages/renderer', () => ( {
+	initMessages: ( ...args ) => mockInitMessages( ...args ),
+	renderMessages: ( ...args ) => mockRenderMessages( ...args ),
+	updateMessagesAmount: ( ...args ) => mockUpdateMessagesAmount( ...args ),
+} ) );
+
+const WRAPPER_SELECTOR = '#ppcp-button-checkout';
+const MINI_CART_WRAPPER_SELECTOR = '#ppcp-mini-cart-button';
+
+const baseConfig = ( overrides = {} ) => ( {
+	labels: {},
+	page_context: 'checkout',
+	wrapper: WRAPPER_SELECTOR,
+	mini_cart_wrapper: MINI_CART_WRAPPER_SELECTOR,
+	button_styles: {},
+	amount: '100.00',
+	currency: 'USD',
+	buyer_country: 'US',
+	ajax: {},
+	...overrides,
+} );
+
+function buildDom() {
+	document.body.innerHTML = `
+		<div id="${ WRAPPER_SELECTOR.slice( 1 ) }"></div>
+		<div id="${ MINI_CART_WRAPPER_SELECTOR.slice( 1 ) }"></div>
+	`;
+}
+
+/**
+ * A jQuery stand-in that records handlers per event name (splitting
+ * space-separated event strings the way real jQuery does) and lets tests
+ * fire one event by name.
+ */
+function createFakeJQuery() {
+	const handlers = {};
+
+	const fakeJQuery = () => ( {
+		on: ( eventNames, handler ) => {
+			eventNames
+				.split( /\s+/ )
+				.forEach( ( name ) => {
+					handlers[ name ] = handlers[ name ] || [];
+					handlers[ name ].push( handler );
+				} );
+		},
+	} );
+
+	fakeJQuery.trigger = ( name, ...args ) => {
+		( handlers[ name ] || [] ).forEach( ( handler ) =>
+			handler( { type: name }, ...args )
+		);
+	};
+
+	return fakeJQuery;
+}
+
+/**
+ * Sets the module's global config, then imports it fresh so its top-level
+ * IIFE runs against the config and DOM this test just set up.
+ */
+function boot( config ) {
+	window.wc_ppcp_sdk_v6 = config;
+	jest.isolateModules( () => {
+		require( '../boot.js' );
+	} );
+}
+
+/**
+ * Advances only far enough to settle already-scheduled microtasks and any
+ * timer already due, without running pending debounce timeouts.
+ *
+ * @return {Promise<void>}
+ */
+const flush = () => jest.advanceTimersByTimeAsync( 0 );
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	jest.clearAllMocks();
+
+	mockHasJQuery.mockReturnValue( true );
+	global.jQuery = createFakeJQuery();
+
+	mockLoadSdkV6.mockResolvedValue( {} );
+	mockCheckEligibility.mockResolvedValue( {
+		paypal: true,
+		venmo: false,
+		paylater: false,
+		payLaterDetails: null,
+	} );
+	mockCreateSession.mockReturnValue( {} );
+	mockRenderWallets.mockResolvedValue();
+	mockInitCardFields.mockResolvedValue();
+	mockInitMessages.mockResolvedValue( 0 );
+	mockRenderMessages.mockResolvedValue( 0 );
+	mockFetchCartTotal.mockResolvedValue( '120.00' );
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+	document.body.innerHTML = '';
+	delete window.wc_ppcp_sdk_v6;
+	delete global.jQuery;
+} );
+
+describe( 'boot', () => {
+	describe( 'eligibility refresh on cart/checkout events', () => {
+		/**
+		 * Regression test for the classic-checkout staleness bug: WooCommerce's
+		 * cart.js fires updated_cart_totals and its checkout.js fires
+		 * updated_checkout, and the two never overlap. Before updated_checkout
+		 * was added to this binding, a coupon or shipping change on classic
+		 * checkout never re-checked eligibility, so the Pay Later button's
+		 * eligibility stayed frozen at the page-load amount for the whole
+		 * checkout session.
+		 */
+		test( 'an updated_checkout event re-checks eligibility after the debounce elapses', async () => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		test( 'nothing happens before the 300ms debounce elapses', async () => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 299 );
+
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'a burst of several updated_checkout events coalesces into one pass', async () => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 100 );
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 100 );
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		test.each( [
+			[ 'updated_cart_totals' ],
+			[ 'added_to_cart' ],
+			[ 'removed_from_cart' ],
+		] )( '%s still triggers an eligibility pass', async ( eventName ) => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+
+			global.jQuery.trigger( eventName );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		test( 'one updated_checkout event results in exactly one fetchCartTotal call, not a duplicate from a separate handler', async () => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			mockFetchCartTotal.mockClear();
+
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockFetchCartTotal ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'updateMessagesAmount is called with the fetched total on checkout, since messages there price the cart', async () => {
+			buildDom();
+			boot( baseConfig( { page_context: 'checkout' } ) );
+			await flush();
+			mockUpdateMessagesAmount.mockClear();
+
+			global.jQuery.trigger( 'updated_cart_totals' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockUpdateMessagesAmount ).toHaveBeenCalledWith( '120.00' );
+		} );
+
+		test( 'updateMessagesAmount is not called on a product page, since a product page keeps pricing the product', async () => {
+			buildDom();
+			boot( baseConfig( { page_context: 'product' } ) );
+			await flush();
+			mockUpdateMessagesAmount.mockClear();
+
+			global.jQuery.trigger( 'updated_cart_totals' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockUpdateMessagesAmount ).not.toHaveBeenCalled();
+		} );
+
+		test( 'a rejected pass is logged and does not prevent a later pass from running', async () => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+
+			mockFetchCartTotal.mockRejectedValueOnce( new Error( 'network failure' ) );
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( console ).toHaveErrored();
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 1 );
+
+			global.jQuery.trigger( 'updated_checkout' );
+			await jest.advanceTimersByTimeAsync( 300 );
+
+			expect( mockCheckEligibility ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+
+	describe( 'DOM-replacing update events', () => {
+		test.each( [
+			[ 'updated_checkout' ],
+			[ 'wc_fragments_loaded' ],
+			[ 'wc_fragments_refreshed' ],
+		] )( '%s re-renders messages', async ( eventName ) => {
+			buildDom();
+			boot( baseConfig() );
+			await flush();
+			mockRenderMessages.mockClear();
+
+			global.jQuery.trigger( eventName );
+			await flush();
+
+			expect( mockRenderMessages ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'found_variation event', () => {
+		test( 'a variation with a display_price re-prices the message', async () => {
+			buildDom();
+			boot( baseConfig( { page_context: 'product' } ) );
+			await flush();
+
+			global.jQuery.trigger( 'found_variation', { display_price: 42 } );
+
+			expect( mockUpdateMessagesAmount ).toHaveBeenCalledWith( '42' );
+		} );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/cartTotalWatcher.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cartTotalWatcher.test.js
@@ -1,0 +1,86 @@
+const mockGetCartTotals = jest.fn();
+const mockSelect = jest.fn( () => ( { getCartTotals: mockGetCartTotals } ) );
+let subscriber;
+const mockUnsubscribe = jest.fn();
+const mockSubscribe = jest.fn( ( callback ) => {
+	subscriber = callback;
+	return mockUnsubscribe;
+} );
+
+jest.mock( '@wordpress/data', () => ( {
+	select: ( ...args ) => mockSelect( ...args ),
+	subscribe: ( ...args ) => mockSubscribe( ...args ),
+} ) );
+
+import { watchBlockCartTotal } from '../messages/cartTotalWatcher';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockSelect.mockImplementation( () => ( {
+		getCartTotals: mockGetCartTotals,
+	} ) );
+	subscriber = undefined;
+} );
+
+describe( 'watchBlockCartTotal()', () => {
+	test( 'fires the callback with the decimal total when it changes', () => {
+		mockGetCartTotals
+			.mockReturnValueOnce( { total_price: '1000', currency_minor_unit: 2 } )
+			.mockReturnValueOnce( { total_price: '1500', currency_minor_unit: 2 } );
+
+		const onChange = jest.fn();
+		watchBlockCartTotal( onChange );
+
+		subscriber();
+
+		expect( onChange ).toHaveBeenCalledWith( '15.00' );
+	} );
+
+	test( 'does not fire when the store notifies but the total is unchanged', () => {
+		mockGetCartTotals.mockReturnValue( {
+			total_price: '1000',
+			currency_minor_unit: 2,
+		} );
+
+		const onChange = jest.fn();
+		watchBlockCartTotal( onChange );
+
+		subscriber();
+		subscriber();
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	test( 'no-ops when the wc/store/cart store is unavailable', () => {
+		mockSelect.mockReturnValue( undefined );
+
+		const onChange = jest.fn();
+		expect( () => watchBlockCartTotal( onChange ) ).not.toThrow();
+
+		subscriber();
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	test( 'no-ops when the store returns no totals', () => {
+		mockGetCartTotals.mockReturnValue( undefined );
+
+		const onChange = jest.fn();
+		watchBlockCartTotal( onChange );
+
+		subscriber();
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	test( 'returns the subscribe unsubscribe function', () => {
+		mockGetCartTotals.mockReturnValue( {
+			total_price: '1000',
+			currency_minor_unit: 2,
+		} );
+
+		const unsubscribe = watchBlockCartTotal( jest.fn() );
+
+		expect( unsubscribe ).toBe( mockUnsubscribe );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/messagesRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/messagesRenderer.test.js
@@ -1,0 +1,396 @@
+const mockCreatePayPalMessages = jest.fn( () => ( {} ) );
+const mockLoadSdkV6 = jest.fn( () =>
+	Promise.resolve( { createPayPalMessages: mockCreatePayPalMessages } )
+);
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+
+import {
+	initMessages,
+	renderMessages,
+	updateMessagesAmount,
+	resetMessages,
+} from '../messages/renderer';
+
+// Matches the module's RESCAN_DEBOUNCE_MS. Not exported, so mirrored here.
+const RESCAN_DEBOUNCE_MS = 100;
+
+// `messages` is spread last so a partial `overrides.messages` merges into the
+// defaults rather than replacing them — spreading `...overrides` afterwards
+// would put the raw partial back over the merged object.
+const baseConfig = ( overrides = {} ) => ( {
+	currency: 'USD',
+	buyer_country: 'US',
+	...overrides,
+	messages: {
+		enabled: true,
+		is_hidden: false,
+		wrapper: '.ppcp-messages',
+		amount: '100.00',
+		page_type: 'product-details',
+		style: {
+			logoType: 'WORDMARK',
+			logoPosition: 'LEFT',
+			textColor: 'BLACK',
+			fontSize: '',
+		},
+		...overrides.messages,
+	},
+} );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	resetMessages();
+	document.body.innerHTML = '';
+} );
+
+describe( 'renderMessages()', () => {
+	test( 'appends one paypal-message per placeholder with the configured attributes', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+
+		await renderMessages( baseConfig(), 'product' );
+
+		const message = document.querySelector( 'paypal-message' );
+		expect( message ).not.toBeNull();
+		expect( message.getAttribute( 'auto-bootstrap' ) ).toBe( '' );
+		expect( message.getAttribute( 'amount' ) ).toBe( '100.00' );
+		expect( message.getAttribute( 'currency-code' ) ).toBe( 'USD' );
+		expect( message.getAttribute( 'page-type' ) ).toBe( 'product-details' );
+		expect( message.getAttribute( 'logo-type' ) ).toBe( 'WORDMARK' );
+		expect( message.getAttribute( 'logo-position' ) ).toBe( 'LEFT' );
+		expect( message.getAttribute( 'text-color' ) ).toBe( 'BLACK' );
+		expect(
+			message.style.getPropertyValue( '--paypal-message-font-size' )
+		).toBe( '' );
+	} );
+
+	test( 'sets the font-size custom property when the config style has one', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+
+		await renderMessages(
+			baseConfig( {
+				messages: {
+					style: {
+						logoType: 'WORDMARK',
+						logoPosition: 'LEFT',
+						textColor: 'BLACK',
+						fontSize: '14px',
+					},
+				},
+			} ),
+			'product'
+		);
+
+		const message = document.querySelector( 'paypal-message' );
+		expect(
+			message.style.getPropertyValue( '--paypal-message-font-size' )
+		).toBe( '14px' );
+	} );
+
+	test( 'never loads the SDK when there is no placeholder on the page', async () => {
+		const count = await renderMessages( baseConfig(), 'product' );
+
+		expect( count ).toBe( 0 );
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test.each( [
+		[ 'messages.enabled is false', { enabled: false } ],
+		[ 'messages.is_hidden is true', { is_hidden: true } ],
+	] )( 'never loads the SDK when %s', async ( _label, override ) => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+
+		const count = await renderMessages(
+			baseConfig( { messages: override } ),
+			'product'
+		);
+
+		expect( count ).toBe( 0 );
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test( 'appends only one component when called twice for the same placeholder', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		const config = baseConfig();
+
+		await renderMessages( config, 'product' );
+		await renderMessages( config, 'product' );
+
+		expect(
+			document.querySelectorAll( 'paypal-message' )
+		).toHaveLength( 1 );
+	} );
+
+	test( 'fills a wrapper again after WooCommerce empties and re-adds it on updated_checkout', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		const config = baseConfig();
+
+		await renderMessages( config, 'product' );
+
+		// WooCommerce replaces the surrounding DOM wholesale, giving back a
+		// fresh, unclaimed wrapper element.
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+
+		await renderMessages( config, 'product' );
+
+		expect(
+			document.querySelectorAll( 'paypal-message' )
+		).toHaveLength( 1 );
+	} );
+
+	test( 'produces exactly one message when two renderMessages calls race on the same wrapper', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		const config = baseConfig();
+
+		const first = renderMessages( config, 'product' );
+		const second = renderMessages( config, 'product' );
+		await Promise.all( [ first, second ] );
+
+		expect(
+			document.querySelectorAll( 'paypal-message' )
+		).toHaveLength( 1 );
+		expect( mockCreatePayPalMessages ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'releases a failed wrapper so a later pass can retry it', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		const config = baseConfig();
+		mockLoadSdkV6.mockRejectedValueOnce( new Error( 'sdk failed to load' ) );
+
+		await expect( renderMessages( config, 'product' ) ).rejects.toThrow(
+			'sdk failed to load'
+		);
+		expect( document.querySelector( 'paypal-message' ) ).toBeNull();
+
+		await renderMessages( config, 'product' );
+
+		expect( document.querySelector( 'paypal-message' ) ).not.toBeNull();
+	} );
+
+	test( 'creates the messages component exactly once across multiple render passes, with only the config currency', async () => {
+		document.body.innerHTML =
+			'<div class="ppcp-messages"></div><div class="ppcp-messages"></div>';
+		const config = baseConfig();
+
+		await renderMessages( config, 'product' );
+
+		document.body.innerHTML += '<div class="ppcp-messages"></div>';
+		await renderMessages( config, 'product' );
+
+		expect( mockCreatePayPalMessages ).toHaveBeenCalledTimes( 1 );
+		// No buyerCountry: it's PayPal's sandbox override for simulating a
+		// buyer's location, not a field to populate from the billing address.
+		// A country the store currency has no Pay Later offer for makes
+		// fetch-presentment-messages fail with a hard 422 and the message
+		// silently never renders.
+		expect( mockCreatePayPalMessages ).toHaveBeenCalledWith(
+			expect.not.objectContaining( { buyerCountry: expect.anything() } )
+		);
+		expect( mockCreatePayPalMessages ).toHaveBeenCalledWith( {
+			currencyCode: 'USD',
+		} );
+	} );
+
+	describe( 'per-wrapper style overrides', () => {
+		test( "a wrapper's own data-pp-style-* attributes win over the config style", async () => {
+			document.body.innerHTML = `
+				<div
+					class="ppcp-messages"
+					data-pp-style-logo-type="alternative"
+					data-pp-style-logo-position="top"
+					data-pp-style-text-color="grayscale"
+					data-pp-style-text-size="20"
+				></div>
+			`;
+
+			await renderMessages(
+				baseConfig( {
+					messages: {
+						style: {
+							logoType: 'WORDMARK',
+							logoPosition: 'LEFT',
+							textColor: 'BLACK',
+							fontSize: '',
+						},
+					},
+				} ),
+				'product'
+			);
+
+			const message = document.querySelector( 'paypal-message' );
+			expect( message.getAttribute( 'logo-type' ) ).toBe( 'MONOGRAM' );
+			expect( message.getAttribute( 'logo-position' ) ).toBe( 'TOP' );
+			expect( message.getAttribute( 'text-color' ) ).toBe( 'MONOCHROME' );
+			expect(
+				message.style.getPropertyValue( '--paypal-message-font-size' )
+			).toBe( '16px' );
+		} );
+
+		test( 'data-pp-style-logo-type="inline" forces the INLINE logo position', async () => {
+			document.body.innerHTML = `
+				<div class="ppcp-messages" data-pp-style-logo-type="inline"></div>
+			`;
+
+			await renderMessages( baseConfig(), 'product' );
+
+			const message = document.querySelector( 'paypal-message' );
+			expect( message.getAttribute( 'logo-position' ) ).toBe( 'INLINE' );
+		} );
+	} );
+
+	describe( 'per-wrapper page type overrides', () => {
+		test.each( [
+			[ 'payment', 'checkout' ],
+			[ 'cart', 'cart' ],
+			[ 'product', 'product-details' ],
+			[ 'product-list', 'product-listing' ],
+			[ 'home', 'home' ],
+		] )(
+			'data-pp-placement="%s" renders page-type="%s"',
+			async ( placement, expectedPageType ) => {
+				document.body.innerHTML = `<div class="ppcp-messages" data-pp-placement="${ placement }"></div>`;
+
+				await renderMessages( baseConfig(), 'product' );
+
+				expect(
+					document
+						.querySelector( 'paypal-message' )
+						.getAttribute( 'page-type' )
+				).toBe( expectedPageType );
+			}
+		);
+
+		test( 'falls back to config.messages.page_type when data-pp-placement is absent', async () => {
+			document.body.innerHTML = '<div class="ppcp-messages"></div>';
+
+			await renderMessages(
+				baseConfig( { messages: { page_type: 'mini-cart' } } ),
+				'product'
+			);
+
+			expect(
+				document
+					.querySelector( 'paypal-message' )
+					.getAttribute( 'page-type' )
+			).toBe( 'mini-cart' );
+		} );
+	} );
+} );
+
+describe( 'updateMessagesAmount()', () => {
+	test( 'sets .amount on every rendered element', async () => {
+		document.body.innerHTML =
+			'<div class="ppcp-messages"></div><div class="ppcp-messages"></div>';
+		await renderMessages( baseConfig(), 'product' );
+
+		updateMessagesAmount( '250.00' );
+
+		document.querySelectorAll( 'paypal-message' ).forEach( ( element ) => {
+			expect( element.amount ).toBe( '250.00' );
+		} );
+	} );
+
+	test( 'prunes and skips elements that are no longer connected to the document', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		await renderMessages( baseConfig(), 'product' );
+
+		const detached = document.querySelector( 'paypal-message' );
+		detached.remove();
+
+		expect( () => updateMessagesAmount( '250.00' ) ).not.toThrow();
+		expect( detached.amount ).toBeUndefined();
+	} );
+
+	test( 'is a no-op for an empty amount', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		await renderMessages( baseConfig(), 'product' );
+
+		updateMessagesAmount( '' );
+
+		expect(
+			document.querySelector( 'paypal-message' ).amount
+		).toBeUndefined();
+	} );
+} );
+
+describe( 'initMessages()', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	test( 'renders once a placeholder appears on a later discovery attempt', async () => {
+		const config = baseConfig();
+		const initPromise = initMessages( config, 'product' );
+
+		await Promise.resolve();
+		expect( document.querySelector( 'paypal-message' ) ).toBeNull();
+
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		await jest.advanceTimersByTimeAsync( RESCAN_DEBOUNCE_MS );
+
+		await initPromise;
+		expect( document.querySelector( 'paypal-message' ) ).not.toBeNull();
+	} );
+
+	test( 'resolves to 0 and never calls loadSdkV6 when no placeholder ever appears', async () => {
+		const config = baseConfig();
+
+		const count = await initMessages( config, 'product' );
+
+		expect( count ).toBe( 0 );
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test.each( [
+		[ 'messages.enabled is false', { enabled: false } ],
+		[ 'messages.is_hidden is true', { is_hidden: true } ],
+	] )( 'resolves to 0 without calling loadSdkV6 when %s', async ( _label, override ) => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+
+		const count = await initMessages(
+			baseConfig( { messages: override } ),
+			'product'
+		);
+
+		expect( count ).toBe( 0 );
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test( 'mounts a fresh message after WooCommerce Blocks replaces the placeholder node', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		const config = baseConfig();
+
+		await initMessages( config, 'product' );
+		expect( document.querySelector( 'paypal-message' ) ).not.toBeNull();
+
+		const freshWrapper = document.createElement( 'div' );
+		freshWrapper.className = 'ppcp-messages';
+		document.querySelector( '.ppcp-messages' ).replaceWith( freshWrapper );
+
+		await Promise.resolve();
+		await jest.advanceTimersByTimeAsync( RESCAN_DEBOUNCE_MS );
+
+		const messages = document.querySelectorAll( 'paypal-message' );
+		expect( messages ).toHaveLength( 1 );
+		expect( freshWrapper.contains( messages[ 0 ] ) ).toBe( true );
+	} );
+
+	test( 'does not keep re-rendering once our own appended message settles', async () => {
+		document.body.innerHTML = '<div class="ppcp-messages"></div>';
+		const config = baseConfig();
+
+		await initMessages( config, 'product' );
+		await Promise.resolve();
+		await jest.advanceTimersByTimeAsync( RESCAN_DEBOUNCE_MS );
+		await jest.advanceTimersByTimeAsync( RESCAN_DEBOUNCE_MS );
+
+		expect(
+			document.querySelectorAll( 'paypal-message' )
+		).toHaveLength( 1 );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/utils/viewedTotal.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/viewedTotal.js
@@ -1,0 +1,169 @@
+/**
+ * Tracks what the page the shopper is looking at currently costs.
+ *
+ * A product page cannot ask the cart: the viewed product is not in it, and
+ * adding it would mutate the cart of a shopper who has not clicked anything.
+ * It prices through the simulate endpoint instead. Every other context asks
+ * the cart.
+ *
+ * Shared, because two surfaces need the same answer in different shapes: Apple
+ * Pay must read it synchronously inside the click handler, Pay Later messaging
+ * needs to be told when it changes.
+ *
+ * @package
+ */
+
+import { fetchCartTotal, productForm, simulateCart } from '../endpointsAdapter';
+import { hasJQuery } from './api';
+
+/**
+ * How long to coalesce product-form changes before re-pricing.
+ *
+ * Short, because Apple Pay cannot re-read the total on click — a stale one is
+ * what the shopper gets charged. Debounced rather than throttled, which would
+ * price the burst's first event and so describe a variation already moved away
+ * from.
+ */
+const REFRESH_DEBOUNCE_MS = 250;
+
+// Per context: 'product' resolves through the simulate endpoint and everything
+// else through the cart, so the two cannot share one cached total.
+const states = new Map();
+
+// Attached once per page, however many surfaces are watching.
+let listening = false;
+
+/**
+ * Resets module state. Test seam only.
+ */
+export function resetViewedTotals() {
+	states.clear();
+	listening = false;
+}
+
+/**
+ * @param {string} context - The page context.
+ * @return {Object} The state for that context.
+ */
+function stateFor( context ) {
+	if ( ! states.has( context ) ) {
+		states.set( context, {
+			total: '',
+			latestRequest: 0,
+			subscribers: new Set(),
+		} );
+	}
+
+	return states.get( context );
+}
+
+/**
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} context - The page context.
+ * @return {Promise<string>} The total, or '' when unknown.
+ */
+async function resolve( config, context ) {
+	try {
+		if ( 'product' === context ) {
+			const { total } = await simulateCart( config );
+
+			return total ?? '';
+		}
+
+		return await fetchCartTotal( config );
+	} catch ( error ) {
+		// Unknown rather than thrown, so watchers keep the total they had.
+		return '';
+	}
+}
+
+/**
+ * Re-prices one context and notifies its subscribers.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} context - The page context.
+ * @return {Promise<string>} The current total.
+ */
+async function refresh( config, context ) {
+	const state = stateFor( context );
+	const request = ++state.latestRequest;
+	const resolved = await resolve( config, context );
+
+	// Never overwritten by a failed lookup's empty string, nor by a request a
+	// newer one has already superseded — overlapping refreshes can resolve out
+	// of order, which is the stale total the debounce exists to prevent.
+	const superseded = request !== state.latestRequest;
+	if ( resolved && ! superseded && resolved !== state.total ) {
+		state.total = resolved;
+		state.subscribers.forEach( ( notify ) => notify( resolved ) );
+	}
+
+	return state.total;
+}
+
+/**
+ * Subscribes to the events that change what the viewed product costs.
+ *
+ * The native change listener covers the quantity field; the variation events
+ * cover variable products, whose variation_id WooCommerce only fills in after
+ * the change event that triggered the selection.
+ *
+ * @param {Object}      config - The wc_ppcp_sdk_v6 config object.
+ * @param {HTMLElement} form   - The product form.
+ */
+function listenToProductForm( config, form ) {
+	let timer = null;
+
+	const schedule = () => {
+		clearTimeout( timer );
+		timer = setTimeout( () => {
+			refresh( config, 'product' ).catch( () => {} );
+		}, REFRESH_DEBOUNCE_MS );
+	};
+
+	form.addEventListener( 'change', schedule );
+
+	if ( hasJQuery() ) {
+		jQuery( form ).on( 'found_variation reset_data', schedule );
+	}
+}
+
+/**
+ * Starts tracking the total for one context.
+ *
+ * Repeated calls for the same context share its total, so every surface sees
+ * the same number and the form listeners are not stacked.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} context - The page context.
+ * @return {{get: Function, subscribe: Function}} Reader and change subscription.
+ */
+export function watchViewedTotal( config, context ) {
+	const state = stateFor( context );
+
+	// Seeded so a synchronous reader that beats the first resolve still has a
+	// number. On a product page it is the cart total whenever the cart is not
+	// empty, so it is a placeholder rather than an answer.
+	if ( ! state.total ) {
+		state.total = config.amount || '';
+	}
+
+	refresh( config, context ).catch( () => {} );
+
+	if ( 'product' === context && ! listening ) {
+		const form = productForm();
+		if ( form ) {
+			listening = true;
+			listenToProductForm( config, form );
+		}
+	}
+
+	return {
+		get: () => state.total,
+		subscribe: ( notify ) => {
+			state.subscribers.add( notify );
+
+			return () => state.subscribers.delete( notify );
+		},
+	};
+}

--- a/modules/ppcp-sdk-v6/resources/js/utils/viewedTotal.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/viewedTotal.test.js
@@ -1,0 +1,321 @@
+import jQuery from 'jquery';
+
+// Declared outside the factory so their identity survives jest.resetModules
+// equivalents: the mocks are shared across tests via jest.clearAllMocks().
+const mockSimulateCart = jest.fn();
+const mockFetchCartTotal = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	simulateCart: ( ...args ) => mockSimulateCart( ...args ),
+	fetchCartTotal: ( ...args ) => mockFetchCartTotal( ...args ),
+	// Not stubbed: it only reads the DOM the fixtures below build, and the
+	// selector pair it uses must live in one place.
+	productForm: jest.requireActual( '../endpointsAdapter' ).productForm,
+} ) );
+
+const mockHasJQuery = jest.fn( () => true );
+jest.mock( './api', () => ( {
+	hasJQuery: () => mockHasJQuery(),
+} ) );
+
+import { watchViewedTotal, resetViewedTotals } from './viewedTotal';
+
+// Mirrors REFRESH_DEBOUNCE_MS in the source.
+const DEBOUNCE_MS = 250;
+
+const config = ( overrides = {} ) => ( {
+	amount: '5.00',
+	...overrides,
+} );
+
+// Microtask chains inside the module (await simulateCart/fetchCartTotal,
+// then await resolve()) resolve over several ticks; real Promise resolution
+// is unaffected by jest's fake timers, so this works either way.
+//
+// The debounce timeout itself must be advanced with the async variant
+// (`await jest.advanceTimersByTimeAsync()`), not the sync one: the sync
+// `tick()` fires the setTimeout callback and returns without draining the
+// microtask queue, so the refresh() call it kicks off would still be
+// unstarted when the very next synchronous test statement runs.
+const flushPromises = async () => {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+};
+
+function renderProductForm() {
+	document.body.innerHTML =
+		'<form><input name="add-to-cart" value="1" /></form>';
+	return document.querySelector( 'form' );
+}
+
+beforeEach( () => {
+	resetViewedTotals();
+	jest.clearAllMocks();
+	jest.useFakeTimers();
+	mockHasJQuery.mockReturnValue( true );
+	document.body.innerHTML = '';
+	global.jQuery = jQuery;
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'watchViewedTotal()', () => {
+	describe( 'resolving through the right endpoint', () => {
+		test( "resolves the 'product' context via simulateCart, never touching fetchCartTotal", async () => {
+			mockSimulateCart.mockResolvedValueOnce( { total: '15.00' } );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			expect( watcher.get() ).toBe( '15.00' );
+			expect( mockFetchCartTotal ).not.toHaveBeenCalled();
+		} );
+
+		test.each( [ 'cart', 'checkout', 'mini-cart' ] )(
+			"resolves the '%s' context via fetchCartTotal, never touching simulateCart",
+			async ( context ) => {
+				mockFetchCartTotal.mockResolvedValueOnce( '20.00' );
+
+				const watcher = watchViewedTotal( config(), context );
+				await flushPromises();
+
+				expect( watcher.get() ).toBe( '20.00' );
+				expect( mockSimulateCart ).not.toHaveBeenCalled();
+			}
+		);
+	} );
+
+	test( 'get() returns the config.amount seed before the first resolve settles, then the resolved total once it does', async () => {
+		let resolveSimulate;
+		mockSimulateCart.mockReturnValueOnce(
+			new Promise( ( resolve ) => {
+				resolveSimulate = resolve;
+			} )
+		);
+
+		const watcher = watchViewedTotal(
+			config( { amount: '5.00' } ),
+			'product'
+		);
+		expect( watcher.get() ).toBe( '5.00' );
+
+		resolveSimulate( { total: '15.00' } );
+		await flushPromises();
+
+		expect( watcher.get() ).toBe( '15.00' );
+	} );
+
+	describe( 'subscribe()', () => {
+		test( 'notifies a subscriber with the new total when it changes', async () => {
+			const form = renderProductForm();
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '10.00' } )
+				.mockResolvedValueOnce( { total: '25.00' } );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			const notify = jest.fn();
+			watcher.subscribe( notify );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( notify ).toHaveBeenCalledWith( '25.00' );
+		} );
+
+		test( 'is not notified when a refresh resolves the same total again', async () => {
+			const form = renderProductForm();
+			mockSimulateCart.mockResolvedValue( { total: '10.00' } );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			const notify = jest.fn();
+			watcher.subscribe( notify );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( notify ).not.toHaveBeenCalled();
+		} );
+
+		test( 'stops notifying once the returned unsubscribe function has been called', async () => {
+			const form = renderProductForm();
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '10.00' } )
+				.mockResolvedValueOnce( { total: '25.00' } )
+				.mockResolvedValueOnce( { total: '30.00' } );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			const notify = jest.fn();
+			const unsubscribe = watcher.subscribe( notify );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+			expect( notify ).toHaveBeenCalledTimes( 1 );
+
+			unsubscribe();
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( notify ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'per-context isolation', () => {
+		test( "two different contexts resolve independently, and each watcher's get() reports its own total", async () => {
+			mockSimulateCart.mockResolvedValueOnce( { total: '15.00' } );
+			mockFetchCartTotal.mockResolvedValueOnce( '99.00' );
+
+			const productWatcher = watchViewedTotal( config(), 'product' );
+			const miniCartWatcher = watchViewedTotal( config(), 'mini-cart' );
+			await flushPromises();
+
+			expect( productWatcher.get() ).toBe( '15.00' );
+			expect( miniCartWatcher.get() ).toBe( '99.00' );
+		} );
+
+		// This is the behaviour change item 1 in the task exists to cover: two
+		// surfaces (Apple Pay, Pay Later messaging) watching the same context
+		// must not report different totals for the same page.
+		test( 'two watchers on the same context share the total after a refresh', async () => {
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '10.00' } )
+				.mockResolvedValueOnce( { total: '20.00' } );
+
+			const firstWatcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+			const secondWatcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			expect( firstWatcher.get() ).toBe( '20.00' );
+			expect( secondWatcher.get() ).toBe( '20.00' );
+		} );
+	} );
+
+	describe( 'debouncing product-form changes', () => {
+		test( 'coalesces a burst of change events into a single refresh, priced after the debounce window elapses', async () => {
+			const form = renderProductForm();
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '10.00' } )
+				.mockResolvedValueOnce( { total: '25.00' } );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+			expect( watcher.get() ).toBe( '10.00' );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( 100 );
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( 100 );
+
+			expect( mockSimulateCart ).toHaveBeenCalledTimes( 1 );
+
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( mockSimulateCart ).toHaveBeenCalledTimes( 2 );
+			expect( watcher.get() ).toBe( '25.00' );
+		} );
+	} );
+
+	describe( 'out-of-order refreshes', () => {
+		test( 'discards an earlier refresh that resolves after a later one, so the later value survives', async () => {
+			const form = renderProductForm();
+			let resolveFirst;
+			let resolveSecond;
+			const first = new Promise( ( resolve ) => {
+				resolveFirst = resolve;
+			} );
+			const second = new Promise( ( resolve ) => {
+				resolveSecond = resolve;
+			} );
+
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '10.00' } )
+				.mockReturnValueOnce( first )
+				.mockReturnValueOnce( second );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+			expect( watcher.get() ).toBe( '10.00' );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+
+			resolveSecond( { total: '30.00' } );
+			await flushPromises();
+			expect( watcher.get() ).toBe( '30.00' );
+
+			resolveFirst( { total: '20.00' } );
+			await flushPromises();
+			expect( watcher.get() ).toBe( '30.00' );
+		} );
+	} );
+
+	describe( 'refresh failures', () => {
+		test( 'a rejected refresh leaves the previous total intact', async () => {
+			const form = renderProductForm();
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '15.00' } )
+				.mockRejectedValueOnce( new Error( 'network down' ) );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( watcher.get() ).toBe( '15.00' );
+		} );
+
+		test( 'a refresh that resolves an empty total leaves the previous total intact', async () => {
+			const form = renderProductForm();
+			mockSimulateCart
+				.mockResolvedValueOnce( { total: '15.00' } )
+				.mockResolvedValueOnce( { total: '' } );
+
+			const watcher = watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( watcher.get() ).toBe( '15.00' );
+		} );
+	} );
+
+	describe( 'listening across repeated calls', () => {
+		test( 'attaches the product-form listener once, however many times watchViewedTotal is called for the page', async () => {
+			const form = renderProductForm();
+			mockSimulateCart.mockResolvedValue( { total: '10.00' } );
+
+			watchViewedTotal( config(), 'product' );
+			await flushPromises();
+			watchViewedTotal( config(), 'product' );
+			await flushPromises();
+
+			mockSimulateCart.mockClear();
+
+			form.dispatchEvent( new Event( 'change' ) );
+			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
+			await flushPromises();
+
+			expect( mockSimulateCart ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.js
@@ -2,89 +2,14 @@
  * Keeps the Apple Pay sheet total readable synchronously.
  *
  * Safari requires the ApplePaySession to be constructed inside the click handler
- * itself, so the bridge cannot await a total the way every other v6 surface does.
- * This resolves it ahead of the click and refreshes it whenever it can change.
+ * itself, so the bridge cannot await a total the way every other v6 surface
+ * does. The shared watcher resolves it ahead of the click and re-prices it
+ * whenever the viewed product changes.
  *
  * @package
  */
 
-import {
-	fetchCartTotal,
-	productForm,
-	simulateCart,
-} from '../endpointsAdapter';
-import { hasJQuery } from '../utils/api';
-
-/**
- * How long to coalesce product-form changes before re-pricing.
- *
- * Kept short because the total cannot be re-read on click: a stale one is what the
- * shopper gets charged. Long enough to collapse the event burst a variation switch
- * fires, short enough that clicking straight after a change gets the new price.
- * Debounced rather than throttled, which would price the burst's first event and
- * so describe a variation the shopper has already moved away from.
- */
-const REFRESH_DEBOUNCE_MS = 250;
-
-/**
- * The form listeners are attached once per page, but every render pass creates a
- * new watcher, so they call whichever watcher is current. That way re-renders
- * neither stack listeners nor leave the live watcher unsubscribed.
- */
-let refreshActive = null;
-let listeningToProductForm = false;
-
-/**
- * Resolves the total the sheet must display, without side effects.
- *
- * The product page cannot ask the cart, because the viewed product is not in it,
- * and must not add it either: that would mutate the cart of a shopper who has
- * not clicked anything yet. Hence the simulate endpoint.
- *
- * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
- * @param {string} context - The page context.
- * @return {Promise<string>} The total as a decimal string, or '' when unknown.
- */
-async function resolveSheetTotal( config, context ) {
-	try {
-		if ( context === 'product' ) {
-			const { total } = await simulateCart( config );
-
-			return total ?? '';
-		}
-
-		return await fetchCartTotal( config );
-	} catch ( error ) {
-		// Unknown rather than thrown, so the caller keeps the total it already had.
-		return '';
-	}
-}
-
-/**
- * Subscribes to the events that change what the viewed product costs.
- *
- * A native change listener covers the quantity field; the variation events cover
- * variable products, whose variation_id WooCommerce only fills in after the change
- * event that triggered the selection.
- *
- * @param {HTMLElement} form - The product form.
- */
-function listenToProductForm( form ) {
-	let timer = null;
-
-	const schedule = () => {
-		clearTimeout( timer );
-		timer = setTimeout( () => {
-			refreshActive?.();
-		}, REFRESH_DEBOUNCE_MS );
-	};
-
-	form.addEventListener( 'change', schedule );
-
-	if ( hasJQuery() ) {
-		jQuery( form ).on( 'found_variation reset_data', schedule );
-	}
-}
+import { watchViewedTotal } from '../utils/viewedTotal';
 
 /**
  * Starts tracking the sheet total for one render target.
@@ -94,43 +19,5 @@ function listenToProductForm( form ) {
  * @return {{get: Function}} The synchronously-readable total.
  */
 export function watchSheetTotal( config, context ) {
-	// Seeded so a click that beats the first resolve still has a number to show.
-	let total = config.amount || '';
-
-	// Refreshes overlap and can resolve out of order, letting a slow answer about
-	// an older variation overwrite a fresh one: the stale total the debounce
-	// exists to prevent.
-	let latestRequest = 0;
-
-	const refresh = async () => {
-		const request = ++latestRequest;
-		const resolved = await resolveSheetTotal( config, context );
-
-		// Never overwritten by a failed lookup's empty string, nor by a request
-		// that a newer one has already superseded.
-		if ( resolved && request === latestRequest ) {
-			total = resolved;
-		}
-
-		return total;
-	};
-
-	refreshActive = refresh;
-
-	// Matters most on the product page, where the localized amount is the cart
-	// total whenever the cart is not empty, so the seed is a placeholder rather
-	// than an answer. Elsewhere it is already this page's own total.
-	refresh().catch( () => {} );
-
-	if ( context === 'product' ) {
-		const form = productForm();
-		if ( form && ! listeningToProductForm ) {
-			listeningToProductForm = true;
-			listenToProductForm( form );
-		}
-	}
-
-	return {
-		get: () => total,
-	};
+	return { get: watchViewedTotal( config, context ).get };
 }

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.test.js
@@ -274,7 +274,13 @@ describe( 'watchSheetTotal()', () => {
 			expect( mockSimulateCart ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		test( "a form change refreshes whichever watcher is current, leaving an earlier render's watcher untouched", async () => {
+		// Sharing is deliberate, not a regression: Apple Pay and Pay Later
+		// messaging both watch the same 'product' context, and a shopper who
+		// changes quantity or variation must not have the two surfaces report
+		// different totals for the one product they are looking at. A watcher
+		// obtained by an earlier render is not a frozen snapshot — it reads
+		// the same context state a later render's watcher does.
+		test( 'a form change refreshes the total shared by every watcher on the context, so none of them disagrees with another', async () => {
 			const form = renderProductForm();
 			mockSimulateCart
 				.mockResolvedValueOnce( { total: '10.00' } )
@@ -286,12 +292,15 @@ describe( 'watchSheetTotal()', () => {
 			const secondWatcher = watchSheetTotal( config(), 'product' );
 			await flushPromises();
 
+			expect( firstWatcher.get() ).toBe( '20.00' );
+			expect( secondWatcher.get() ).toBe( '20.00' );
+
 			form.dispatchEvent( new Event( 'change' ) );
 			await jest.advanceTimersByTimeAsync( DEBOUNCE_MS );
 			await flushPromises();
 
+			expect( firstWatcher.get() ).toBe( '40.00' );
 			expect( secondWatcher.get() ).toBe( '40.00' );
-			expect( firstWatcher.get() ).toBe( '10.00' );
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -20,6 +20,8 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
@@ -94,6 +96,21 @@ return array(
 		};
 	},
 
+	'sdk-v6.message-style-mapper'       => static function ( ContainerInterface $container ): MessageStyleMapper {
+		return new MessageStyleMapper(
+			$container->get( 'settings.settings-provider' )
+		);
+	},
+
+	'sdk-v6.messages-eligibility'       => static function ( ContainerInterface $container ): MessagesEligibility {
+		return new MessagesEligibility(
+			$container->get( 'settings.settings-provider' ),
+			$container->get( 'wcgateway.settings.status' ),
+			$container->get( 'button.helper.messages-apply' ),
+			$container->get( 'wc-subscriptions.free-trial-subscription-helper' )
+		);
+	},
+
 	'sdk-v6.manager'                    => static function ( ContainerInterface $container ): SdkV6Manager {
 		$settings_provider = $container->get( 'settings.settings-provider' );
 		assert( $settings_provider instanceof SettingsProvider );
@@ -123,6 +140,8 @@ return array(
 				&& $settings_provider->save_card_details(),
 			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'wcgateway.credit-card-icons' ),
+			$container->get( 'sdk-v6.message-style-mapper' ),
+			$container->get( 'sdk-v6.messages-eligibility' ),
 			$settings_provider->merchant_country(),
 			$container->get( 'sdk-v6.google-pay-config' ),
 			$container->get( 'sdk-v6.apple-pay-config' )

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -80,7 +80,10 @@ return array(
 	},
 
 	/**
-	 * Whether this module renders the PayPal stack on the current page.
+	 * Whether the PayPal v6 SDK loads on the current page.
+	 *
+	 * Callers use this to decide whether to stand down and not load a second (v5)
+	 * PayPal SDK against window.paypal.
 	 *
 	 * A callable rather than a bool: the answer depends on the query, which is
 	 * unresolved while the container is being built. Exposed as a service so the

--- a/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
@@ -75,11 +75,16 @@ class AddPaymentMethodManager {
 			return;
 		}
 
+		$asset = $this->asset_getter->get_asset_data(
+			'boot-add-payment-method.js',
+			$this->version
+		);
+
 		wp_register_script(
 			'wc-ppcp-sdk-v6-add-payment-method',
 			$script_url,
-			array(),
-			$this->version,
+			$asset['dependencies'],
+			$asset['version'],
 			true
 		);
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -24,6 +24,8 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -49,6 +51,10 @@ class SdkV6Manager {
 	 */
 	public const PAYMENT_BUTTON_HEIGHT = '48px';
 
+	// The pay-for-order page has no pre-payment hook, so the message renders
+	// after the submit button and is relocated by SdkV6Module.
+	public const PAY_ORDER_MESSAGE_HOOK = 'woocommerce_pay_order_before_submit';
+
 	// Existing WC credit-card-form field IDs (see CardFieldsModule's
 	// woocommerce_credit_card_form_fields filter and WC core's own
 	// card-number/expiry/cvc fields) that the v6 card fields mount into,
@@ -72,6 +78,8 @@ class SdkV6Manager {
 	private CardPaymentsConfiguration $card_payments_configuration;
 	private bool $card_vaulting_enabled;
 	private SubscriptionHelper $subscription_helper;
+	private MessageStyleMapper $message_style_mapper;
+	private MessagesEligibility $messages_eligibility;
 	private string $merchant_country;
 
 	/**
@@ -111,6 +119,8 @@ class SdkV6Manager {
 		bool $card_vaulting_enabled,
 		SubscriptionHelper $subscription_helper,
 		array $credit_card_icons,
+		MessageStyleMapper $message_style_mapper,
+		MessagesEligibility $messages_eligibility,
 		string $merchant_country,
 		GooglePayConfig $google_pay_config,
 		ApplePayConfig $apple_pay_config
@@ -130,6 +140,8 @@ class SdkV6Manager {
 		$this->card_vaulting_enabled       = $card_vaulting_enabled;
 		$this->subscription_helper         = $subscription_helper;
 		$this->credit_card_icons           = $credit_card_icons;
+		$this->message_style_mapper        = $message_style_mapper;
+		$this->messages_eligibility        = $messages_eligibility;
 		$this->merchant_country            = $merchant_country;
 		$this->apple_pay_config            = $apple_pay_config;
 
@@ -354,9 +366,8 @@ class SdkV6Manager {
 	 * card gateway is a regular WC payment method that can be selectable
 	 * at checkout even when the wallet button is disabled there, so it
 	 * gets its own OR'd condition rather than being folded into the
-	 * location check above.
-	 *
-	 * @return bool
+	 * location check above. Pay Later messaging is a third such condition:
+	 * it can claim a classic page where nothing else here would.
 	 */
 	public function should_load_on_current_page(): bool {
 		$page_location = $this->get_page_context();
@@ -365,6 +376,10 @@ class SdkV6Manager {
 		}
 
 		if ( $this->is_card_fields_enabled( $page_location ) ) {
+			return true;
+		}
+
+		if ( $this->should_load_messages() ) {
 			return true;
 		}
 
@@ -413,6 +428,215 @@ class SdkV6Manager {
 	}
 
 	/**
+	 * Whether Pay Later messaging alone should pull the v6 SDK onto this page.
+	 *
+	 * Two exclusions:
+	 *
+	 * - Block contexts, where claiming the page for messaging alone may
+	 *   leave nothing rendering it.
+	 * - Pages this module will not actually paint. messages_render_hook()
+	 *   returns null for shop, home and the mini-cart fallback context, which
+	 *   stay with v5.
+	 */
+	private function should_load_messages(): bool {
+		if ( is_admin() || $this->is_block_context() ) {
+			return false;
+		}
+
+		return $this->messages_enabled() && null !== $this->messages_render_hook();
+	}
+
+	/**
+	 * Whether Pay Later messaging is enabled and eligible on this page.
+	 */
+	public function messages_enabled(): bool {
+		if ( is_admin() ) {
+			return false;
+		}
+
+		return $this->messages_eligibility->is_enabled_for_location(
+			$this->messages_settings_location()
+		);
+	}
+
+	/**
+	 * Maps the current page onto a Pay Later messaging settings location.
+	 *
+	 * The single normalization point for both the style and the eligibility
+	 * lookup. SettingsStatus::normalize_location() cannot be relied on here:
+	 * it is button-oriented and maps 'checkout-block' to
+	 * 'checkout-block-express', a location the messaging settings never
+	 * contain, so messaging would silently never enable on the block
+	 * checkout.
+	 *
+	 * Returns an empty string for shop, home and the mini-cart context, which
+	 * this module currently does not serve.
+	 */
+	private function messages_settings_location(): string {
+		switch ( $this->context->location() ) {
+			case 'product':
+				return 'product';
+			case 'cart':
+			case 'cart-block':
+				return 'cart';
+			case 'checkout':
+			case 'checkout-block':
+			case 'pay-now':
+				return 'checkout';
+			default:
+				return '';
+		}
+	}
+
+	/**
+	 * The v6 page-type attribute value for the current page.
+	 */
+	private function messages_page_type(): string {
+		switch ( $this->messages_settings_location() ) {
+			case 'product':
+				return 'product-details';
+			case 'cart':
+				return 'cart';
+			default:
+				return 'checkout';
+		}
+	}
+
+	/**
+	 * The amount the Pay Later message prices.
+	 *
+	 * Product-first, matching v5's message_values(): on a product page the
+	 * message must price the product the buyer is looking at, even when the
+	 * cart already holds other items. This is why transaction_amount() (which
+	 * is cart-first, because it feeds button eligibility) cannot be reused.
+	 */
+	private function messages_amount(): string {
+		if ( 'pay-now' === $this->get_page_context() ) {
+			$order = $this->order_pay();
+
+			return $order ? number_format( (float) $order->get_total(), 2, '.', '' ) : '';
+		}
+
+		// Scoped to the product location rather than probing wc_get_product()
+		// unconditionally the way v5 does: on a cart or checkout page a stray
+		// global $product — left behind by a theme loop or another plugin —
+		// would otherwise make the message price that product instead of the
+		// cart. The location check also covers the [product_page] shortcut,
+		// where is_product() is false but the context is still 'product'.
+		if ( 'product' === $this->messages_settings_location() ) {
+			$product = wc_get_product();
+			if ( $product instanceof \WC_Product ) {
+				return number_format( (float) wc_get_price_including_tax( $product ), 2, '.', '' );
+			}
+		}
+
+		$cart = WC()->cart;
+		if ( $cart ) {
+			return number_format( (float) $cart->get_total( 'edit' ), 2, '.', '' );
+		}
+
+		return '';
+	}
+
+	/**
+	 * The action hook the message wrapper renders on, or null when this
+	 * module does not place messages on the current page.
+	 *
+	 * Reuses the v5 filter names so a merchant override relocates both
+	 * stacks.
+	 *
+	 * @return array{name: string, priority: int}|null
+	 */
+	public function messages_render_hook(): ?array {
+		switch ( $this->context->location() ) {
+			case 'checkout':
+				return $this->message_hook( 'checkout', 'woocommerce_review_order_before_payment', 10 );
+			case 'cart':
+				/**
+				 * The action name that the PayPal buttons use for rendering next to the cart's Proceed to Checkout button.
+				 */
+				$cart_hook = (string) apply_filters(
+					'woocommerce_paypal_payments_proceed_to_checkout_button_renderer_hook',
+					'woocommerce_proceed_to_checkout'
+				);
+
+				return $this->message_hook( 'cart', $cart_hook, 19 );
+			case 'product':
+				/**
+				 * The action name that the PayPal buttons use for rendering on the single product page.
+				 */
+				$product_hook = (string) apply_filters(
+					'woocommerce_paypal_payments_single_product_renderer_hook',
+					'woocommerce_single_product_summary'
+				);
+
+				return $this->message_hook( 'product', $product_hook, 30 );
+			case 'pay-now':
+				return $this->message_hook( 'pay-now', self::PAY_ORDER_MESSAGE_HOOK, 10 );
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Applies the per-location message hook and priority filters.
+	 *
+	 * @param string $location         The page location.
+	 * @param string $default_hook     The default action name.
+	 * @param int    $default_priority The default priority.
+	 * @return array{name: string, priority: int}
+	 */
+	private function message_hook( string $location, string $default_hook, int $default_priority ): array {
+		$location_hook = 'pay-now' === $location ? 'pay_order' : $location;
+
+		/**
+		 * The filter returning the action name that will be used for rendering Pay Later messages.
+		 */
+		$name = (string) apply_filters(
+			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_hook",
+			$default_hook
+		);
+
+		/**
+		 * The filter returning the action priority that will be used for rendering Pay Later messages.
+		 */
+		$priority = (int) apply_filters(
+			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_priority",
+			$default_priority
+		);
+
+		return array(
+			'name'     => $name,
+			'priority' => $priority,
+		);
+	}
+
+	/**
+	 * Prints the Pay Later message placeholder.
+	 *
+	 * Emits the same .ppcp-messages wrapper v5 emits rather than the
+	 * <paypal-message> element itself, so one JS mount path serves both these
+	 * wrappers and the Pay Later message blocks, and so theme and plugin CSS
+	 * keyed on the class keeps working.
+	 */
+	public function render_message_wrapper(): void {
+		$location      = $this->context->location();
+		$location_hook = 'pay-now' === $location ? 'pay_order' : $location;
+
+		/**
+		 * A hook executed before rendering of the PCP Pay Later messages wrapper.
+		 */
+		do_action( "ppcp_before_{$location_hook}_message_wrapper" );
+
+		echo '<div class="ppcp-messages"></div>';
+
+		/**
+		 * A hook executed after rendering of the PCP Pay Later messages wrapper.
+		 */
+		do_action( "ppcp_after_{$location_hook}_message_wrapper" );
+	}
+
+	/**
 	 * The configuration data for the SDK v6 bootstrap script.
 	 *
 	 * Also consumed by the block payment method (V6PaymentMethod), which
@@ -450,6 +674,8 @@ class SdkV6Manager {
 		}
 
 		$card_fields_enabled = $this->is_card_fields_enabled();
+
+		$messages_settings_location = $this->messages_settings_location();
 
 		$data = array(
 			'sdk_url'           => $base_url . '/web-sdk/v6/core',
@@ -547,6 +773,14 @@ class SdkV6Manager {
 					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
 					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
 				),
+			),
+			'messages'          => array(
+				'enabled'   => $this->messages_enabled(),
+				'wrapper'   => '.ppcp-messages',
+				'is_hidden' => $this->messages_eligibility->is_hidden( $page_context ),
+				'amount'    => $this->messages_amount(),
+				'page_type' => $this->messages_page_type(),
+				'style'     => $this->message_style_mapper->styles_for_location( $messages_settings_location ),
 			),
 		);
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -192,14 +192,12 @@ class SdkV6Manager {
 	/**
 	 * Determines which button locations should render on the current page.
 	 *
+	 * Expects Context::init_context() to have run, so that is_cart() and
+	 * is_checkout() resolve on classic-shortcode block pages.
+	 *
 	 * @return array<string, bool> Location => enabled (product, cart, checkout, pay-now, mini-cart).
 	 */
 	public function determine_render_places(): array {
-		// Activate is_cart()/is_checkout() on classic-shortcode block pages;
-		// otherwise this only happens as a side effect of constructing the
-		// (discarded) v5 SmartButton.
-		$this->context->init_context();
-
 		// Free orders ($0 total, e.g. a 100%-off coupon or free trial) do not
 		// need payment, so the cart/checkout wallet buttons must not render —
 		// matching v5's is_cart_price_total_zero() suppression.

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -172,11 +172,13 @@ class SdkV6Manager {
 			return;
 		}
 
+		$asset = $this->asset_getter->get_asset_data( 'boot.js', $this->version );
+
 		wp_register_script(
 			'wc-ppcp-sdk-v6-boot',
 			$script_url,
-			array(),
-			$this->version,
+			$asset['dependencies'],
+			$asset['version'],
 			true
 		);
 

--- a/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
+++ b/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
@@ -58,14 +58,11 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 			return array();
 		}
 
-		$handle    = 'wc-ppcp-sdk-v6-blocks';
-		$asset_php = $this->asset_getter->get_asset_php_path( 'checkout-block.js' );
-		$asset     = file_exists( $asset_php )
-			? require $asset_php
-			: array(
-				'dependencies' => array(),
-				'version'      => $this->version,
-			);
+		$handle = 'wc-ppcp-sdk-v6-blocks';
+		$asset  = $this->asset_getter->get_asset_data(
+			'checkout-block.js',
+			$this->version
+		);
 
 		wp_register_script(
 			$handle,

--- a/modules/ppcp-sdk-v6/src/Helper/MessageStyleMapper.php
+++ b/modules/ppcp-sdk-v6/src/Helper/MessageStyleMapper.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+
+/**
+ * Maps admin Pay Later messaging settings to v6 Web Component attributes.
+ */
+class MessageStyleMapper {
+
+	/**
+	 * Maps admin logo types to v6 logo-type values.
+	 */
+	private const LOGO_TYPE_MAP = array(
+		'primary'     => 'WORDMARK',
+		'alternative' => 'MONOGRAM',
+		'inline'      => 'WORDMARK',
+		'none'        => 'TEXT',
+	);
+
+	/**
+	 * Maps admin logo positions to v6 logo-position values.
+	 *
+	 * INLINE is absent because the admin setting that asks for it
+	 * is the logo *type*, not the position, so an entry here
+	 * would never be reached. See styles_for_location().
+	 */
+	private const LOGO_POSITION_MAP = array(
+		'left'  => 'LEFT',
+		'right' => 'RIGHT',
+		'top'   => 'TOP',
+	);
+
+	/**
+	 * Maps admin text colors to v6 text-color values.
+	 *
+	 * There is no v6 "grayscale", so MONOCHROME is its nearest neighbour.
+	 */
+	private const TEXT_COLOR_MAP = array(
+		'black'      => 'BLACK',
+		'white'      => 'WHITE',
+		'monochrome' => 'MONOCHROME',
+		'grayscale'  => 'MONOCHROME',
+	);
+
+	/**
+	 * The font-size range the v6 component accepts, in px.
+	 */
+	private const FONT_SIZE_MIN = 10;
+	private const FONT_SIZE_MAX = 16;
+
+	private SettingsProvider $settings_provider;
+
+	public function __construct( SettingsProvider $settings_provider ) {
+		$this->settings_provider = $settings_provider;
+	}
+
+	/**
+	 * Returns v6 message attributes for a messaging settings location.
+	 *
+	 * The v6 messaging component styles text messages only: it has no
+	 * equivalent for the admin "banner" (flex) layout, its flex color, or
+	 * its aspect ratio, so those three settings are not read
+	 * and a banner-configured location renders as a text message.
+	 *
+	 * @param string $location The messaging settings location (cart, checkout, product, ...).
+	 * @return array{logoType: string, logoPosition: string, textColor: string, fontSize: string}
+	 */
+	public function styles_for_location( string $location ): array {
+		$style = $this->settings_provider->pay_later_messaging_style( $location );
+
+		$logo_type     = (string) ( $style['logo_type'] ?? '' );
+		$logo_position = (string) ( $style['logo_position'] ?? '' );
+		$text_color    = (string) ( $style['text_color'] ?? '' );
+
+		return array(
+			'logoType'     => self::LOGO_TYPE_MAP[ $logo_type ] ?? 'WORDMARK',
+			'logoPosition' => 'inline' === $logo_type
+				? 'INLINE'
+				: ( self::LOGO_POSITION_MAP[ $logo_position ] ?? 'LEFT' ),
+			'textColor'    => self::TEXT_COLOR_MAP[ $text_color ] ?? 'BLACK',
+			'fontSize'     => $this->font_size( $style['text_size'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Converts the admin text size into a CSS length for
+	 * --paypal-message-font-size, or an empty string when it is unusable.
+	 *
+	 * @param mixed $text_size The configured text size.
+	 */
+	private function font_size( $text_size ): string {
+		if ( ! is_numeric( $text_size ) ) {
+			return '';
+		}
+
+		$size = (int) $text_size;
+		$size = max( self::FONT_SIZE_MIN, min( self::FONT_SIZE_MAX, $size ) );
+
+		return $size . 'px';
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Helper/MessagesEligibility.php
+++ b/modules/ppcp-sdk-v6/src/Helper/MessagesEligibility.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use WC_Product;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
+
+/**
+ * Decides whether Pay Later messaging may render, and whether it is filtered out.
+ *
+ * Ports the eligibility half of the v5 SmartButton::should_load_messages()
+ * and is_pay_later_filter_enabled_for_location().
+ */
+class MessagesEligibility {
+
+	private SettingsProvider $settings_provider;
+	private SettingsStatus $settings_status;
+	private MessagesApply $messages_apply;
+	private FreeTrialSubscriptionHelper $free_trial_helper;
+
+	public function __construct(
+		SettingsProvider $settings_provider,
+		SettingsStatus $settings_status,
+		MessagesApply $messages_apply,
+		FreeTrialSubscriptionHelper $free_trial_helper
+	) {
+		$this->settings_provider = $settings_provider;
+		$this->settings_status   = $settings_status;
+		$this->messages_apply    = $messages_apply;
+		$this->free_trial_helper = $free_trial_helper;
+	}
+
+	/**
+	 * Whether messaging is enabled for a messaging settings location.
+	 *
+	 * The location must already be normalized to the settings vocabulary
+	 * (cart, checkout, product, ...) — see SdkV6Manager::messages_settings_location().
+	 *
+	 * @param string $location The messaging settings location.
+	 */
+	public function is_enabled_for_location( string $location ): bool {
+		if ( '' === $location ) {
+			return false;
+		}
+
+		/**
+		 * The filter returning whether Pay Later messaging should render at all.
+		 * Shared with the v5 SmartButton.
+		 */
+		if ( ! apply_filters( 'woocommerce_paypal_payments_should_render_pay_later_messaging', true ) ) {
+			return false;
+		}
+
+		if ( ! $this->settings_provider->gateway_enabled( PayPalGateway::ID ) ) {
+			return false;
+		}
+
+		if ( ! $this->settings_status->is_pay_later_messaging_enabled()
+			|| ! $this->settings_status->has_pay_later_messaging_locations() ) {
+			return false;
+		}
+
+		if ( ! $this->messages_apply->for_country() ) {
+			return false;
+		}
+
+		if ( $this->free_trial_helper->is_free_trial_cart() ) {
+			return false;
+		}
+
+		return $this->settings_status->is_pay_later_messaging_enabled_for_location( $location );
+	}
+
+	/**
+	 * Whether a merchant filter has switched Pay Later off for this context.
+	 *
+	 * @param string $context The page context (product, cart, checkout, ...).
+	 */
+	public function is_hidden( string $context ): bool {
+		if ( 'product' === $context ) {
+			/**
+			 * Allows to decide if Pay Later should be disabled for a given product.
+			 * Shared with the v5 SmartButton.
+			 */
+			return (bool) apply_filters(
+				'woocommerce_paypal_payments_product_buttons_paylater_disabled',
+				false,
+				$this->product_filter_context_data()
+			);
+		}
+
+		/**
+		 * Allows to decide if Pay Later should be disabled on a given context.
+		 * Shared with the v5 SmartButton.
+		 */
+		return (bool) apply_filters(
+			'woocommerce_paypal_payments_buttons_paylater_disabled',
+			false,
+			$context
+		);
+	}
+
+	/**
+	 * The context data passed to the product-level Pay Later filter.
+	 */
+	private function product_filter_context_data(): array {
+		$product = wc_get_product();
+		if ( ! $product instanceof WC_Product ) {
+			return array();
+		}
+
+		return array(
+			'product'     => $product,
+			'order_total' => (float) $product->get_price( 'raw' ),
+		);
+	}
+}

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -106,6 +106,7 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 				assert( $manager instanceof SdkV6Manager );
 
 				$this->register_render_hooks( $manager );
+				$this->register_message_hooks( $manager );
 			}
 		);
 
@@ -214,6 +215,61 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Registers the hook that outputs the Pay Later message wrapper.
+	 */
+	private function register_message_hooks( SdkV6Manager $manager ): void {
+		if ( ! $manager->should_load_on_current_page() || ! $manager->messages_enabled() ) {
+			return;
+		}
+
+		$hook = $manager->messages_render_hook();
+		if ( ! $hook ) {
+			return;
+		}
+
+		add_action(
+			$hook['name'],
+			static fn() => $manager->render_message_wrapper(),
+			$hook['priority']
+		);
+
+		$this->maybe_relocate_pay_order_message( $hook['name'] );
+	}
+
+	/**
+	 * Moves the pay-for-order message above the payment methods.
+	 *
+	 * The pay-for-order page has no equivalent of
+	 * woocommerce_review_order_before_payment, so the wrapper is printed after
+	 * the submit button and relocated in the browser.
+	 *
+	 * @param string $hook_name The hook the wrapper was registered on.
+	 */
+	private function maybe_relocate_pay_order_message( string $hook_name ): void {
+		if ( SdkV6Manager::PAY_ORDER_MESSAGE_HOOK !== $hook_name ) {
+			return;
+		}
+
+		/**
+		 * The filter returning true if Pay Later messages should be displayed before payment methods
+		 * on the pay for order page, like in checkout.
+		 */
+		if ( ! apply_filters( 'woocommerce_paypal_payments_put_pay_order_messages_before_payment_methods', true ) ) {
+			return;
+		}
+
+		add_action(
+			'ppcp_after_pay_order_message_wrapper',
+			static function () {
+				echo '
+<script>
+document.querySelector("#payment").before(document.querySelector(".ppcp-messages"))
+</script>';
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\SdkV6;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\AddPaymentMethodManager;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
@@ -93,6 +94,13 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 				if ( is_admin() ) {
 					return;
 				}
+
+				// Activates is_cart()/is_checkout() on classic-shortcode block
+				// pages. The hook registrars below resolve the page context, so this
+				// needs to run before.
+				$context = $c->get( 'button.helper.context' );
+				assert( $context instanceof Context );
+				$context->init_context();
 
 				$manager = $c->get( 'sdk-v6.manager' );
 				assert( $manager instanceof SdkV6Manager );

--- a/src/Assets/AssetGetter.php
+++ b/src/Assets/AssetGetter.php
@@ -48,6 +48,32 @@ class AssetGetter {
 	}
 
 	/**
+	 * Returns the dependencies and version webpack generated for a compiled asset.
+	 *
+	 * Use this over hardcoding an empty dependency list. The WP dependency-extraction
+	 * webpack plugin rewrites `@wordpress/*` imports to `window.wp.*` globals and
+	 * records the matching script handles here.
+	 * Registering without them may cause failure in some cases depending on the page and environment.
+	 *
+	 * The version is a content hash, so it also busts caches on rebuild where
+	 * the plugin version would not.
+	 *
+	 * @param string $asset_name       The asset name like 'index.js'.
+	 * @param string $fallback_version Version to use when the file is absent.
+	 * @return array{dependencies: string[], version: string}
+	 */
+	public function get_asset_data( string $asset_name, string $fallback_version ): array {
+		$path = $this->get_asset_php_path( $asset_name );
+
+		$asset = file_exists( $path ) ? require $path : array();
+
+		return array(
+			'dependencies' => is_array( $asset['dependencies'] ?? null ) ? $asset['dependencies'] : array(),
+			'version'      => is_string( $asset['version'] ?? null ) ? $asset['version'] : $fallback_version,
+		);
+	}
+
+	/**
 	 * Returns URL for the static asset (images, ...) in the module assets/ dir.
 	 *
 	 * @param string $asset_name The asset name like 'images/icon.svg'.

--- a/tests/PHPUnit/Assets/AssetGetterTest.php
+++ b/tests/PHPUnit/Assets/AssetGetterTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Assets;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class AssetGetterTest extends TestCase
+{
+    private string $plugin_folder_path;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        when('trailingslashit')->alias(static function (string $path): string {
+            return rtrim($path, '/') . '/';
+        });
+
+        $this->plugin_folder_path = sys_get_temp_dir() . '/ppcp-asset-getter-test-' . uniqid('', true);
+        mkdir($this->plugin_folder_path . '/assets', 0777, true);
+    }
+
+    public function tearDown(): void
+    {
+        $assets_dir = $this->plugin_folder_path . '/assets';
+        if (is_dir($assets_dir)) {
+            foreach (glob($assets_dir . '/*') ?: [] as $file) {
+                unlink($file);
+            }
+            rmdir($assets_dir);
+        }
+        if (is_dir($this->plugin_folder_path)) {
+            rmdir($this->plugin_folder_path);
+        }
+
+        parent::tearDown();
+    }
+
+    private function createTestee(string $module_name = 'test-module'): AssetGetter
+    {
+        return new AssetGetter('https://example.com/', $this->plugin_folder_path, $module_name);
+    }
+
+    private function write_asset_file(string $module_name, string $asset_name, string $php_content): void
+    {
+        $compiled_name = str_replace('/', '-', $asset_name);
+        $type          = pathinfo($asset_name, PATHINFO_EXTENSION);
+        $without_ext   = pathinfo("{$module_name}-{$type}-{$compiled_name}", PATHINFO_FILENAME);
+
+        file_put_contents(
+            $this->plugin_folder_path . "/assets/{$without_ext}.asset.php",
+            $php_content
+        );
+    }
+
+    /**
+     * GIVEN a webpack-generated .asset.php file declaring dependencies and a content-hash version
+     * WHEN the asset data is requested
+     * THEN the dependencies and version are returned exactly as recorded by webpack
+     */
+    public function test_get_asset_data_returns_dependencies_and_version_from_existing_file(): void
+    {
+        $this->write_asset_file(
+            'test-module',
+            'boot.js',
+            "<?php return array('dependencies' => array('wp-data', 'wp-element'), 'version' => 'abc123');"
+        );
+
+        $testee = $this->createTestee();
+        $data   = $testee->get_asset_data('boot.js', '1.0.0');
+
+        $this->assertSame(['wp-data', 'wp-element'], $data['dependencies']);
+        $this->assertSame('abc123', $data['version']);
+    }
+
+    /**
+     * GIVEN no compiled .asset.php file exists for the requested asset (e.g. an unbuilt checkout)
+     * WHEN the asset data is requested
+     * THEN an empty dependency list and the caller-supplied fallback version are returned
+     */
+    public function test_get_asset_data_falls_back_when_file_is_missing(): void
+    {
+        $testee = $this->createTestee();
+        $data   = $testee->get_asset_data('boot.js', 'fallback-version');
+
+        $this->assertSame([], $data['dependencies']);
+        $this->assertSame('fallback-version', $data['version']);
+    }
+
+    /**
+     * GIVEN a .asset.php file whose contents do not match the expected shape
+     * WHEN the asset data is requested
+     * THEN each key falls back independently rather than the whole result erroring or
+     *      being discarded
+     *
+     * @dataProvider malformed_asset_file_provider
+     */
+    public function test_get_asset_data_falls_back_per_key_on_malformed_file(
+        string $php_content,
+        array $expected_dependencies,
+        string $expected_version
+    ): void {
+        $this->write_asset_file('test-module', 'boot.js', $php_content);
+
+        $testee = $this->createTestee();
+        $data   = $testee->get_asset_data('boot.js', 'fallback-version');
+
+        $this->assertSame($expected_dependencies, $data['dependencies']);
+        $this->assertSame($expected_version, $data['version']);
+    }
+
+    public function malformed_asset_file_provider(): array
+    {
+        return [
+            'file returns a non-array value entirely' => [
+                '<?php return null;',
+                [],
+                'fallback-version',
+            ],
+            'dependencies key missing falls back to empty array' => [
+                "<?php return array('version' => 'abc123');",
+                [],
+                'abc123',
+            ],
+            'version key missing falls back to the caller-supplied version' => [
+                "<?php return array('dependencies' => array('wp-data'));",
+                ['wp-data'],
+                'fallback-version',
+            ],
+            'dependencies is not an array falls back to empty array' => [
+                "<?php return array('dependencies' => 'wp-data', 'version' => 'abc123');",
+                [],
+                'abc123',
+            ],
+            'version is not a string falls back to the caller-supplied version' => [
+                "<?php return array('dependencies' => array('wp-data'), 'version' => 123);",
+                ['wp-data'],
+                'fallback-version',
+            ],
+        ];
+    }
+}

--- a/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
 class AddPaymentMethodManagerTest extends TestCase
@@ -171,5 +172,73 @@ class AddPaymentMethodManagerTest extends TestCase
         $method->setAccessible(true);
 
         return $method->invoke($testee);
+    }
+
+    // -------------------------------------------------------------------------
+    // enqueue()
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN a logged-in buyer with vaulting enabled on the add-payment-method page
+     * WHEN the bootstrap script is enqueued
+     * THEN it is registered with the dependencies and version webpack recorded for the
+     *      compiled bundle, not an empty dependency list and not just the plugin version.
+     */
+    public function testEnqueueRegistersScriptWithAssetDataDependenciesAndVersion(): void
+    {
+        when('is_user_logged_in')->justReturn(true);
+        $this->context->shouldReceive('is_add_payment_method_page')->andReturn(true);
+
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->settings_provider->shouldReceive('three_d_secure_enum')->andReturn('SCA_ALWAYS');
+        when('apply_filters')->alias(static fn (string $filter, $value) => $value);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('wc_get_account_endpoint_url')->justReturn('https://example.com/my-account/payment-methods');
+        when('wp_create_nonce')->justReturn('nonce');
+        when('wp_register_style')->justReturn(true);
+        when('wp_enqueue_style')->justReturn(null);
+        when('wp_add_inline_style')->justReturn(null);
+
+        $this->asset_getter->shouldReceive('get_asset_url')
+            ->with('boot-add-payment-method.js')
+            ->andReturn('https://example.com/assets/boot-add-payment-method.js');
+        $this->asset_getter->shouldReceive('get_asset_data')
+            ->with('boot-add-payment-method.js', '1.0.0')
+            ->andReturn(['dependencies' => ['wp-data'], 'version' => 'deadbeef']);
+
+        expect('wp_register_script')
+            ->once()
+            ->with(
+                'wc-ppcp-sdk-v6-add-payment-method',
+                'https://example.com/assets/boot-add-payment-method.js',
+                ['wp-data'],
+                'deadbeef',
+                true
+            );
+        expect('wp_localize_script')->once();
+        expect('wp_enqueue_script')->once()->with('wc-ppcp-sdk-v6-add-payment-method');
+
+        $testee = $this->createTestee(true, true);
+        $testee->enqueue();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * GIVEN the add-payment-method surfaces should not load on the current page
+     * WHEN enqueue() is called
+     * THEN no script is registered — the method returns before touching the asset getter
+     */
+    public function testEnqueueDoesNothingWhenShouldNotLoadOnCurrentPage(): void
+    {
+        when('is_user_logged_in')->justReturn(false);
+
+        expect('wp_register_script')->never();
+
+        $testee = $this->createTestee(true, true);
+        $testee->enqueue();
+
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -152,11 +152,17 @@ class SdkV6ManagerTest extends TestCase
      * AND the product and pay-now locations render regardless of the cart's payment status,
      *     since pay-now is driven by an existing WC order rather than the cart
      *
+     * AND determine_render_places() does not call Context::init_context() itself — that
+     *     initialization now happens once in SdkV6Module's 'wp' callback, before both the
+     *     button and message hook registrars run, so neither registrar depends on the other
+     *     running first to trip it as a side effect. Reintroducing the call here would restore
+     *     that ordering coupling.
+     *
      * @dataProvider render_places_needs_payment_provider
      */
     public function testDetermineRenderPlacesGatedByCartNeedsPayment(?bool $cart_needs_payment, array $expected): void
     {
-        $this->context->shouldReceive('init_context')->once();
+        $this->context->shouldReceive('init_context')->never();
         $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(true);
 
         if (null === $cart_needs_payment) {

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -9,6 +9,8 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
@@ -17,6 +19,9 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use function Brain\Monkey\Actions\expectDone;
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
 class SdkV6ManagerTest extends TestCase
@@ -31,6 +36,8 @@ class SdkV6ManagerTest extends TestCase
     private $card_payments_configuration;
     private $subscription_helper;
 	private $credit_card_icons;
+	private $message_style_mapper;
+	private $messages_eligibility;
 	private $google_pay_config;
 	private $apple_pay_config;
 
@@ -49,6 +56,22 @@ class SdkV6ManagerTest extends TestCase
 		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
 		$this->credit_card_icons = [];
+
+		$this->message_style_mapper = Mockery::mock(MessageStyleMapper::class);
+		$this->message_style_mapper->shouldReceive('styles_for_location')->andReturn([
+			'logoType'     => 'WORDMARK',
+			'logoPosition' => 'LEFT',
+			'textColor'    => 'BLACK',
+			'fontSize'     => '',
+		])->byDefault();
+
+		$this->messages_eligibility = Mockery::mock(MessagesEligibility::class);
+		$this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(false)->byDefault();
+		$this->messages_eligibility->shouldReceive('is_hidden')->andReturn(false)->byDefault();
+
+		$this->context->shouldReceive('location')->andReturn('')->byDefault();
+
+		when('is_admin')->justReturn(false);
 
 		$this->google_pay_config = Mockery::mock(GooglePayConfig::class);
 		$this->google_pay_config->shouldReceive('should_render')->andReturn(false)->byDefault();
@@ -98,10 +121,35 @@ class SdkV6ManagerTest extends TestCase
 	        $card_vaulting_enabled,
 	        $this->subscription_helper,
 	        $credit_card_icons,
+	        $this->message_style_mapper,
+	        $this->messages_eligibility,
 	        $merchant_country,
 	        $this->google_pay_config,
 	        $this->apple_pay_config
         );
+    }
+
+    private function stubScriptDataBaseline(string $page_context, string $location): void
+    {
+        $this->context->shouldReceive('context')->andReturn($page_context);
+        $this->context->shouldReceive('location')->andReturn($location);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        when('WC')->justReturn($this->create_wc_stub());
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wp_create_nonce')->justReturn('nonce');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
     }
 
     public function tearDown(): void
@@ -217,17 +265,21 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
-     * GIVEN the mini-cart smart button location is disabled and the page has no matching context
+     * GIVEN the mini-cart smart button location is disabled, the page has no matching
+     *       context, and Pay Later messaging is explicitly ineligible for the resolved
+     *       (empty) location
      * WHEN checking whether the v6 SDK should load on the current page
      * THEN the SDK does not load
      */
     public function testShouldNotLoadWhenMiniCartDisabledAndNoMatchingPageContext(): void
     {
         $this->context->shouldReceive('context')->andReturn('');
+        $this->context->shouldReceive('location')->andReturn('');
         $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
         $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
             ->with('mini-cart')
             ->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->with('')->andReturn(false);
 
         $testee = $this->createTestee();
 
@@ -446,5 +498,638 @@ class SdkV6ManagerTest extends TestCase
                 [],
             ],
         ];
+    }
+
+    // -------------------------------------------------------------------------
+    // should_load_on_current_page(): button, ACDC and messaging conditions
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN a WooCommerce Blocks cart or checkout page, where should_load_on_current_page()
+     *       is only allowed to answer for the payment-method surface (button locations and
+     *       ACDC), never for Pay Later messaging alone
+     * WHEN checking whether the v6 SDK should load a payment-method-owning surface,
+     *      once with Pay Later messaging eligible for the page and once with it ineligible
+     * THEN should_load_on_current_page() returns the same result either way
+     *
+     * Two callers narrow this predicate further with is_block_context():
+     * V6PaymentMethod::is_active() and the v5 block-method unregistration in SdkV6Module
+     * (`&& is_block_context()`). Both rely on seeing only the payment-method answer in
+     * block contexts. If this invariant ever breaks, v6 express buttons get registered on
+     * block pages where the merchant disabled them, and the v5 Google Pay, Apple Pay and
+     * Fastlane block methods get unregistered with no v6 replacement behind them.
+     *
+     * Context::location() is stubbed here (not just context()) so the messaging chain is
+     * genuinely exercised down to MessagesEligibility::is_enabled_for_location(), called
+     * with the normalized location — otherwise this reduces to false === false for a
+     * reason unrelated to block contexts.
+     *
+     * Block contexts are excluded from messaging by two independent mechanisms in
+     * production: should_load_messages()'s own is_block_context() early-out, and
+     * messages_render_hook() returning null for block locations (its switch has no block
+     * cases). This test only fails when BOTH are undone at once; removing either alone
+     * still leaves the other vetoing messaging, so it cannot pin one mechanism in
+     * isolation. That redundancy is deliberate today, but it is exactly what the future
+     * "make block messaging claim a page on its own" change would need to undo, and
+     * that change must revisit both should_load_messages() and messages_render_hook()
+     * together. testMessagesRenderHookReturnsNullForBlockLocations() pins the second
+     * mechanism (messages_render_hook()) on its own; the first (is_block_context()) has
+     * no standalone test — see that test's docblock for why.
+     *
+     * @dataProvider blockContextProvider
+     */
+    public function testShouldLoadOnCurrentPageInBlockContextsIsUnaffectedByMessagingEligibility(
+        string $page_context,
+        string $normalized_location
+    ): void {
+        $this->context->shouldReceive('context')->andReturn($page_context);
+        $this->context->shouldReceive('location')->andReturn($page_context);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')
+            ->with($normalized_location)
+            ->andReturn(true);
+        $withMessagingEnabled = $this->createTestee()->should_load_on_current_page();
+
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')
+            ->with($normalized_location)
+            ->andReturn(false);
+        $withMessagingDisabled = $this->createTestee()->should_load_on_current_page();
+
+        $this->assertSame($withMessagingEnabled, $withMessagingDisabled);
+    }
+
+    public function blockContextProvider(): array
+    {
+        return [
+            'cart block'     => ['cart-block', 'cart'],
+            'checkout block' => ['checkout-block', 'checkout'],
+        ];
+    }
+
+    /**
+     * GIVEN a page whose location has smart buttons enabled
+     * WHEN checking whether the v6 SDK should load on the current page, for any reason
+     * THEN it loads
+     */
+    public function testShouldLoadOnCurrentPageTrueWhenButtonLocationEnabled(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->with('checkout')->andReturn(true);
+
+        $testee = $this->createTestee();
+
+        $this->assertTrue($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN a classic checkout page with no smart button enabled anywhere, but Pay Later
+     *       messaging eligible on that page
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN it still loads, purely to render the message
+     */
+    public function testShouldLoadOnCurrentPageTrueWhenOnlyMessagingIsEnabledOnAClassicPage(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->context->shouldReceive('location')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->with('checkout')->andReturn(true);
+
+        $testee = $this->createTestee();
+
+        $this->assertTrue($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN a WooCommerce Blocks cart or checkout page, with Pay Later messaging eligible
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN it does not load through the messaging path — block pages get the SDK through
+     *      the block payment method instead, gated on the button/ACDC conditions alone
+     *
+     * Context::location() is stubbed to the block location (not just context()) and
+     * MessagesEligibility::is_enabled_for_location() is stubbed to true for the
+     * normalized location, so the false result genuinely comes from the block-context
+     * exclusion rather than from an unstubbed location() defaulting to null/empty.
+     *
+     * This is a concrete instance of the invariant pinned by
+     * testShouldLoadOnCurrentPageInBlockContextsIsUnaffectedByMessagingEligibility()
+     * (messaging eligibility never changes the block-context answer); kept alongside it
+     * because it also documents the specific value (false) that answer takes, which the
+     * invariant test deliberately leaves unspecified. Like that test, it is only
+     * mutation-sensitive to should_load_messages()'s and messages_render_hook()'s block
+     * exclusions being removed together, not to either alone — see the redundancy note
+     * there.
+     *
+     * @dataProvider blockContextProvider
+     */
+    public function testShouldLoadOnCurrentPageFalseInBlockContextsEvenWhenMessagingEnabled(
+        string $page_context,
+        string $normalized_location
+    ): void {
+        $this->context->shouldReceive('context')->andReturn($page_context);
+        $this->context->shouldReceive('location')->andReturn($page_context);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')
+            ->with($normalized_location)
+            ->andReturn(true);
+
+        $testee = $this->createTestee();
+
+        $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN a page whose location resolves to shop, home or no location at all
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN it does not load — this module never places a message on these pages, so
+     *      messages_render_hook() returning null must veto the messaging-only claim
+     *
+     * @dataProvider unsupportedMessageLocationProvider
+     */
+    public function testShouldLoadOnCurrentPageFalseWhenMessagesRenderHookIsNull(string $location): void
+    {
+        $this->context->shouldReceive('context')->andReturn('');
+        $this->context->shouldReceive('location')->andReturn($location);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(true);
+
+        $testee = $this->createTestee();
+
+        $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    public function unsupportedMessageLocationProvider(): array
+    {
+        return [
+            'shop page'    => ['shop'],
+            'home page'    => ['home'],
+            'no location'  => [''],
+        ];
+    }
+
+    /**
+     * GIVEN a classic page in wp-admin, one where Pay Later messaging would otherwise be
+     *       eligible
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN it does not load, even though nothing else would have vetoed messaging
+     *
+     * Messaging is stubbed eligible for the checkout location so the false result is not
+     * an accident of an unstubbed location() silently keeping messaging off.
+     *
+     * is_admin() is checked twice in production — once in should_load_messages() and
+     * again, independently, inside messages_enabled() — so this test is only
+     * mutation-sensitive to both checks being removed together, not to either alone.
+     * That duplication is real redundancy in the production code, not a test defect.
+     */
+    public function testShouldLoadOnCurrentPageFalseUnderIsAdmin(): void
+    {
+        when('is_admin')->justReturn(true);
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->context->shouldReceive('location')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->with('checkout')->andReturn(true);
+
+        $testee = $this->createTestee();
+
+        $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    // -------------------------------------------------------------------------
+    // Block location normalization for the messaging eligibility lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN the current page resolves to a block cart/checkout location, or to pay-now
+     * WHEN checking whether Pay Later messaging is enabled
+     * THEN MessagesEligibility::is_enabled_for_location() is called with the normalized
+     *      messaging-settings location, not the raw block/page location
+     *
+     * SettingsStatus::normalize_location() would turn 'checkout-block' into
+     * 'checkout-block-express', a location the messaging settings never contain, so
+     * skipping this normalization would silently disable messaging on block checkout.
+     *
+     * @dataProvider blockLocationNormalizationProvider
+     */
+    public function testMessagesEnabledNormalizesBlockLocationsForEligibilityLookup(string $raw_location, string $expected_location): void
+    {
+        $this->context->shouldReceive('location')->andReturn($raw_location);
+        $this->messages_eligibility
+            ->shouldReceive('is_enabled_for_location')
+            ->once()
+            ->with($expected_location)
+            ->andReturn(true);
+
+        $testee = $this->createTestee();
+
+        $this->assertTrue($testee->messages_enabled());
+    }
+
+    public function blockLocationNormalizationProvider(): array
+    {
+        return [
+            'checkout-block normalizes to checkout, not checkout-block-express' => ['checkout-block', 'checkout'],
+            'cart-block normalizes to cart'                                      => ['cart-block', 'cart'],
+            'pay-now normalizes to checkout'                                     => ['pay-now', 'checkout'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // script_data()['messages']
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN Pay Later messaging is not enabled for the current page
+     * WHEN the SDK bootstrap data is generated
+     * THEN the messages payload still carries all six documented keys, with enabled: false
+     *      rather than the key being omitted — so the bootstrap can branch on it directly
+     */
+    public function testScriptDataMessagesShapeIncludesAllKeysEvenWhenDisabled(): void
+    {
+        $this->stubScriptDataBaseline('checkout', 'checkout');
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_hidden')->with('checkout')->andReturn(false);
+        $this->message_style_mapper->shouldReceive('styles_for_location')->with('checkout')->andReturn([
+            'logoType' => 'WORDMARK', 'logoPosition' => 'LEFT', 'textColor' => 'BLACK', 'fontSize' => '',
+        ]);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(
+            ['enabled', 'wrapper', 'is_hidden', 'amount', 'page_type', 'style'],
+            array_keys($data['messages'])
+        );
+        $this->assertFalse($data['messages']['enabled']);
+    }
+
+    // -------------------------------------------------------------------------
+    // messages_amount() — product-first, unlike transaction_amount()
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN a product page while the cart already holds other, different-priced items
+     * WHEN the SDK bootstrap data is generated
+     * THEN the Pay Later message prices the product being viewed, not the cart total
+     * AND the button-eligibility amount (transaction_amount) remains cart-first,
+     *     the opposite behaviour
+     */
+    public function testMessagesAmountIsProductFirstOnProductPageEvenWithNonEmptyCart(): void
+    {
+        $this->stubScriptDataBaseline('product', 'product');
+
+        $product = Mockery::mock(\WC_Product::class);
+        when('wc_get_product')->justReturn($product);
+        when('wc_get_price_including_tax')->justReturn(29.99);
+
+        $cart = Mockery::mock();
+        $cart->shouldReceive('is_empty')->andReturn(false);
+        $cart->shouldReceive('get_total')->with('edit')->andReturn('99.99');
+        $cart->shouldReceive('needs_shipping')->andReturn(false);
+        when('WC')->justReturn((object) ['customer' => null, 'cart' => $cart]);
+
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_hidden')->andReturn(false);
+        $this->message_style_mapper->shouldReceive('styles_for_location')->andReturn([]);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame('29.99', $data['messages']['amount']);
+        $this->assertSame('99.99', $data['amount']);
+    }
+
+    /**
+     * GIVEN a buyer on the pay-for-order page for an existing WC order
+     * WHEN the SDK bootstrap data is generated
+     * THEN the Pay Later message prices the validated order total
+     */
+    public function testMessagesAmountUsesValidatedOrderTotalOnPayNowPage(): void
+    {
+        global $wp;
+        $wp = (object) ['query_vars' => ['order-pay' => 42]];
+        $_GET['key'] = 'order-key-abc';
+
+        $order = Mockery::mock(\WC_Order::class);
+        $order->shouldReceive('get_order_key')->andReturn('order-key-abc');
+        $order->shouldReceive('get_total')->andReturn('150.00');
+
+        $this->stubScriptDataBaseline('pay-now', 'pay-now');
+        when('wc_get_order')->justReturn($order);
+
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_hidden')->andReturn(false);
+        $this->message_style_mapper->shouldReceive('styles_for_location')->andReturn([]);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame('150.00', $data['messages']['amount']);
+    }
+
+    /**
+     * GIVEN neither a product, a cart, nor a pay-for-order order is available
+     * WHEN the SDK bootstrap data is generated
+     * THEN the Pay Later message amount falls back to an empty string
+     */
+    public function testMessagesAmountFallsBackToEmptyStringWhenNothingIsAvailable(): void
+    {
+        $this->stubScriptDataBaseline('checkout', 'checkout');
+        when('wc_get_product')->justReturn(null);
+
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_hidden')->andReturn(false);
+        $this->message_style_mapper->shouldReceive('styles_for_location')->andReturn([]);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame('', $data['messages']['amount']);
+    }
+
+    // -------------------------------------------------------------------------
+    // messages_render_hook()
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN a page location this module places a message on
+     * WHEN resolving the message render hook, with no merchant filter overriding it
+     * THEN the documented default hook name and priority are returned
+     *
+     * @dataProvider defaultMessagesRenderHookProvider
+     */
+    public function testMessagesRenderHookReturnsDocumentedDefaults(string $location, string $expected_name, int $expected_priority): void
+    {
+        $this->context->shouldReceive('location')->andReturn($location);
+
+        $testee = $this->createTestee();
+        $hook   = $testee->messages_render_hook();
+
+        $this->assertSame(['name' => $expected_name, 'priority' => $expected_priority], $hook);
+    }
+
+    public function defaultMessagesRenderHookProvider(): array
+    {
+        return [
+            'checkout' => ['checkout', 'woocommerce_review_order_before_payment', 10],
+            'cart'     => ['cart', 'woocommerce_proceed_to_checkout', 19],
+            'product'  => ['product', 'woocommerce_single_product_summary', 30],
+            'pay-now'  => ['pay-now', 'woocommerce_pay_order_before_submit', 10],
+        ];
+    }
+
+    /**
+     * GIVEN a location this module does not place a message on (shop, home, or none)
+     * WHEN resolving the message render hook
+     * THEN null is returned, so this module stays out of the way and leaves the page to v5
+     *
+     * @dataProvider unsupportedRenderHookLocationProvider
+     */
+    public function testMessagesRenderHookReturnsNullForPagesThisModuleDoesNotServe(string $location): void
+    {
+        $this->context->shouldReceive('location')->andReturn($location);
+
+        $testee = $this->createTestee();
+
+        $this->assertNull($testee->messages_render_hook());
+    }
+
+    public function unsupportedRenderHookLocationProvider(): array
+    {
+        return [
+            'shop'  => ['shop'],
+            'home'  => ['home'],
+            'empty' => [''],
+        ];
+    }
+
+    /**
+     * GIVEN the current page resolves to a block cart or checkout location
+     * WHEN resolving the message render hook
+     * THEN null is returned — the switch in messages_render_hook() has no case for
+     *      'cart-block' or 'checkout-block', so block pages never get a message wrapper
+     *      from this module
+     *
+     * This pins, on its own, the second of should_load_messages()'s two independent
+     * block exclusions (see should_load_on_current_page()'s docblock and
+     * testShouldLoadOnCurrentPageInBlockContextsIsUnaffectedByMessagingEligibility()).
+     * The first exclusion — should_load_messages()'s own is_block_context() early-out —
+     * has no equivalent standalone test here: any test of should_load_on_current_page()
+     * still routes through the real messages_render_hook(), so removing the
+     * is_block_context() check alone would still be masked by this second exclusion.
+     * Isolating it would require a testable subclass overriding messages_render_hook(),
+     * which is out of scope for this fix.
+     *
+     * @dataProvider blockContextProvider
+     */
+    public function testMessagesRenderHookReturnsNullForBlockLocations(string $location): void
+    {
+        $this->context->shouldReceive('location')->andReturn($location);
+
+        $testee = $this->createTestee();
+
+        $this->assertNull($testee->messages_render_hook());
+    }
+
+    /**
+     * GIVEN a merchant has overridden the per-location message renderer hook and priority
+     * WHEN resolving the message render hook
+     * THEN the overridden values are returned
+     * AND the pay-now location uses the 'pay_order' filter name segment, not 'pay-now'
+     *
+     * @dataProvider renderHookFilterProvider
+     */
+    public function testMessagesRenderHookIsOverriddenByPerLocationFilters(string $location, string $filter_segment): void
+    {
+        $this->context->shouldReceive('location')->andReturn($location);
+
+        expectApplied("woocommerce_paypal_payments_{$filter_segment}_messages_renderer_hook")
+            ->once()
+            ->andReturn('custom_hook');
+        expectApplied("woocommerce_paypal_payments_{$filter_segment}_messages_renderer_priority")
+            ->once()
+            ->andReturn(99);
+
+        $testee = $this->createTestee();
+        $hook   = $testee->messages_render_hook();
+
+        $this->assertSame(['name' => 'custom_hook', 'priority' => 99], $hook);
+    }
+
+    public function renderHookFilterProvider(): array
+    {
+        return [
+            'checkout uses the checkout filter segment'          => ['checkout', 'checkout'],
+            'cart uses the cart filter segment'                  => ['cart', 'cart'],
+            'product uses the product filter segment'            => ['product', 'product'],
+            'pay-now uses the pay_order filter segment, not pay-now' => ['pay-now', 'pay_order'],
+        ];
+    }
+
+    /**
+     * GIVEN the cart or product default message hook, with a merchant override of the
+     *       corresponding button relocation filter
+     * WHEN resolving the message render hook, with no messaging-specific hook override
+     * THEN the relocated button hook is used as the message hook's default, keeping the
+     *      message attached to a button the merchant moved
+     *
+     * @dataProvider relocatedButtonHookProvider
+     */
+    public function testMessagesRenderHookDefaultUsesRelocatedButtonHookFirst(string $location, string $relocation_filter, string $relocated_hook): void
+    {
+        $this->context->shouldReceive('location')->andReturn($location);
+
+        expectApplied($relocation_filter)->once()->andReturn($relocated_hook);
+
+        $testee = $this->createTestee();
+        $hook   = $testee->messages_render_hook();
+
+        $this->assertSame($relocated_hook, $hook['name']);
+    }
+
+    public function relocatedButtonHookProvider(): array
+    {
+        return [
+            'cart passes through the proceed-to-checkout button relocation filter first' => [
+                'cart', 'woocommerce_paypal_payments_proceed_to_checkout_button_renderer_hook', 'my_custom_proceed_hook',
+            ],
+            'product passes through the single-product button relocation filter first' => [
+                'product', 'woocommerce_paypal_payments_single_product_renderer_hook', 'my_custom_product_hook',
+            ],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // render_message_wrapper()
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN a page location this module places a message on
+     * WHEN the message wrapper is rendered
+     * THEN the .ppcp-messages wrapper is echoed between the location's
+     *      "before" and "after" actions, in that order
+     * AND the pay-now location uses the 'pay_order' action name segment, not 'pay-now'
+     *
+     * @dataProvider renderMessageWrapperProvider
+     */
+    public function testRenderMessageWrapperEchoesWrapperBetweenBeforeAndAfterActions(string $location, string $action_segment): void
+    {
+        $this->context->shouldReceive('location')->andReturn($location);
+
+        $order = [];
+        expectDone("ppcp_before_{$action_segment}_message_wrapper")
+            ->once()
+            ->whenHappen(function () use (&$order): void {
+                $order[] = 'before';
+            });
+        expectDone("ppcp_after_{$action_segment}_message_wrapper")
+            ->once()
+            ->whenHappen(function () use (&$order): void {
+                $order[] = 'after';
+            });
+
+        $testee = $this->createTestee();
+
+        ob_start();
+        $testee->render_message_wrapper();
+        $output = ob_get_clean();
+
+        $this->assertSame('<div class="ppcp-messages"></div>', $output);
+        $this->assertSame(['before', 'after'], $order);
+    }
+
+    public function renderMessageWrapperProvider(): array
+    {
+        return [
+            'checkout'                        => ['checkout', 'checkout'],
+            'cart'                             => ['cart', 'cart'],
+            'product'                          => ['product', 'product'],
+            'pay-now uses pay_order segment'  => ['pay-now', 'pay_order'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // enqueue()
+    // -------------------------------------------------------------------------
+
+    /**
+     * GIVEN the v6 SDK should load on the current classic checkout page
+     * WHEN the bootstrap script is enqueued
+     * THEN it is registered with the dependencies and version webpack recorded for the
+     *      compiled bundle, not an empty dependency list and not just the plugin version.
+     */
+    public function testEnqueueRegistersScriptWithAssetDataDependenciesAndVersion(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->context->shouldReceive('location')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
+            ->with('checkout')->andReturn(true);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
+            ->with('mini-cart')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        when('WC')->justReturn($this->create_wc_stub());
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $this->asset_getter->shouldReceive('get_asset_url')
+            ->with('boot.js')
+            ->andReturn('https://example.com/assets/boot.js');
+        $this->asset_getter->shouldReceive('get_asset_data')
+            ->with('boot.js', '1.0.0')
+            ->andReturn(['dependencies' => ['wp-data'], 'version' => 'deadbeef']);
+
+        expect('wp_register_script')
+            ->once()
+            ->with(
+                'wc-ppcp-sdk-v6-boot',
+                'https://example.com/assets/boot.js',
+                ['wp-data'],
+                'deadbeef',
+                true
+            );
+        expect('wp_localize_script')->once();
+        expect('wp_enqueue_script')->once()->with('wc-ppcp-sdk-v6-boot');
+
+        $testee = $this->createTestee();
+        $testee->enqueue();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * GIVEN the v6 SDK does not load on the current page
+     * WHEN enqueue() is called
+     * THEN no script is registered — the method returns before touching the asset getter
+     */
+    public function testEnqueueDoesNothingWhenShouldNotLoadOnCurrentPage(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('');
+        $this->context->shouldReceive('location')->andReturn('');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->messages_eligibility->shouldReceive('is_enabled_for_location')->with('')->andReturn(false);
+
+        expect('wp_register_script')->never();
+
+        $testee = $this->createTestee();
+        $testee->enqueue();
+
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/PHPUnit/SdkV6/Blocks/V6PaymentMethodTest.php
+++ b/tests/PHPUnit/SdkV6/Blocks/V6PaymentMethodTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Blocks;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use function Brain\Monkey\Functions\expect;
+
+class V6PaymentMethodTest extends TestCase
+{
+    private $manager;
+    private $asset_getter;
+    private $gateway;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manager      = Mockery::mock(SdkV6Manager::class);
+        $this->asset_getter = Mockery::mock(AssetGetter::class);
+        $this->gateway      = Mockery::mock(PayPalGateway::class);
+    }
+
+    private function createTestee(): V6PaymentMethod
+    {
+        return new V6PaymentMethod(
+            $this->manager,
+            $this->asset_getter,
+            '1.0.0',
+            $this->gateway
+        );
+    }
+
+    /**
+     * GIVEN a compiled checkout-block bundle whose webpack asset file records the
+     *       @wordpress/* script handles it depends on and a content-hash version
+     * WHEN the block payment method resolves its script handles
+     * THEN the script is registered with those exact dependencies and version, not an
+     *      empty dependency list and not just the plugin version.
+     * AND the resolved handle is returned so WooCommerce Blocks loads it
+     */
+    public function test_get_payment_method_script_handles_passes_through_webpack_dependencies_and_version(): void
+    {
+        $this->asset_getter->shouldReceive('get_asset_url')
+            ->with('checkout-block.js')
+            ->andReturn('https://example.com/assets/checkout-block.js');
+        $this->asset_getter->shouldReceive('get_asset_data')
+            ->with('checkout-block.js', '1.0.0')
+            ->andReturn(['dependencies' => ['wp-data', 'wp-element'], 'version' => 'deadbeef']);
+
+        expect('wp_register_script')
+            ->once()
+            ->with(
+                'wc-ppcp-sdk-v6-blocks',
+                'https://example.com/assets/checkout-block.js',
+                ['wp-data', 'wp-element'],
+                'deadbeef',
+                true
+            );
+
+        $testee  = $this->createTestee();
+        $handles = $testee->get_payment_method_script_handles();
+
+        $this->assertSame(['wc-ppcp-sdk-v6-blocks'], $handles);
+    }
+
+    /**
+     * GIVEN no compiled checkout-block bundle URL is available
+     * WHEN the block payment method resolves its script handles
+     * THEN no script is registered and an empty handle list is returned
+     */
+    public function test_get_payment_method_script_handles_returns_empty_array_when_no_asset_url(): void
+    {
+        $this->asset_getter->shouldReceive('get_asset_url')
+            ->with('checkout-block.js')
+            ->andReturn('');
+
+        expect('wp_register_script')->never();
+
+        $testee  = $this->createTestee();
+        $handles = $testee->get_payment_method_script_handles();
+
+        $this->assertSame([], $handles);
+    }
+}

--- a/tests/PHPUnit/SdkV6/Helper/MessageStyleMapperTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/MessageStyleMapperTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class MessageStyleMapperTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private const LOCATION = 'checkout';
+
+    private function mapperFor(array $style): MessageStyleMapper
+    {
+        $provider = Mockery::mock(SettingsProvider::class);
+        $provider
+            ->shouldReceive('pay_later_messaging_style')
+            ->with(self::LOCATION)
+            ->andReturn($style);
+
+        return new MessageStyleMapper($provider);
+    }
+
+    /**
+     * GIVEN an admin logo type and logo position configured for a messaging location
+     * WHEN the v6 message styles are mapped for that location
+     * THEN the logo type maps to its v6 Web Component value
+     * AND an "inline" logo type forces the logo position to INLINE, overriding whatever
+     *     logo_position was separately configured
+     *
+     * @dataProvider logoTypeData
+     */
+    public function testMapsLogoTypesAndInlinePosition(
+        string $logoType,
+        string $logoPosition,
+        string $expectedLogoType,
+        string $expectedLogoPosition
+    ): void {
+        $result = $this->mapperFor([
+            'logo_type'     => $logoType,
+            'logo_position' => $logoPosition,
+            'text_color'    => 'black',
+            'text_size'     => '',
+        ])->styles_for_location(self::LOCATION);
+
+        $this->assertSame($expectedLogoType, $result['logoType']);
+        $this->assertSame($expectedLogoPosition, $result['logoPosition']);
+    }
+
+    public function logoTypeData(): array
+    {
+        return [
+            'primary maps to WORDMARK, keeps configured position'      => ['primary', 'left', 'WORDMARK', 'LEFT'],
+            'alternative maps to MONOGRAM, keeps configured position'  => ['alternative', 'right', 'MONOGRAM', 'RIGHT'],
+            'none maps to TEXT, keeps configured position'             => ['none', 'top', 'TEXT', 'TOP'],
+            'inline maps to WORDMARK and forces INLINE position'       => ['inline', 'right', 'WORDMARK', 'INLINE'],
+        ];
+    }
+
+    /**
+     * GIVEN an admin text color configured for a messaging location
+     * WHEN the v6 message styles are mapped for that location
+     * THEN the text color maps to its v6 Web Component value
+     * AND the v5-only "grayscale" option maps onto v6's nearest neighbour, MONOCHROME
+     *
+     * @dataProvider textColorData
+     */
+    public function testMapsTextColors(string $textColor, string $expected): void
+    {
+        $result = $this->mapperFor([
+            'logo_type'     => 'primary',
+            'logo_position' => 'left',
+            'text_color'    => $textColor,
+            'text_size'     => '',
+        ])->styles_for_location(self::LOCATION);
+
+        $this->assertSame($expected, $result['textColor']);
+    }
+
+    public function textColorData(): array
+    {
+        return [
+            'black maps to BLACK'           => ['black', 'BLACK'],
+            'white maps to WHITE'           => ['white', 'WHITE'],
+            'monochrome maps to MONOCHROME' => ['monochrome', 'MONOCHROME'],
+            'grayscale maps to MONOCHROME'  => ['grayscale', 'MONOCHROME'],
+        ];
+    }
+
+    /**
+     * GIVEN an admin text size configured for a messaging location
+     * WHEN the v6 message styles are mapped for that location
+     * THEN the size is clamped into the v6 component's 10-16px range
+     * AND a non-numeric size yields no font size at all
+     *
+     * @dataProvider textSizeData
+     */
+    public function testClampsTextSizeIntoSupportedRange(string $textSize, string $expected): void
+    {
+        $result = $this->mapperFor([
+            'logo_type'     => 'primary',
+            'logo_position' => 'left',
+            'text_color'    => 'black',
+            'text_size'     => $textSize,
+        ])->styles_for_location(self::LOCATION);
+
+        $this->assertSame($expected, $result['fontSize']);
+    }
+
+    public function textSizeData(): array
+    {
+        return [
+            'below the minimum is clamped up to 10px' => ['8', '10px'],
+            'within range is kept as-is'               => ['12', '12px'],
+            'above the maximum is clamped down to 16px' => ['20', '16px'],
+            'empty value yields no font size'          => ['', ''],
+            'non-numeric value yields no font size'    => ['abc', ''],
+        ];
+    }
+
+    /**
+     * GIVEN a location configured with the admin "banner" (flex) layout, a flex color
+     *       and an aspect ratio
+     * WHEN the v6 message styles are mapped for that location
+     * THEN the mapper still returns ordinary text message styles, because v6 has no
+     *      flex/banner layout equivalent — the flex-only keys are never read
+     */
+    public function testFlexLayoutSettingsAreIgnoredAndTextStylesAreReturned(): void
+    {
+        $result = $this->mapperFor([
+            'layout'        => 'flex',
+            'flex_color'    => 'blue',
+            'ratio'         => '8x1',
+            'logo_type'     => 'alternative',
+            'logo_position' => 'top',
+            'text_color'    => 'white',
+            'text_size'     => '14',
+        ])->styles_for_location(self::LOCATION);
+
+        $this->assertSame([
+            'logoType'     => 'MONOGRAM',
+            'logoPosition' => 'TOP',
+            'textColor'    => 'WHITE',
+            'fontSize'     => '14px',
+        ], $result);
+    }
+
+    /**
+     * GIVEN unrecognised/garbage values for every mapped setting
+     * WHEN the v6 message styles are mapped for that location
+     * THEN the mapper falls back to its safe defaults: WORDMARK, LEFT and BLACK
+     */
+    public function testUnknownValuesFallBackToDefaults(): void
+    {
+        $result = $this->mapperFor([
+            'logo_type'     => 'bogus',
+            'logo_position' => 'bogus',
+            'text_color'    => 'bogus',
+            'text_size'     => '',
+        ])->styles_for_location(self::LOCATION);
+
+        $this->assertSame('WORDMARK', $result['logoType']);
+        $this->assertSame('LEFT', $result['logoPosition']);
+        $this->assertSame('BLACK', $result['textColor']);
+    }
+}

--- a/tests/PHPUnit/SdkV6/Helper/MessagesEligibilityTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/MessagesEligibilityTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
+
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\when;
+
+class MessagesEligibilityTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private const RENDER_FILTER = 'woocommerce_paypal_payments_should_render_pay_later_messaging';
+
+    private $settings_provider;
+    private $settings_status;
+    private $messages_apply;
+    private $free_trial_helper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->settings_provider = Mockery::mock(SettingsProvider::class);
+        $this->settings_status   = Mockery::mock(SettingsStatus::class);
+        $this->messages_apply    = Mockery::mock(MessagesApply::class);
+        $this->free_trial_helper = Mockery::mock(FreeTrialSubscriptionHelper::class);
+    }
+
+    private function createTestee(): MessagesEligibility
+    {
+        return new MessagesEligibility(
+            $this->settings_provider,
+            $this->settings_status,
+            $this->messages_apply,
+            $this->free_trial_helper
+        );
+    }
+
+    /**
+     * Stubs every condition in the eligibility chain to pass, so a single override
+     * isolates the one condition under test.
+     */
+    private function stubHappyPath(array $overrides = []): void
+    {
+        expectApplied(self::RENDER_FILTER)->andReturn($overrides['render_filter'] ?? true);
+
+        $this->settings_provider
+            ->shouldReceive('gateway_enabled')
+            ->with(PayPalGateway::ID)
+            ->andReturn($overrides['gateway_enabled'] ?? true);
+
+        $this->settings_status
+            ->shouldReceive('is_pay_later_messaging_enabled')
+            ->andReturn($overrides['messaging_enabled'] ?? true);
+
+        $this->settings_status
+            ->shouldReceive('has_pay_later_messaging_locations')
+            ->andReturn($overrides['has_locations'] ?? true);
+
+        $this->messages_apply
+            ->shouldReceive('for_country')
+            ->andReturn($overrides['for_country'] ?? true);
+
+        $this->free_trial_helper
+            ->shouldReceive('is_free_trial_cart')
+            ->andReturn($overrides['free_trial_cart'] ?? false);
+
+        $this->settings_status
+            ->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->andReturn($overrides['enabled_for_location'] ?? true);
+    }
+
+    /**
+     * GIVEN an empty messaging settings location
+     * WHEN checking whether Pay Later messaging is enabled for that location
+     * THEN it is not enabled, and none of the other eligibility checks are consulted
+     */
+    public function testReturnsFalseForEmptyLocationWithoutCheckingAnythingElse(): void
+    {
+        expectApplied(self::RENDER_FILTER)->never();
+        $this->settings_provider->shouldNotReceive('gateway_enabled');
+
+        $result = $this->createTestee()->is_enabled_for_location('');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * GIVEN pay later messaging would otherwise be fully eligible for a location
+     * WHEN a single condition in the eligibility chain fails
+     * THEN messaging is not enabled for that location
+     * AND WHEN every condition in the chain passes, including the location's own flag
+     * THEN messaging is enabled for that location
+     *
+     * @dataProvider eligibilityChainData
+     */
+    public function testEligibilityChain(array $overrides, bool $expected): void
+    {
+        $this->stubHappyPath($overrides);
+
+        $result = $this->createTestee()->is_enabled_for_location('checkout');
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function eligibilityChainData(): array
+    {
+        return [
+            'the shared should-render filter disables messaging entirely' => [
+                ['render_filter' => false], false,
+            ],
+            'the PayPal gateway itself is disabled'                       => [
+                ['gateway_enabled' => false], false,
+            ],
+            'pay later messaging is switched off in the settings'         => [
+                ['messaging_enabled' => false], false,
+            ],
+            'no locations have pay later messaging configured'            => [
+                ['has_locations' => false], false,
+            ],
+            'the buyer country is not eligible for pay later messaging'   => [
+                ['for_country' => false], false,
+            ],
+            'the cart is a free trial subscription'                      => [
+                ['free_trial_cart' => true], false,
+            ],
+            'every condition passes and the location itself is enabled'  => [
+                [], true,
+            ],
+        ];
+    }
+
+    /**
+     * GIVEN a product page with a product currently being viewed
+     * WHEN checking whether Pay Later messaging is hidden for the product context
+     * THEN the product-specific filter is applied
+     * AND it receives the product and its raw price as the filter context data
+     */
+    public function testIsHiddenForProductContextAppliesProductFilterWithContextData(): void
+    {
+        $product = Mockery::mock(\WC_Product::class);
+        $product->shouldReceive('get_price')->with('raw')->andReturn('19.99');
+        when('wc_get_product')->justReturn($product);
+
+        expectApplied('woocommerce_paypal_payments_product_buttons_paylater_disabled')
+            ->once()
+            ->with(
+                false,
+                Mockery::on(function (array $context) use ($product): bool {
+                    return $context['product'] === $product && $context['order_total'] === 19.99;
+                })
+            )
+            ->andReturn(true);
+
+        $result = $this->createTestee()->is_hidden('product');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * GIVEN a non-product page context (e.g. cart or checkout)
+     * WHEN checking whether Pay Later messaging is hidden for that context
+     * THEN the generic filter is applied with the context string as its second argument
+     */
+    public function testIsHiddenForNonProductContextAppliesGenericFilterWithContextString(): void
+    {
+        expectApplied('woocommerce_paypal_payments_buttons_paylater_disabled')
+            ->once()
+            ->with(false, 'cart')
+            ->andReturn(true);
+
+        $result = $this->createTestee()->is_hidden('cart');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * GIVEN no merchant filter intervenes for either a product or a non-product context
+     * WHEN checking whether Pay Later messaging is hidden
+     * THEN it defaults to not hidden in both cases
+     */
+    public function testIsHiddenDefaultsToFalseWhenNoFilterIntervenes(): void
+    {
+        when('wc_get_product')->justReturn(null);
+
+        $this->assertFalse($this->createTestee()->is_hidden('product'));
+        $this->assertFalse($this->createTestee()->is_hidden('checkout'));
+    }
+}

--- a/tests/PHPUnit/SdkV6/OwnsCurrentPageServiceTest.php
+++ b/tests/PHPUnit/SdkV6/OwnsCurrentPageServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Exercises the 'sdk-v6.owns-current-page' service exactly as it is defined in
+ * modules/ppcp-sdk-v6/services.php: the container closure is loaded from the real
+ * production file and invoked against a stub container, rather than re-implemented
+ * here, so a future edit to that file is what these tests actually protect.
+ *
+ * ApplepayModule and GooglepayModule read this service (via their private
+ * v6_owns_current_page() helpers) to decide whether to stand down so a second
+ * PayPal SDK does not run against window.paypal.
+ */
+class OwnsCurrentPageServiceTest extends TestCase
+{
+    /**
+     * Resolves the 'sdk-v6.owns-current-page' callable from the real services.php,
+     * backed by a container that only ever serves 'sdk-v6.manager'.
+     */
+    private function resolveService(SdkV6Manager $manager): callable
+    {
+        $container = Mockery::mock(ContainerInterface::class);
+        $container->shouldReceive('get')
+            ->with('sdk-v6.manager')
+            ->andReturn($manager);
+
+        $services = require ROOT_DIR . '/modules/ppcp-sdk-v6/services.php';
+
+        $factory = $services['sdk-v6.owns-current-page'];
+
+        return $factory($container);
+    }
+
+    /**
+     * GIVEN a classic checkout page with Pay Later messaging enabled and eligible, and
+     *       no smart-button location or ACDC surface owning the page — so
+     *       should_load_on_current_page() is true only because its messaging condition
+     *       claims the page
+     * WHEN the 'sdk-v6.owns-current-page' service is asked whether v6 owns the page
+     * THEN it reports true
+     *
+     * A false here is the regression that shipped: GooglepayModule's continuation
+     * fallback (`if ( is_checkout() && ! self::v6_owns_current_page( $c ) ) { $button->enqueue(); }`)
+     * would then enqueue the v5 Google Pay button, which loads the v5 PayPal SDK
+     * alongside the v6 SDK that messaging already put on the page — both claiming
+     * window.paypal.
+     */
+    public function testRegressionOwnsCurrentPageTrueWhenOnlyMessagingLoadsTheSdk(): void
+    {
+        $manager = Mockery::mock(SdkV6Manager::class);
+        $manager->shouldReceive('should_load_on_current_page')->andReturn(true);
+
+        $owns_current_page = $this->resolveService($manager);
+
+        $this->assertTrue($owns_current_page());
+    }
+
+    /**
+     * GIVEN v6 owns the page through an ordinary enabled button location (no messaging
+     *       involved)
+     * WHEN the 'sdk-v6.owns-current-page' service resolves its answer
+     * THEN it reports true, matching should_load_on_current_page()
+     */
+    public function testOwnsCurrentPageTrueWhenAButtonLocationOwnsThePage(): void
+    {
+        $manager = Mockery::mock(SdkV6Manager::class);
+        $manager->shouldReceive('should_load_on_current_page')->andReturn(true);
+
+        $owns_current_page = $this->resolveService($manager);
+
+        $this->assertTrue($owns_current_page());
+    }
+
+    /**
+     * GIVEN a page where neither buttons, ACDC, the mini-cart location, nor Pay Later
+     *       messaging apply
+     * WHEN the 'sdk-v6.owns-current-page' service resolves its answer
+     * THEN it reports false, so the v5 wallets stay in control of that page
+     */
+    public function testOwnsCurrentPageFalseWhenNothingClaimsTheSdk(): void
+    {
+        $manager = Mockery::mock(SdkV6Manager::class);
+        $manager->shouldReceive('should_load_on_current_page')->andReturn(false);
+
+        $owns_current_page = $this->resolveService($manager);
+
+        $this->assertFalse($owns_current_page());
+    }
+}


### PR DESCRIPTION
Implemented Pay Later messages using the v6 SDK: filling the `.ppcp-messages` wrapper with `<paypal-message>` components and converted style attributes.

They should work on all payment pages the same as v5, but currently the messages on shop and home pages and separate Pay Later blocks are still v5. One of the reasons for that is that v6 does not seem to support the `flex` layout and it is default in these cases.

Some other more general changes and improvements:
- Added `AssetGetter::get_asset_data` and fixed the list of dependencies of the scripts in the v6 module. Not sure if it is actually important in practice, but either way it should be more correct than just an empty list. 
- `Context::init_context()` is moved to the top of `wp` hook and called explicitly instead of being hidden inside `register_render_hooks`. It is now needed in multiple places, so this makes things simpler and avoids dependency on the order of the function calls or duplicated inits.
- `refreshEligibility` now is also triggered by the `updated_checkout` event, otherwise it was not refreshed in some cases, such as when applying a coupon. Also added debounce to improve performance and reduce network requests.
- Extracted the Apple Pay product page cart simulation price refreshes, to reuse that.

## 🧪 Tests

Unit tests cover eligibility, style mapping, the script-data payload, the renderer's mount and re-price paths, and the shared total watcher. What they cannot cover is the v6 component actually fetching and painting a message, which is verified manually with the steps below.

## 🧪 How to verify

1. With the `PCP_SDK_V6_ENABLED=1` flag, enable Pay Later messaging for product, cart and checkout.
2. Open a single product page, the cart, the checkout and a pay-for-order link. The message renders in the same location as before, but using the `<paypal-message>` component.
3. Change the quantity or pick a variation on the product page. The message re-prices to the product on display, not to the cart.
4. Change the quantity on the block cart and block checkout. The message re-prices.