### PR TITLE
[PAYPAL-174] Clean up orphaned reCAPTCHA inbox note and align enabled checks

### DIFF
--- a/modules/ppcp-fraud-protection/extensions.php
+++ b/modules/ppcp-fraud-protection/extensions.php
@@ -20,7 +20,7 @@ return array(
 		assert( $inbox_note_factory instanceof InboxNoteFactory );
 
 		$recaptcha_settings = get_option( 'woocommerce_ppcp-recaptcha_settings', array() );
-		$is_recaptcha_enabled = isset( $recaptcha_settings['enabled'] ) && 'yes' === $recaptcha_settings['enabled'];
+		$is_recaptcha_enabled = wc_string_to_bool( $recaptcha_settings['enabled'] ?? 'no' );
 
 		return array_merge(
 			$notes,
@@ -49,6 +49,15 @@ return array(
 						Note::E_WC_ADMIN_NOTE_UNACTIONED,
 						false
 					)
+				),
+				// Disabled former name of the note above (renamed in 3.3.2), so the registrar deletes copies left over from 3.3.1.
+				$inbox_note_factory->create_note(
+					'',
+					'',
+					Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+					'ppcp-recaptcha-protection-note',
+					Note::E_WC_ADMIN_NOTE_UNACTIONED,
+					false
 				),
 			)
 		);

