### PR TITLE
Orders paid via woo payments or bacs are overwritten as ppcp gateway when stale pay pal order meta exists (6698)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -947,7 +947,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	 */
 	private function register_block_express_payment_method_handler( ContainerInterface $c ): void {
 		// Request-scoped guard for the save listener below: the ID of the WC order this request
-		// routed through PayPal, zero when no such switch happened.Documented in
+		// routed through PayPal, zero when no such switch happened. Documented in
 		// tests/integration/PHPUnit/WcGateway/BlockExpressPaymentMethodHandlerTest.php.
 		$marked_order_id = 0;
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -946,9 +946,14 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	 * Ensures PayPal handles block-checkout express payments even when another PCP gateway is sorted first in WC Settings → Payments.
 	 */
 	private function register_block_express_payment_method_handler( ContainerInterface $c ): void {
+		// Request-scoped guard for the save listener below: the ID of the WC order this request
+		// routed through PayPal, zero when no such switch happened.Documented in
+		// tests/integration/PHPUnit/WcGateway/BlockExpressPaymentMethodHandlerTest.php.
+		$marked_order_id = 0;
+
 		add_action(
 			'woocommerce_rest_checkout_process_payment_with_context',
-			function ( $context ) use ( $c ): void {
+			function ( $context ) use ( $c, &$marked_order_id ): void {
 				$payment_data = (array) ( $context->payment_data ?? array() );
 
 				if ( empty( $payment_data['paypal_order_id'] ) ) {
@@ -976,6 +981,9 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$funding_source = $payment_data['funding_source']
 						?: ( $session_handler->funding_source() ?: 'paypal' );
 					$order->set_payment_method_title( $funding_source_renderer->render_name( $funding_source ) );
+
+					$marked_order_id = $order->get_id();
+
 					$order->save();
 				}
 			},
@@ -985,8 +993,11 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_action(
 			'woocommerce_before_order_object_save',
-			function ( $order ): void {
+			function ( $order ) use ( &$marked_order_id ): void {
 				if ( ! $order instanceof WC_Order ) {
+					return;
+				}
+				if ( ! $marked_order_id || $order->get_id() !== $marked_order_id ) {
 					return;
 				}
 				if ( ! $order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ) {
@@ -994,9 +1005,6 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				}
 				$payment_method = $order->get_payment_method();
 				if ( $payment_method && strpos( $payment_method, 'ppcp-' ) === 0 ) {
-					return;
-				}
-				if ( $order->get_payment_method() === CreditCardGateway::ID ) {
 					return;
 				}
 				$order->set_payment_method( PayPalGateway::ID );

--- a/tests/integration/PHPUnit/WcGateway/BlockExpressPaymentMethodHandlerTest.php
+++ b/tests/integration/PHPUnit/WcGateway/BlockExpressPaymentMethodHandlerTest.php
@@ -1,0 +1,332 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\WcGateway;
+
+use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
+use WC_Order;
+use WooCommerce\PayPalCommerce\Tests\Integration\IntegrationMockedTestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * Integration tests for the "woocommerce_before_order_object_save" listener registered by
+ * WCGatewayModule::register_block_express_payment_method_handler().
+ *
+ * The listener fires on *every* order save, and the rewrite to PayPalGateway::ID is scoped to a
+ * request-scoped marker ($marked_order_id) set by the
+ * "woocommerce_rest_checkout_process_payment_with_context" handler.
+ *
+ * Why the marker is scoped to the request: the _ppcp_paypal_order_id meta only records that a
+ * PayPal order was created at some point in the order's life, typically during an earlier or
+ * abandoned checkout attempt. It does not prove PayPal took the payment, so it must never on its
+ * own authorize a payment method rewrite.
+ *
+ * Why a single ID is enough: the block checkout produces one order per request. If that ever
+ * changes, the marker must become a set of IDs — otherwise every order but the last one silently
+ * loses the guard for the rest of the request. No test covers that scenario, because the current
+ * flow cannot produce it.
+ *
+ * The tests split along that marker:
+ *
+ * - Unmarked orders (the production bug): stale "_ppcp_paypal_order_id" meta left over from an
+ *   abandoned express-checkout attempt must never cause a rewrite. Reproducing this needs TWO
+ *   saves — the first save, which persists the meta, already exposes the order to the listener,
+ *   so only a later save reproduces "order paid through another gateway, saved again afterwards".
+ *   See trigger_second_save().
+ * - Marked orders (the feature PR #4349 added): after the context handler has routed the order
+ *   through PayPal in this request, the listener re-asserts PayPalGateway::ID if something resets
+ *   the payment method, but leaves a deliberate 'ppcp-' method such as ACDC alone.
+ *
+ * @covers \WooCommerce\PayPalCommerce\WcGateway\WCGatewayModule::register_block_express_payment_method_handler
+ */
+class BlockExpressPaymentMethodHandlerTest extends IntegrationMockedTestCase
+{
+    /**
+     * @var int[]
+     */
+    private array $order_ids_to_cleanup = [];
+
+    /**
+     * @var callable|null
+     */
+    private $available_gateways_filter = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->order_ids_to_cleanup = [];
+        $this->available_gateways_filter = null;
+    }
+
+    public function tearDown(): void
+    {
+        if (null !== $this->available_gateways_filter) {
+            remove_filter('woocommerce_available_payment_gateways', $this->available_gateways_filter);
+            $this->available_gateways_filter = null;
+        }
+
+        foreach ($this->order_ids_to_cleanup as $order_id) {
+            wp_delete_post($order_id, true);
+        }
+        $this->order_ids_to_cleanup = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @scenario An order whose payment method is 'bacs' and which carries a non-empty
+     * _ppcp_paypal_order_id meta keeps payment_method 'bacs' after
+     * 'woocommerce_before_order_object_save' fires.
+     */
+    public function test_bacs_order_with_stale_paypal_order_id_keeps_bacs(): void
+    {
+        // Arrange
+        $order = $this->create_order_with_payment_method('bacs', true);
+
+        // When
+        $this->trigger_second_save($order->get_id());
+
+        // Then
+        $reloaded = wc_get_order($order->get_id());
+        $this->assertSame('bacs', $reloaded->get_payment_method());
+    }
+
+    /**
+     * @scenario An order whose payment method is 'woocommerce_payments' and which carries a
+     * non-empty _ppcp_paypal_order_id meta keeps payment_method 'woocommerce_payments' (and its
+     * transaction id) after 'woocommerce_before_order_object_save' fires. This mirrors the
+     * reported production order.
+     */
+    public function test_woocommerce_payments_order_with_stale_paypal_order_id_keeps_its_gateway(): void
+    {
+        // Arrange
+        $order = $this->create_order_with_payment_method('woocommerce_payments', true);
+        $order->set_transaction_id('pi_1234567890');
+        $order->save();
+
+        // When
+        $this->trigger_second_save($order->get_id());
+
+        // Then
+        $reloaded = wc_get_order($order->get_id());
+        $this->assertSame('woocommerce_payments', $reloaded->get_payment_method());
+        $this->assertSame('pi_1234567890', $reloaded->get_transaction_id());
+    }
+
+    /**
+     * @scenario In a request where the 'woocommerce_rest_checkout_process_payment_with_context'
+     * handler switched the context to PayPalGateway::ID for a given order, that order is still
+     * saved with payment_method 'ppcp-gateway'.
+     */
+    public function test_express_checkout_context_switch_still_stores_paypal_gateway(): void
+    {
+        if (!class_exists(PaymentContext::class)) {
+            $this->markTestSkipped('Automattic\WooCommerce\StoreApi\Payments\PaymentContext is not available in this environment.');
+        }
+
+        // Arrange
+        $this->force_paypal_gateway_available();
+        $order = $this->create_order_with_payment_method('some-other-gateway', false);
+
+        // When
+        $context = $this->mark_order_via_express_checkout_context($order);
+        $order->save();
+
+        // Then
+        $reloaded = wc_get_order($order->get_id());
+        $this->assertSame(PayPalGateway::ID, $reloaded->get_payment_method());
+        // The context itself must be switched too, otherwise Store API routes the payment to the
+        // gateway the shopper's request named instead of PayPal.
+        $this->assertSame(PayPalGateway::ID, $context->payment_method);
+    }
+
+    /**
+     * @scenario An order marked by the express-checkout context handler that is reset to a
+     * non-PayPal payment method later in the same request is restored to 'ppcp-gateway' by the
+     * save listener. This is the behaviour PR #4349 added, and the only test that exercises the
+     * listener's positive path in isolation from the context handler.
+     */
+    public function test_marked_order_reset_to_another_gateway_is_restored_to_paypal(): void
+    {
+        if (!class_exists(PaymentContext::class)) {
+            $this->markTestSkipped('Automattic\WooCommerce\StoreApi\Payments\PaymentContext is not available in this environment.');
+        }
+
+        // Arrange
+        $this->force_paypal_gateway_available();
+        $order = $this->create_order_with_payment_method('some-other-gateway', false);
+        $this->mark_order_via_express_checkout_context($order);
+
+        // When: another gateway sorted first in WC Settings resets the method after the context ran
+        $reloaded = wc_get_order($order->get_id());
+        $reloaded->update_meta_data(PayPalGateway::ORDER_ID_META_KEY, 'PAYPAL-ORDER-EXPRESS-1');
+        $reloaded->set_payment_method('some-other-gateway');
+        $reloaded->save();
+
+        // Then
+        $this->assertSame(PayPalGateway::ID, wc_get_order($order->get_id())->get_payment_method());
+    }
+
+    /**
+     * @scenario A marked order that carries a deliberate 'ppcp-' payment method (ACDC) is not
+     * rewritten to 'ppcp-gateway' by the save listener.
+     */
+    public function test_marked_order_with_acdc_payment_method_is_not_rewritten(): void
+    {
+        if (!class_exists(PaymentContext::class)) {
+            $this->markTestSkipped('Automattic\WooCommerce\StoreApi\Payments\PaymentContext is not available in this environment.');
+        }
+
+        // Arrange
+        $this->force_paypal_gateway_available();
+        $order = $this->create_order_with_payment_method('some-other-gateway', false);
+        $this->mark_order_via_express_checkout_context($order);
+
+        // When
+        $reloaded = wc_get_order($order->get_id());
+        $reloaded->update_meta_data(PayPalGateway::ORDER_ID_META_KEY, 'PAYPAL-ORDER-EXPRESS-1');
+        $reloaded->set_payment_method(CreditCardGateway::ID);
+        $reloaded->save();
+
+        // Then
+        $this->assertSame(CreditCardGateway::ID, wc_get_order($order->get_id())->get_payment_method());
+    }
+
+    /**
+     * @scenario A marked order without the _ppcp_paypal_order_id meta is not rewritten by the
+     * save listener.
+     */
+    public function test_marked_order_without_paypal_order_meta_is_not_rewritten(): void
+    {
+        if (!class_exists(PaymentContext::class)) {
+            $this->markTestSkipped('Automattic\WooCommerce\StoreApi\Payments\PaymentContext is not available in this environment.');
+        }
+
+        // Arrange
+        $this->force_paypal_gateway_available();
+        $order = $this->create_order_with_payment_method('some-other-gateway', false);
+        $this->mark_order_via_express_checkout_context($order);
+
+        // When: no PayPal order id meta is ever written to this order
+        $reloaded = wc_get_order($order->get_id());
+        $reloaded->set_payment_method('some-other-gateway');
+        $reloaded->save();
+
+        // Then
+        $this->assertSame('some-other-gateway', wc_get_order($order->get_id())->get_payment_method());
+    }
+
+    /**
+     * @scenario An order that was never marked by the express-checkout context handler in the
+     * current request is not modified by the save listener, regardless of its current payment
+     * method and regardless of whether it carries a stale _ppcp_paypal_order_id meta.
+     *
+     * @dataProvider dataForUnmarkedOrder
+     */
+    public function test_unmarked_order_is_never_touched(string $payment_method, bool $with_paypal_meta): void
+    {
+        // Arrange
+        $order = $this->create_order_with_payment_method($payment_method, $with_paypal_meta);
+
+        // When
+        $this->trigger_second_save($order->get_id());
+
+        // Then
+        $reloaded = wc_get_order($order->get_id());
+        $this->assertSame($payment_method, $reloaded->get_payment_method());
+    }
+
+    public function dataForUnmarkedOrder(): array
+    {
+        return [
+            'cheque payment method is preserved' => ['cheque', true],
+            'cash on delivery payment method is preserved' => ['cod', true],
+            'empty payment method is preserved' => ['', true],
+            'ppcp- prefixed payment method is preserved' => [CreditCardGateway::ID, true],
+            'order without PayPal order meta is preserved' => ['bacs', false],
+        ];
+    }
+
+    /**
+     * The express handler returns early unless PayPalGateway::ID is among the *available*
+     * gateways. In the integration environment there is no cart or customer session, so
+     * WC_Payment_Gateways::get_available_payment_gateways() returns an empty list and the
+     * handler would never run. Inject the real, already registered PayPal gateway object into
+     * the availability list for the duration of the test.
+     */
+    private function force_paypal_gateway_available(): void
+    {
+        $registered = WC()->payment_gateways->payment_gateways();
+        if (!isset($registered[PayPalGateway::ID])) {
+            $this->markTestSkipped('PayPalGateway is not registered in this environment.');
+        }
+
+        $paypal_gateway = $registered[PayPalGateway::ID];
+
+        $this->available_gateways_filter = function ($gateways) use ($paypal_gateway) {
+            $gateways[PayPalGateway::ID] = $paypal_gateway;
+
+            return $gateways;
+        };
+
+        add_filter('woocommerce_available_payment_gateways', $this->available_gateways_filter);
+    }
+
+    /**
+     * Runs the express block-checkout entry point for the given order: the
+     * 'woocommerce_rest_checkout_process_payment_with_context' handler, which is what marks the
+     * order as routed through PayPal for the rest of the request.
+     */
+    private function mark_order_via_express_checkout_context(WC_Order $order): PaymentContext
+    {
+        $context = new PaymentContext();
+        $context->set_order($order);
+        $context->set_payment_data(
+            [
+                'paypal_order_id' => 'PAYPAL-ORDER-EXPRESS-1',
+                // Required: the handler reads this key unconditionally.
+                'funding_source' => 'paypal',
+            ]
+        );
+        $context->set_payment_method('some-other-gateway');
+
+        do_action('woocommerce_rest_checkout_process_payment_with_context', $context);
+
+        return $context;
+    }
+
+    /**
+     * Creates a plain WC_Order with a given payment method, optionally carrying a stale
+     * PayPal order id meta, and persists it with a first save().
+     */
+    private function create_order_with_payment_method(string $payment_method, bool $with_paypal_meta): WC_Order
+    {
+        $order = wc_create_order(['customer_id' => $this->customer_id]);
+        $order->set_payment_method($payment_method);
+
+        if ($with_paypal_meta) {
+            $order->update_meta_data(PayPalGateway::ORDER_ID_META_KEY, 'PAYPAL-ORDER-STALE-1');
+        }
+
+        $order->save();
+
+        $this->order_ids_to_cleanup[] = $order->get_id();
+
+        return $order;
+    }
+
+    /**
+     * Reloads the order and forces a second save() (via a harmless customer note change) to
+     * reproduce the real-world scenario where an order carrying stale PayPal meta gets saved
+     * again by another part of checkout/admin.
+     */
+    private function trigger_second_save(int $order_id): WC_Order
+    {
+        $order = wc_get_order($order_id);
+        $order->set_customer_note('trigger second save ' . uniqid());
+        $order->save();
+
+        return wc_get_order($order_id);
+    }
+}


### PR DESCRIPTION
## 🐛 What and why

WooCommerce orders paid with a gateway other than PayPal were being stored with `payment_method = ppcp-gateway`. Two production orders confirmed it: one paid via WooPayments (title `Karte`, transaction ID a Stripe `pi_` PaymentIntent) and one via Direct Bank Transfer (title `Banküberweisung`, no transaction ID). Both carried a **PayPal order ID left over from an earlier or abandoned checkout attempt**, and the presence of that meta alone was enough to rewrite the gateway on the next save.

The payment method title and transaction data still pointed at the real gateway, so the orders looked correct in the admin list while the internal gateway ID was wrong — breaking refunds, reporting, and any integration that keys off `payment_method`.

## ⚙️ How it works now

`register_block_express_payment_method_handler()` keeps a request-scoped `$marked_order_id`, shared by reference between its two closures. The `woocommerce_rest_checkout_process_payment_with_context` closure records the WC order ID at the moment it routes the payment to `PayPalGateway::ID`; the `woocommerce_before_order_object_save` closure then acts **only on that order, in that request**.

Everything else is unchanged: the listener still requires `PayPalGateway::ORDER_ID_META_KEY` and still leaves any deliberate `ppcp-` prefixed method — such as `CreditCardGateway::ID` — alone.

## 🔍 What to verify in review

### Covered by tests

These are integration tests (`tests/integration/`), not unit tests — the listener is a WordPress hook closure and needs a real `WC_Order` save to exercise. All 6 acceptance criteria are covered; 11 tests, 13 assertions.

- ✅ A `bacs` order carrying a stale PayPal order ID keeps `bacs`.
- ✅ A `woocommerce_payments` order carrying a stale PayPal order ID keeps its gateway *and* its `pi_` transaction ID.
- ✅ An order the block express checkout routed through PayPal is still stored as `ppcp-gateway`, and the payment context itself is switched too.
- ✅ An order carrying the PayPal order ID meta that this request never routed through PayPal is untouched — whatever its gateway, including an empty one.
- ✅ An order already on a `ppcp-` prefixed method is never rewritten to `ppcp-gateway`.
- ✅ An order without the PayPal order ID meta is never modified.

### Not covered by tests

- ❌ Two different orders marked within one PHP request — `$marked_order_id` holds a single ID, so only the last would keep the guard. The block checkout produces one order per request, so the current flow cannot reach this; noted in the test file so a future checkout change does not reintroduce it silently.

### Worth knowing during review

- Mutation testing was run manually against the fix (8 mutants, all killed). 
- Pre-existing, not fixed here: the context closure reads `$payment_data['funding_source']` unconditionally, emitting an undefined-index warning when the key is absent.