--- a/modules/ppcp-fraud-protection/services.php
+++ b/modules/ppcp-fraud-protection/services.php
@@ -54,7 +54,7 @@ return array(
 	},
 	'fraud-protection.wc-tasks.recaptcha-task-config' => static function ( ContainerInterface $container ): array {
 		$recaptcha_settings = get_option( 'woocommerce_ppcp-recaptcha_settings', array() );
-		if ( isset( $recaptcha_settings['enabled'] ) && 'yes' === $recaptcha_settings['enabled'] ) {
+		if ( wc_string_to_bool( $recaptcha_settings['enabled'] ?? 'no' ) ) {
 			return array();
 		}
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -604,7 +604,7 @@ return array(
 		$is_working_capital_eligible = $container->get( 'settings.data.general' )->get_merchant_country() === 'US' && $settings_model->get_stay_updated();
 
 		$recaptcha_settings = get_option( 'woocommerce_ppcp-recaptcha_settings', array() );
-		$is_recaptcha_enabled = isset( $recaptcha_settings['enabled'] ) && 'yes' === $recaptcha_settings['enabled'];
+		$is_recaptcha_enabled = wc_string_to_bool( $recaptcha_settings['enabled'] ?? 'no' );
 
 		/**
 		 * Initializes TodosEligibilityService with eligibility conditions for various PayPal features.

--- a/tests/PHPUnit/FraudProtection/InboxNotesExtensionTest.php
+++ b/tests/PHPUnit/FraudProtection/InboxNotesExtensionTest.php
@@ -1,0 +1,70 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\FraudProtection;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\WcInboxNotes\InboxNoteFactory;
+use WooCommerce\PayPalCommerce\WcGateway\WcInboxNotes\InboxNoteInterface;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Covers the 'wcgateway.settings.inbox-notes' extension.
+ */
+class InboxNotesExtensionTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	const REMINDER_NOTE_NAME = 'ppcp-recaptcha-protection-note12';
+	const LEGACY_NOTE_NAME   = 'ppcp-recaptcha-protection-note';
+
+	/**
+	 * @return array<string, InboxNoteInterface> Notes keyed by name.
+	 */
+	private function build_notes( array $recaptcha_settings ): array {
+		when( 'get_option' )->justReturn( $recaptcha_settings );
+		when( 'admin_url' )->returnArg();
+
+		$extensions = require ROOT_DIR . '/modules/ppcp-fraud-protection/extensions.php';
+		$callback   = $extensions['wcgateway.settings.inbox-notes'];
+
+		$container = Mockery::mock( ContainerInterface::class );
+		$container->shouldReceive( 'get' )
+			->with( 'wcgateway.settings.inbox-note-factory' )
+			->andReturn( new InboxNoteFactory() );
+
+		$notes = $callback( array(), $container );
+
+		$by_name = array();
+		foreach ( $notes as $note ) {
+			$by_name[ $note->name() ] = $note;
+		}
+
+		return $by_name;
+	}
+
+	/**
+	 * @dataProvider recaptcha_settings_provider
+	 */
+	public function test_reminder_note_reflects_recaptcha_setting( array $recaptcha_settings, bool $expected_reminder_enabled ): void {
+		$notes = $this->build_notes( $recaptcha_settings );
+
+		$this->assertArrayHasKey( self::REMINDER_NOTE_NAME, $notes );
+		$this->assertSame( $expected_reminder_enabled, $notes[ self::REMINDER_NOTE_NAME ]->is_enabled() );
+
+		$this->assertArrayHasKey( self::LEGACY_NOTE_NAME, $notes );
+		$this->assertFalse( $notes[ self::LEGACY_NOTE_NAME ]->is_enabled() );
+	}
+
+	public function recaptcha_settings_provider(): array {
+		return array(
+			'recaptcha enabled via "yes" string'                 => array( array( 'enabled' => 'yes' ), false ),
+			'recaptcha enabled via numeric "1" string (regression)' => array( array( 'enabled' => '1' ), false ),
+			'recaptcha enabled via native boolean true (regression)' => array( array( 'enabled' => true ), false ),
+			'recaptcha disabled via "no" string'                 => array( array( 'enabled' => 'no' ), true ),
+			'recaptcha settings missing defaults to disabled'    => array( array(), true ),
+		);
+	}
+}

--- a/tests/PHPUnit/FraudProtection/RecaptchaTaskConfigServiceTest.php
+++ b/tests/PHPUnit/FraudProtection/RecaptchaTaskConfigServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\FraudProtection;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Covers the 'fraud-protection.wc-tasks.recaptcha-task-config' service.
+ */
+class RecaptchaTaskConfigServiceTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * @return array<int, array<string, string>>
+	 */
+	private function build_task_config( array $recaptcha_settings ): array {
+		when( 'get_option' )->justReturn( $recaptcha_settings );
+		when( 'admin_url' )->returnArg();
+
+		$services = require ROOT_DIR . '/modules/ppcp-fraud-protection/services.php';
+		$callback = $services['fraud-protection.wc-tasks.recaptcha-task-config'];
+
+		$container = Mockery::mock( ContainerInterface::class );
+
+		return $callback( $container );
+	}
+
+	/**
+	 * @dataProvider recaptcha_enabled_settings_provider
+	 */
+	public function test_task_suppressed_when_recaptcha_enabled( array $recaptcha_settings ): void {
+		$this->assertSame( array(), $this->build_task_config( $recaptcha_settings ) );
+	}
+
+	public function recaptcha_enabled_settings_provider(): array {
+		return array(
+			'recaptcha enabled via "yes" string'                    => array( array( 'enabled' => 'yes' ) ),
+			'recaptcha enabled via numeric "1" string (regression)' => array( array( 'enabled' => '1' ) ),
+		);
+	}
+
+	/**
+	 * @dataProvider recaptcha_disabled_settings_provider
+	 */
+	public function test_task_surfaced_when_recaptcha_disabled( array $recaptcha_settings ): void {
+		$task_config = $this->build_task_config( $recaptcha_settings );
+
+		$this->assertNotSame( array(), $task_config );
+		$this->assertSame( 'ppcp-recaptcha-protection-task', $task_config[0]['id'] );
+	}
+
+	public function recaptcha_disabled_settings_provider(): array {
+		return array(
+			'recaptcha disabled via "no" string'              => array( array( 'enabled' => 'no' ) ),
+			'recaptcha settings missing defaults to disabled' => array( array() ),
+		);
+	}
+}

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -17,6 +17,7 @@ require_once TESTS_ROOT_DIR . '/stubs/WC_Session_Handler.php';
 require_once TESTS_ROOT_DIR . '/stubs/Task.php';
 require_once TESTS_ROOT_DIR . '/stubs/DefaultPaymentGateways.php';
 require_once TESTS_ROOT_DIR . '/stubs/NoteTraits.php';
+require_once TESTS_ROOT_DIR . '/stubs/Note.php';
 require_once TESTS_ROOT_DIR . '/stubs/AbstractPaymentMethodType.php';
 require_once TESTS_ROOT_DIR . '/stubs/ProductStatus.php';
 require_once TESTS_ROOT_DIR . '/stubs/ProductType.php';

--- a/tests/stubs/Note.php
+++ b/tests/stubs/Note.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Minimal constants-only stub of \Automattic\WooCommerce\Admin\Notes\Note for unit tests.
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+if ( ! class_exists( __NAMESPACE__ . '\\Note' ) ) {
+	class Note {
+		const E_WC_ADMIN_NOTE_INFORMATIONAL = 'info';
+		const E_WC_ADMIN_NOTE_UNACTIONED    = 'unactioned';
+	}
+}


### PR DESCRIPTION
**Issue**: #4602

**Ticket**: [PAYPAL-174](https://linear.app/a8c/issue/PAYPAL-174/fraud-protection-inbox-note-persists-after-recaptcha-is-enabled)

---

### Description

Fixes the persisting "fraud protection" inbox notice reported in #4602 (closed as support, no fix tracked).

**Root cause:** 3.3.1 shipped the inbox note under the name `ppcp-recaptcha-protection-note`; 3.3.2 renamed it to `ppcp-recaptcha-protection-note12` without deleting the note under the old name. `InboxNoteRegistrar` only manages notes by their current name, so stores that received the note on 3.3.1 keep the card in the WooCommerce Inbox forever — even with reCAPTCHA fully enabled and demonstrably working (confirmed via live scoring in the Google reCAPTCHA console by the #4602 reporter). The "Activate Now" button described in that report only ever existed on the 3.3.1 note, which corroborates this.

**Changes:**

- Register the legacy name `ppcp-recaptcha-protection-note` as a permanently disabled note in the fraud-protection module's `wcgateway.settings.inbox-notes` extension. The registrar already deletes disabled notes, so any remaining orphaned copy is removed on the next admin page load — retroactively clearing affected merchants. A comment documents the pattern for any future rename.
- Switch the three `'yes' ===` checks on `woocommerce_ppcp-recaptcha_settings['enabled']` (inbox note, WC task, settings todo) to `wc_string_to_bool()`, matching how the reCAPTCHA runtime itself reads the flag — so a truthy-but-not-`'yes'` stored value can no longer run protection while the notice claims it is off.

Unit tests cover the extension gating (including the `'1'`/`true` regression cases) and the task config; full suite, PHPCS and PHPStan are green.

### Steps to Test

1. On a store where the note exists under the old name, e.g. by inserting a row named `ppcp-recaptcha-protection-note` into `wc_admin_notes` (as 3.3.1 created it), go to **WooCommerce → Settings → Integration → WooCommerce PayPal Payments reCAPTCHA**, enter all four keys, check **Enable reCAPTCHA protection**, and save.
2. Load any wp-admin page, then go to **WooCommerce → Home → Inbox**: the fraud-protection card no longer shows, and both `ppcp-recaptcha-protection-note` and `ppcp-recaptcha-protection-note12` are gone from `wc_admin_notes`.
3. Uncheck **Enable reCAPTCHA protection**, save, and reload wp-admin: `ppcp-recaptcha-protection-note12` is created as before, and the "Enable required fraud protection" task reappears.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

No documentation changes needed: the fix retroactively removes the stale notice, so the "dismiss the card manually" guidance this would otherwise require becomes unnecessary.

### Changelog Entry

> Fix - Remove the orphaned fraud-protection inbox notice left behind by the 3.3.1 → 3.3.2 note rename, which kept telling merchants to enable reCAPTCHA after they had already done so.

Closes #4602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)