### PR TITLE
Wallets: Collect shipping and reconcile tax in the sheet (6787)

### DIFF
--- a/modules/ppcp-sdk-v6/docs/wallet-shipping-and-tax.md
+++ b/modules/ppcp-sdk-v6/docs/wallet-shipping-and-tax.md
@@ -1,0 +1,95 @@
+# Wallet shipping and tax
+
+How Apple Pay and Google Pay behave when the buyer picks a shipping address inside the payment sheet, and why the charged total can differ from the one the sheet showed.
+
+Context for contributors and for debugging. Both wallets behave identically here: [`applePayShipping`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js) and [`googlePayShipping`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.js) translate their own sheet protocol and nothing else, so there is no Apple-only or Google-only rule in this document.
+
+## Who owns the shipping address
+
+Only one surface may collect the shipping address for a payment. Where the page already collects it, the wallet does not, and the sheet only authorizes what the page displays. [`SdkV6Manager::shipping_for_context()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php) decides per context, and the answer reaches the browser as `shipping.in_context`, which [`walletShippingRequired()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js) reads.
+
+| Context                                 | Sheet collects shipping                       | Why                                              |
+|-----------------------------------------|-----------------------------------------------|--------------------------------------------------|
+| Classic checkout                        | No                                            | The page has its own address and shipping fields |
+| Pay for order                           | No                                            | The order already carries both                   |
+| Product page                            | Yes, unless virtual or downloadable           | The page has no address form                     |
+| Cart, mini cart                         | Yes, when the cart needs shipping             | The page has no address form                     |
+| Cart block, checkout block express area | Yes, when the block reports it needs shipping | The block asks live                              |
+
+Consequence that surprises people: on the two contexts in the first rows the shipping callback is not implemented at all. A buyer who changes the address in the sheet there is not being ignored by a bug, the sheet is never given the chance to ask.
+
+One setting overrides the whole table. With **Pay now** disabled the buyer reviews the order on PayPal, so no wallet sheet collects shipping in any context.
+
+## Why the tax in the sheet is an estimate
+
+Tax may depend on the buyer's billing country, and neither wallet reveals it before the buyer authorizes the payment. Apple Pay hands over `shippingContact` during the shipping callbacks and `billingContact` only in [`onpaymentauthorized`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js); Google Pay hands over the shipping address in its `onPaymentDataChanged` callback and the card's billing address only in the [authorized payment data](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js). [`walletContacts`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.js) maps both shapes onto WooCommerce fields.
+
+So everything the sheet shows is taxed on the **shipping** address. The billing address first exists at authorization, which is also the last moment before the order is created.
+
+We chose to let WooCommerce price the order normally and reconcile afterwards, rather than force the wallet's billing country onto the order. Anyone tempted by the other route should know it was considered and rejected.
+
+## What happens when the real tax differs
+
+At authorization [`commit()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js) re-prices the payment on the addresses the order will actually use, and sends along the total the sheet displayed. [`WalletShippingEndpoint`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Endpoint/WalletShippingEndpoint.php) compares them, so there is nothing in the browser to bypass.
+
+| Real total            | Outcome  | What the buyer sees                                               |
+|-----------------------|----------|-------------------------------------------------------------------|
+| Same as the sheet     | Proceeds | Nothing. The common case                                          |
+| Lower than the sheet  | Proceeds | Nothing during payment; an explanation on the order-received page |
+| Higher than the sheet | Refused  | The sheet reports the failure and the corrected total             |
+
+Two guarantees behind that table. **The buyer is never charged more than they approved**, not by a cent and not silently. And **being charged less needs no consent**, so a reduction never interrupts the payment.
+
+The refusal message leads with the fact that no money moved:
+
+> Nothing has been charged yet. Tax for Germany differs from our estimate, so your total is now €48.30. Please try again.
+
+**The refusal is self-correcting.** [`RecordedTaxBasis`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedTaxBasis.php) is written before the payment is refused, so the next attempt's very first quote is priced on the real billing basis and the sheet shows the correct total from the start. A buyer who retries is expected to succeed, and support can say "try once more" with confidence.
+
+## Feedback on a reduced total
+
+A payment that came out lower than quoted leaves a trail in two places, both from [`RecordedQuote`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedQuote.php).
+
+The merchant gets a private order note, and the sheet's total is kept in order meta `_ppcp_wallet_quoted_total`:
+
+> The wallet payment sheet showed €52.10 and this order totals €48.30. The sheet estimated tax from the shipping address; the final amount uses the card's billing address.
+
+The buyer gets a sentence appended to the order-received text:
+
+> You saved €3.80. We estimated €52.10 at checkout, but the tax for your billing address is lower, so your actual charge is €48.30.
+
+Known limitation: that sentence appears on the **classic** thank-you page only. It hangs off `woocommerce_thankyou_order_received_text`, which the blocks order-confirmation block does not use. A blocks buyer still gets the reduced charge and the merchant still gets the order note, there is simply no sentence explaining it.
+
+## Decisions made in the sheet, and their lifetime
+
+Three decisions taken inside the sheet have to survive until the order is created: the chosen shipping rate in [`RecordedShippingRate`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedShippingRate.php), the tax basis in [`RecordedTaxBasis`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedTaxBasis.php), and the total the sheet displayed in [`RecordedQuote`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedQuote.php). All three extend [`WalletPaymentRecord`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/WalletPaymentRecord.php) and live in the WooCommerce session, not in the browser, because WooCommerce recalculates totals server-side and would discard a browser-held choice before the next request could read it.
+
+A recorded decision must never affect anything but the wallet payment that created it:
+
+- Each record expires 15 minutes after it was written.
+- The filters that read them are registered by [`SdkV6Module`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/SdkV6Module.php) and active only during the plugin's own wallet AJAX requests.
+- Cancelling the sheet drops all three, leaving the page behind it exactly as it was.
+- The recorded shipping rate can only fill a selection WooCommerce itself just cleared. It can never override a rate the buyer actively chose.
+
+## Sheet behavior worth knowing
+
+- An address with no rates is reported against the address field. The sheet stays open with the last total that priced, so the buyer can correct it.
+- A sheet that cannot price what it is about to charge is aborted rather than degraded. No stale total is charged.
+- Rapid address or rate changes are chained rather than raced by [`createShippingController()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js), so the buyer always ends on the total for their newest choice.
+- Apple presents the first shipping method in the list as the chosen one, so [`applePayShipping`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js) moves the selected rate to the front.
+- Google renders no price beside a shipping option, so [`googlePayShipping`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.js) writes each option's cost into its description.
+
+## Source layout
+
+| Path                                        | Contains                                                 |
+|---------------------------------------------|----------------------------------------------------------|
+| `src/Endpoint/WalletShippingEndpoint.php`   | Prices a selection, refuses an increase                  |
+| `src/Helper/WalletPaymentRecord.php`        | Session record base: write, read, expire, forget         |
+| `src/Helper/RecordedShippingRate.php`       | The rate the buyer picked in the sheet                   |
+| `src/Helper/RecordedTaxBasis.php`           | The address tax is calculated from                       |
+| `src/Helper/RecordedQuote.php`              | The sheet's total, the order note, the buyer's message   |
+| `resources/js/wallets/walletShipping.js`    | Wallet-agnostic quoting, and the commit at authorization |
+| `resources/js/wallets/shippingQuote.js`     | The quote shape both sheets are built from               |
+| `resources/js/wallets/walletContacts.js`    | Wallet contacts mapped to WooCommerce address fields     |
+| `resources/js/wallets/applePayShipping.js`  | Apple sheet protocol only                                |
+| `resources/js/wallets/googlePayShipping.js` | Google sheet protocol only                               |

--- a/modules/ppcp-sdk-v6/docs/wallet-shipping-and-tax.md
+++ b/modules/ppcp-sdk-v6/docs/wallet-shipping-and-tax.md
@@ -28,7 +28,17 @@ So everything the sheet shows is taxed on the **shipping** address. The billing 
 
 We chose to let WooCommerce price the order normally and reconcile afterwards, rather than force the wallet's billing country onto the order. Anyone tempted by the other route should know it was considered and rejected.
 
-## What happens when the real tax differs
+### Which stores this affects
+
+Only one of WooCommerce's three tax settings is affected. [`record_tax_basis()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Endpoint/WalletShippingEndpoint.php) returns early unless the store taxes on billing, because in the other two cases the sheet already has everything the calculation needs.
+
+| `woocommerce_tax_based_on`                     | Wallet impact                                                              |
+|------------------------------------------------|----------------------------------------------------------------------------|
+| Customer shipping address                      | None. The sheet collects that address, so the first quote is already right |
+| Customer billing address (WooCommerce default) | Estimated from the shipping address, then reconciled at authorization      |
+| Shop base address                              | None. The basis never depends on the buyer                                 |
+
+### What happens when the real tax differs
 
 At authorization [`commit()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js) re-prices the payment on the addresses the order will actually use, and sends along the total the sheet displayed. [`WalletShippingEndpoint`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Endpoint/WalletShippingEndpoint.php) compares them, so there is nothing in the browser to bypass.
 
@@ -46,15 +56,15 @@ The refusal message leads with the fact that no money moved:
 
 **The refusal is self-correcting.** [`RecordedTaxBasis`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedTaxBasis.php) is written before the payment is refused, so the next attempt's very first quote is priced on the real billing basis and the sheet shows the correct total from the start. A buyer who retries is expected to succeed, and support can say "try once more" with confidence.
 
-## Feedback on a reduced total
+### Feedback on a reduced total
 
 A payment that came out lower than quoted leaves a trail in two places, both from [`RecordedQuote`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/src/Helper/RecordedQuote.php).
 
-The merchant gets a private order note, and the sheet's total is kept in order meta `_ppcp_wallet_quoted_total`:
+**The merchant** gets a private order note, and the sheet's total is kept in order meta `_ppcp_wallet_quoted_total`:
 
 > The wallet payment sheet showed €52.10 and this order totals €48.30. The sheet estimated tax from the shipping address; the final amount uses the card's billing address.
 
-The buyer gets a sentence appended to the order-received text:
+**The buyer** gets a sentence appended to the order-received text:
 
 > You saved €3.80. We estimated €52.10 at checkout, but the tax for your billing address is lower, so your actual charge is €48.30.
 
@@ -93,3 +103,7 @@ A recorded decision must never affect anything but the wallet payment that creat
 | `resources/js/wallets/walletContacts.js`    | Wallet contacts mapped to WooCommerce address fields     |
 | `resources/js/wallets/applePayShipping.js`  | Apple sheet protocol only                                |
 | `resources/js/wallets/googlePayShipping.js` | Google sheet protocol only                               |
+
+---
+
+Related: [Wallets (Overview)](wallets.md)

--- a/modules/ppcp-sdk-v6/docs/wallets.md
+++ b/modules/ppcp-sdk-v6/docs/wallets.md
@@ -1,0 +1,57 @@
+# Wallets
+
+Apple Pay and Google Pay in the v6 SDK integration.
+
+Both are **merchant-presented** wallets: PayPal opens no popup and runs no approval flow of its own, so the store builds the payment sheet, drives it, and reports the outcome back. Everything below follows from that.
+
+## What has to be true for a button to appear
+
+The following conditions, all of them required, checked in different places:
+
+1. **The merchant is eligible for the wallet.** Country, currency, and the state of the PayPal account. The v6 module never judges this itself, it asks the wallet's own module, so the answer is the same one v5 would get.
+2. **The wallet is enabled in the settings for that location.** Each location has its own styling and its own list of shown payment methods, and a wallet absent from that list does not render there.
+3. **A live eligibility call includes it.** [`checkEligibility()`](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/eligibility.js) asks the SDK through `findEligibleMethods()` on every page load, with the page's currency, country and amount. A wallet can be eligible on one page and not the next.
+4. The device has to support the wallet. [Google Pay](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js) asks before rendering and removes its button when the answer is no; [Apple Pay](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js) asks before loading anything at all, so an unsupported browser touches neither the SDK nor the DOM.
+
+Condition 3 and 4 cause wallet buttons to appear with a short delay after loading the page; they are not present in DOM on page load.
+
+## The payment sequence
+
+```mermaid
+flowchart TD
+    Click["Buyer clicks the wallet button"] --> Total["Resolve the total"]
+    Total --> Sheet["The sheet opens"]
+    Sheet --> Shipping["Shipping callbacks"]
+    Shipping --> Authorize["Buyer authorizes"]
+    Authorize --> Create["1. Create the PayPal order"]
+    Create --> Confirm["2. Confirm it with the wallet token"]
+    Confirm --> Approve["3. Approve it into a WooCommerce order"]
+    Approve --> Done(["Order received"])
+
+    Total -. "no total" .-> NoOpen(["The sheet never opens"])
+    Sheet -. "Apple domain not validated" .-> Closed(["The sheet closes again"])
+    Shipping -. "no rates" .-> Rejected(["Address rejected, sheet stays open"])
+    Confirm -. "not approved" .-> Failed(["Payment fails, no order created"])
+
+    classDef exit stroke-dasharray: 4 3
+    class NoOpen,Closed,Rejected,Failed exit
+```
+
+The shipping callbacks fire once per address or shipping-option change, so the middle of the diagram repeats as often as the buyer edits the sheet. The three numbered steps are [the store's own](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletPayment.js). Only the last one creates anything in WooCommerce, which is why a failure before it leaves no order behind. The sheet's own state differs by wallet: Apple keeps it open until the outcome is reported back, while Google's closes the moment the buyer authorizes.
+
+Cancelling is not a failure. The sheet closes, the payment records are released, and the page is left as it was.
+
+[Failures](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/utils/errorHandler.js) split by who can act on them. A message the server marked shopper-facing is shown in the sheet, so the buyer can correct something and try again. Anything else is internal and the buyer sees the wallet's own wording instead, since a technical detail gives them nothing to act on.
+
+## How the two wallets differ
+
+The shipping and pricing behavior is identical, and the per-wallet files translate sheet protocols and nothing more. Four differences change what a maintainer may do:
+
+- **Apple builds its session synchronously inside the click handler.** Nothing may be awaited before the sheet opens, so anything the sheet needs must already be resolved. Google may await freely.
+- **[Apple's merchant-domain validation](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/applePayValidation.js) is the store's job.** The sheet asks mid-payment and the store answers from PayPal. Google has no equivalent step.
+- **Apple learns the buyer's street only at authorization.** Its shipping callbacks carry a [redacted address](https://github.com/woocommerce/woocommerce-paypal-payments/blob/dev/develop/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.js), which is enough to resolve a shipping zone but not to complete an order.
+- **Each wallet loads its own platform SDK**, separately from the PayPal SDK, and a wallet whose script fails to load simply does not render.
+
+---
+
+Related: [Wallet: Shipping and tax](wallet-shipping-and-tax.md)

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6ExpressComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6ExpressComponent.js
@@ -220,7 +220,7 @@ export function V6ExpressComponent( {
 		if (
 			method === FundingSources.PAYPAL &&
 			needsShipping &&
-			config.shipping?.handle_in_paypal
+			config.shipping?.in_context?.[ context ]
 		) {
 			handlers.onShippingAddressChange = ( data ) =>
 				callbacksRef.current.shippingHandlers.onShippingAddressChange(

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
@@ -11,7 +11,7 @@
 
 import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
 import { payerData } from '@ppcp-button/Helper/PayerData';
-import { postJson } from './utils/api';
+import { postJson, postStoreApi } from './utils/api';
 import { FundingSources } from './utils/fundingSources';
 import { minorUnitsToDecimal } from './utils/amount';
 import { continuationRedirectUrl } from './utils/continuation';
@@ -441,6 +441,24 @@ export async function updateShipping( config, orderId ) {
 }
 
 /**
+ * Fetches the current cart from the WC Store API.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {Promise<?Object>} The cart, or null when it could not be read.
+ */
+export async function fetchCart( config ) {
+	try {
+		const response = await fetch( config.ajax.wc_store_api.cart, {
+			credentials: 'same-origin',
+		} );
+
+		return await response.json();
+	} catch ( error ) {
+		return null;
+	}
+}
+
+/**
  * Fetches the current cart total from the WC Store API, for refreshing
  * amount-sensitive eligibility (Pay Later thresholds) after cart changes.
  *
@@ -448,17 +466,44 @@ export async function updateShipping( config, orderId ) {
  * @return {Promise<string>} The total as a decimal string, or '' on failure.
  */
 export async function fetchCartTotal( config ) {
-	try {
-		const response = await fetch( config.ajax.wc_store_api.cart, {
-			credentials: 'same-origin',
-		} );
-		const cart = await response.json();
+	const cart = await fetchCart( config );
 
-		return minorUnitsToDecimal(
-			cart?.totals?.total_price,
-			cart?.totals?.currency_minor_unit
-		);
-	} catch ( error ) {
-		return '';
-	}
+	return minorUnitsToDecimal(
+		cart?.totals?.total_price,
+		cart?.totals?.currency_minor_unit
+	);
+}
+
+/**
+ * Writes the shopper's shipping address to the WC customer.
+ *
+ * The Store API merges partial addresses server-side and answers with the
+ * recalculated cart, so the caller learns the new totals and rates from the
+ * same request.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {Object} address - WC address fields.
+ * @return {Promise<?Object>} The recalculated cart.
+ */
+export async function updateCustomerAddress( config, address ) {
+	const storeApi = config.ajax.wc_store_api;
+
+	return postStoreApi( storeApi, storeApi.update_customer, {
+		shipping_address: address,
+	} );
+}
+
+/**
+ * Selects a shipping rate on the WC cart.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @param {string} rateId - The WC rate id, e.g. flat_rate:3.
+ * @return {Promise<?Object>} The recalculated cart.
+ */
+export async function selectShippingRate( config, rateId ) {
+	const storeApi = config.ajax.wc_store_api;
+
+	return postStoreApi( storeApi, storeApi.select_shipping_rate, {
+		rate_id: rateId,
+	} );
 }

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
@@ -294,6 +294,8 @@ export async function approveOrder(
 				jQuery( gatewayRadio ).trigger( 'change' );
 			}
 
+			selectShippingMethodInForm( contact.shippingRateId );
+
 			checkoutForm.trigger( 'submit' );
 			return;
 		}
@@ -491,6 +493,85 @@ export async function updateCustomerAddress( config, address ) {
 	return postStoreApi( storeApi, storeApi.update_customer, {
 		shipping_address: address,
 	} );
+}
+
+/**
+ * Points the checkout form's shipping-method field at the sheet's rate.
+ *
+ * The form submits its own shipping_method, and that beats the session. Assigned
+ * rather than clicked: a click fires update_checkout, which posts the form's own
+ * address back over the one the sheet just set.
+ *
+ * @param {?string} rateId - The WC rate id, e.g. flat_rate:3.
+ */
+function selectShippingMethodInForm( rateId ) {
+	if ( ! rateId ) {
+		return;
+	}
+
+	const input = document.querySelector(
+		`input[name^="shipping_method"][value="${ rateId.replace(
+			/"/g,
+			''
+		) }"]`
+	);
+
+	if ( input ) {
+		input.checked = true;
+	}
+}
+
+/**
+ * Prices the cart for an address and rate chosen in a wallet payment sheet.
+ *
+ * One request, because WooCommerce re-picks the shipping method on every
+ * recalculation, so setting the destination and the rate separately loses the
+ * shopper's choice. Its total is the one ppc-create-order will charge.
+ *
+ * @param {Object}  config                  - The wc_ppcp_sdk_v6 config object.
+ * @param {Object}  args                    - The selection.
+ * @param {Object}  args.address            - WC shipping address fields, as
+ *                                            complete as known.
+ * @param {?string} [args.rateId]           - The rate the sheet selected.
+ * @param {?Object} [args.billingAddress]   - The card's WC billing address, once
+ *                                            authorization reveals it. Omitted
+ *                                            leaves the customer's own untouched.
+ * @param {?string} [args.expectedTotal]    - The total the sheet displayed. The
+ *                                            server refuses a higher one rather
+ *                                            than charge it.
+ * @return {Promise<Object>} The quote.
+ */
+export async function quoteWalletShipping(
+	config,
+	{ address, rateId = null, billingAddress = null, expectedTotal = null }
+) {
+	const body = {
+		address,
+		rate_id: rateId ?? '',
+	};
+
+	if ( billingAddress ) {
+		body.billing_address = billingAddress;
+	}
+
+	if ( expectedTotal ) {
+		body.expected_total = expectedTotal;
+	}
+
+	return postJson( config.ajax.wallet_shipping, body );
+}
+
+/**
+ * Drops the server-side hold on the sheet's chosen rate.
+ *
+ * Called when the sheet closes without paying, so the shopper's own rate choices
+ * apply again on the page behind it.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {Promise<?Object>} The endpoint's acknowledgement.
+ */
+export async function releaseWalletShipping( config ) {
+	return postJson( config.ajax.wallet_shipping, { release: true } );
 }
 
 /**

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
@@ -21,6 +21,7 @@ jest.mock(
 
 jest.mock( './utils/api', () => ( {
 	postJson: jest.fn(),
+	postStoreApi: jest.fn(),
 } ) );
 
 import {
@@ -28,11 +29,14 @@ import {
 	approveOrder,
 	createCardOrder,
 	approveCardOrder,
+	fetchCart,
 	fetchCartTotal,
 	simulateCart,
+	updateCustomerAddress,
+	selectShippingRate,
 	navigation,
 } from './endpointsAdapter';
-import { postJson } from './utils/api';
+import { postJson, postStoreApi } from './utils/api';
 
 const config = {
 	ajax: {
@@ -40,7 +44,13 @@ const config = {
 		create_order: { endpoint: '/co', nonce: 'n-co' },
 		approve_order: { endpoint: '/ao', nonce: 'n-ao' },
 		simulate_cart: { endpoint: '/sc', nonce: 'n-sc' },
-		wc_store_api: { cart: '/wp-json/wc/store/v1/cart' },
+		wc_store_api: {
+			cart: '/wp-json/wc/store/v1/cart',
+			update_customer: '/wp-json/wc/store/v1/cart/update-customer',
+			select_shipping_rate:
+				'/wp-json/wc/store/v1/cart/select-shipping-rate',
+			nonce: 'store-nonce',
+		},
 	},
 	urls: { checkout: '/checkout/' },
 	card_fields: {
@@ -51,6 +61,7 @@ const config = {
 
 afterEach( () => {
 	postJson.mockReset();
+	postStoreApi.mockReset();
 	mockGetProducts.mockReset();
 	document.body.innerHTML = '';
 } );
@@ -776,5 +787,62 @@ describe( 'fetchCartTotal', () => {
 		global.fetch = jest.fn().mockRejectedValue( new Error( 'down' ) );
 
 		await expect( fetchCartTotal( config ) ).resolves.toBe( '' );
+	} );
+} );
+
+describe( 'fetchCart', () => {
+	afterEach( () => {
+		global.fetch = undefined;
+	} );
+
+	test( 'returns the parsed Store API cart', async () => {
+		const cart = { totals: { total_price: '1000' } };
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: async () => cart,
+		} );
+
+		await expect( fetchCart( config ) ).resolves.toEqual( cart );
+		expect( global.fetch ).toHaveBeenCalledWith( config.ajax.wc_store_api.cart, {
+			credentials: 'same-origin',
+		} );
+	} );
+
+	test( 'returns null when the request fails', async () => {
+		global.fetch = jest.fn().mockRejectedValue( new Error( 'down' ) );
+
+		await expect( fetchCart( config ) ).resolves.toBeNull();
+	} );
+} );
+
+describe( 'updateCustomerAddress', () => {
+	test( 'posts the address to the Store API and returns the recalculated cart', async () => {
+		const cart = { totals: { total_price: '1100' } };
+		postStoreApi.mockResolvedValueOnce( cart );
+
+		const address = { country: 'US', state: 'CA' };
+		const result = await updateCustomerAddress( config, address );
+
+		expect( result ).toEqual( cart );
+		expect( postStoreApi ).toHaveBeenCalledWith(
+			config.ajax.wc_store_api,
+			config.ajax.wc_store_api.update_customer,
+			{ shipping_address: address }
+		);
+	} );
+} );
+
+describe( 'selectShippingRate', () => {
+	test( 'posts the rate id to the Store API and returns the recalculated cart', async () => {
+		const cart = { totals: { total_price: '1150' } };
+		postStoreApi.mockResolvedValueOnce( cart );
+
+		const result = await selectShippingRate( config, 'flat_rate:1' );
+
+		expect( result ).toEqual( cart );
+		expect( postStoreApi ).toHaveBeenCalledWith(
+			config.ajax.wc_store_api,
+			config.ajax.wc_store_api.select_shipping_rate,
+			{ rate_id: 'flat_rate:1' }
+		);
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
@@ -33,6 +33,8 @@ import {
 	fetchCartTotal,
 	simulateCart,
 	updateCustomerAddress,
+	quoteWalletShipping,
+	releaseWalletShipping,
 	selectShippingRate,
 	navigation,
 } from './endpointsAdapter';
@@ -51,6 +53,7 @@ const config = {
 				'/wp-json/wc/store/v1/cart/select-shipping-rate',
 			nonce: 'store-nonce',
 		},
+		wallet_shipping: { endpoint: '/ws', nonce: 'n-ws' },
 	},
 	urls: { checkout: '/checkout/' },
 	card_fields: {
@@ -815,7 +818,7 @@ describe( 'fetchCart', () => {
 } );
 
 describe( 'updateCustomerAddress', () => {
-	test( 'posts the address to the Store API and returns the recalculated cart', async () => {
+	test( 'posts the address as shipping only to the Store API and returns the recalculated cart', async () => {
 		const cart = { totals: { total_price: '1100' } };
 		postStoreApi.mockResolvedValueOnce( cart );
 
@@ -828,6 +831,121 @@ describe( 'updateCustomerAddress', () => {
 			config.ajax.wc_store_api.update_customer,
 			{ shipping_address: address }
 		);
+	} );
+
+	test( 'never sends a billing_address', async () => {
+		postStoreApi.mockResolvedValueOnce( {} );
+
+		await updateCustomerAddress( config, { country: 'US' } );
+
+		expect( postStoreApi ).toHaveBeenCalledWith(
+			config.ajax.wc_store_api,
+			config.ajax.wc_store_api.update_customer,
+			expect.not.objectContaining( { billing_address: expect.anything() } )
+		);
+	} );
+} );
+
+describe( 'quoteWalletShipping', () => {
+	test.each( [
+		[ 'a rate id is selected', 'flat_rate:1', 'flat_rate:1' ],
+		[ 'no rateId is passed', undefined, '' ],
+		[ 'rateId is explicitly null', null, '' ],
+	] )( 'posts the address and rate_id when %s', async ( label, rateId, expectedRateId ) => {
+		const quote = { total: '110.00' };
+		postJson.mockResolvedValueOnce( quote );
+		const address = { country: 'US', state: 'CA' };
+
+		const result = await quoteWalletShipping( config, { address, rateId } );
+
+		expect( result ).toEqual( quote );
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.wallet_shipping, {
+			address,
+			rate_id: expectedRateId,
+		} );
+	} );
+
+	test( 'includes billing_address in the posted body when one is given', async () => {
+		postJson.mockResolvedValueOnce( { total: '110.00' } );
+		const address = { country: 'US', state: 'CA' };
+		const billingAddress = { country: 'US', state: 'NY' };
+
+		await quoteWalletShipping( config, { address, billingAddress } );
+
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.wallet_shipping, {
+			address,
+			rate_id: '',
+			billing_address: billingAddress,
+		} );
+	} );
+
+	test.each( [
+		[ 'billingAddress is null', null ],
+		[ 'billingAddress is not passed', undefined ],
+	] )(
+		'omits billing_address entirely when %s, so the endpoint leaves the customer\'s own untouched',
+		async ( label, billingAddress ) => {
+			postJson.mockResolvedValueOnce( { total: '110.00' } );
+			const address = { country: 'US', state: 'CA' };
+
+			await quoteWalletShipping( config, { address, billingAddress } );
+
+			expect( postJson ).toHaveBeenCalledWith(
+				config.ajax.wallet_shipping,
+				expect.not.objectContaining( {
+					billing_address: expect.anything(),
+				} )
+			);
+		}
+	);
+
+	test( 'includes expected_total in the posted body when one is given', async () => {
+		postJson.mockResolvedValueOnce( { total: '110.00' } );
+		const address = { country: 'US', state: 'CA' };
+
+		await quoteWalletShipping( config, {
+			address,
+			expectedTotal: '110.00',
+		} );
+
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.wallet_shipping, {
+			address,
+			rate_id: '',
+			expected_total: '110.00',
+		} );
+	} );
+
+	test.each( [
+		[ 'expectedTotal is null', null ],
+		[ 'expectedTotal is not passed', undefined ],
+	] )(
+		'omits expected_total entirely when %s, leaving the server to charge whatever it prices',
+		async ( label, expectedTotal ) => {
+			postJson.mockResolvedValueOnce( { total: '110.00' } );
+			const address = { country: 'US', state: 'CA' };
+
+			await quoteWalletShipping( config, { address, expectedTotal } );
+
+			expect( postJson ).toHaveBeenCalledWith(
+				config.ajax.wallet_shipping,
+				expect.not.objectContaining( {
+					expected_total: expect.anything(),
+				} )
+			);
+		}
+	);
+} );
+
+describe( 'releaseWalletShipping', () => {
+	test( 'posts a release flag to the wallet-shipping endpoint', async () => {
+		postJson.mockResolvedValueOnce( { released: true } );
+
+		const result = await releaseWalletShipping( config );
+
+		expect( result ).toEqual( { released: true } );
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.wallet_shipping, {
+			release: true,
+		} );
 	} );
 } );
 

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSession.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSession.js
@@ -84,11 +84,16 @@ export function createSession(
 	const isBlockContext =
 		context === 'cart-block' || context === 'checkout-block';
 
+	// Whether the PayPal popup should collect shipping details.
+	// Only happens when the context requires shipping details and these details
+	// cannot be entered on the current page.
+	// - block checkout/checkout have a shipping form.
+	// - pay-now can only pay an already finished order.
 	const shouldHandleShipping =
-		method === FundingSources.PAYPAL &&
+		Boolean( config.shipping?.in_context?.[ context ] ) &&
 		! isBlockContext &&
-		config.shipping?.handle_in_paypal &&
-		( config.shipping?.need_shipping || context === 'product' );
+		! [ 'checkout', 'pay-now' ].includes( context ) &&
+		method === FundingSources.PAYPAL;
 
 	// Rejections must propagate so the SDK is informed of the failure.
 	if ( handlers.onShippingAddressChange ) {

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSession.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSession.js
@@ -32,6 +32,19 @@ const SESSION_FACTORIES = {
  */
 export const SUPPORTED_METHODS = Object.keys( SESSION_FACTORIES );
 
+// Wallet sessions are merchant-presented, so the SDK shows no popup and these
+// callbacks never fire; wallets collect shipping in their own sheet instead.
+const SHIPPING_POPUP_METHODS = [ FundingSources.PAYPAL ];
+
+// Contexts where the buyer enters shipping on the page: checkout has the form,
+// pay-now pays an order that is already addressed.
+const CONTEXTS_WITH_PAGE_SHIPPING = [ 'checkout', 'pay-now' ];
+
+// Blocks collect shipping through the Blocks data store instead
+// (blocks/blocksShippingHandlers.js); the defaults below post to the Store API
+// and would desynchronise the React cart UI.
+const CONTEXTS_WITH_OWN_SHIPPING_HANDLERS = [ 'cart-block', 'checkout-block' ];
+
 /**
  * Creates a one-time payment session for the given method.
  *
@@ -79,27 +92,20 @@ export function createSession(
 			};
 	}
 
-	// The default handlers post to the Store API directly, which desynchronises
-	// the React cart UI — block surfaces must supply their own or go without.
-	const isBlockContext =
-		context === 'cart-block' || context === 'checkout-block';
+	const collectsShipping =
+		SHIPPING_POPUP_METHODS.includes( method ) &&
+		! CONTEXTS_WITH_PAGE_SHIPPING.includes( context ) &&
+		Boolean( config.shipping?.in_context?.[ context ] );
 
-	// Whether the PayPal popup should collect shipping details.
-	// Only happens when the context requires shipping details and these details
-	// cannot be entered on the current page.
-	// - block checkout/checkout have a shipping form.
-	// - pay-now can only pay an already finished order.
-	const shouldHandleShipping =
-		Boolean( config.shipping?.in_context?.[ context ] ) &&
-		! isBlockContext &&
-		! [ 'checkout', 'pay-now' ].includes( context ) &&
-		method === FundingSources.PAYPAL;
+	const useDefaultHandlers =
+		collectsShipping &&
+		! CONTEXTS_WITH_OWN_SHIPPING_HANDLERS.includes( context );
 
 	// Rejections must propagate so the SDK is informed of the failure.
 	if ( handlers.onShippingAddressChange ) {
 		sessionConfig.onShippingAddressChange =
 			handlers.onShippingAddressChange;
-	} else if ( shouldHandleShipping ) {
+	} else if ( useDefaultHandlers ) {
 		sessionConfig.onShippingAddressChange = ( data ) =>
 			handleShippingAddressChange( data, config );
 	}
@@ -107,7 +113,7 @@ export function createSession(
 	if ( handlers.onShippingOptionsChange ) {
 		sessionConfig.onShippingOptionsChange =
 			handlers.onShippingOptionsChange;
-	} else if ( shouldHandleShipping ) {
+	} else if ( useDefaultHandlers ) {
 		sessionConfig.onShippingOptionsChange = ( data ) =>
 			handleShippingOptionsChange( data, config );
 	}

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSession.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSession.test.js
@@ -89,7 +89,7 @@ describe( 'createSession', () => {
 		const onShippingAddressChange = jest.fn();
 		const onShippingOptionsChange = jest.fn();
 
-		// shipping.handle_in_paypal is absent, so the classic path would attach nothing.
+		// shipping.in_context has no entry for this context, so the classic path would attach nothing.
 		createSession( sdk, 'paypal', { shipping: {} }, 'checkout-block', {
 			onShippingAddressChange,
 			onShippingOptionsChange,
@@ -112,10 +112,10 @@ describe( 'createSession', () => {
 		expect( sdk.capture.config.onShippingOptionsChange ).toBeUndefined();
 	} );
 
-	test( 'classic default attaches the fetch-based shipping handlers when enabled', async () => {
+	test( 'classic default attaches the fetch-based shipping handlers when the context collects shipping', async () => {
 		const sdk = fakeSdk();
 		const config = {
-			shipping: { handle_in_paypal: true, need_shipping: true },
+			shipping: { in_context: { cart: true } },
 		};
 
 		createSession( sdk, 'paypal', config, 'cart' );
@@ -126,6 +126,25 @@ describe( 'createSession', () => {
 			config
 		);
 	} );
+
+	test.each( [ 'checkout', 'pay-now' ] )(
+		'no popup shipping handlers on %s even when the context collects shipping, because PayPal is given a fixed address there',
+		( context ) => {
+			const sdk = fakeSdk();
+			const config = {
+				shipping: { in_context: { [ context ]: true } },
+			};
+
+			createSession( sdk, 'paypal', config, context );
+
+			expect(
+				sdk.capture.config.onShippingAddressChange
+			).toBeUndefined();
+			expect(
+				sdk.capture.config.onShippingOptionsChange
+			).toBeUndefined();
+		}
+	);
 
 	describe.each( [
 		[ 'googlepay', 'createGooglePayOneTimePaymentSession' ],
@@ -153,10 +172,10 @@ describe( 'createSession', () => {
 			);
 		} );
 
-		test( 'gets neither in-sheet shipping handler even when classic shipping-in-PayPal is enabled', () => {
+		test( 'gets neither in-sheet shipping handler even when the context collects shipping', () => {
 			const sdk = fakeSdk();
 			const config = {
-				shipping: { handle_in_paypal: true, need_shipping: true },
+				shipping: { in_context: { product: true } },
 			};
 
 			createSession( sdk, method, config, 'product' );

--- a/modules/ppcp-sdk-v6/resources/js/sessions/shippingHandler.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/shippingHandler.js
@@ -7,8 +7,11 @@
  * @package
  */
 
-import { updateShipping } from '../endpointsAdapter';
-import { postStoreApi } from '../utils/api';
+import {
+	selectShippingRate,
+	updateCustomerAddress,
+	updateShipping,
+} from '../endpointsAdapter';
 import { sdkShippingAddressToWc } from '../utils/sdkAddress';
 
 /**
@@ -22,11 +25,10 @@ import { sdkShippingAddressToWc } from '../utils/sdkAddress';
  * @param {Object} config - The wc_ppcp_sdk_v6 config object.
  */
 export async function handleShippingAddressChange( data, config ) {
-	const storeApi = config.ajax.wc_store_api;
-
-	await postStoreApi( storeApi, storeApi.update_customer, {
-		shipping_address: sdkShippingAddressToWc( data.shippingAddress ),
-	} );
+	await updateCustomerAddress(
+		config,
+		sdkShippingAddressToWc( data.shippingAddress )
+	);
 
 	await updateShipping( config, data.orderId );
 }
@@ -39,13 +41,10 @@ export async function handleShippingAddressChange( data, config ) {
  * @param {Object} config - The wc_ppcp_sdk_v6 config object.
  */
 export async function handleShippingOptionsChange( data, config ) {
-	const storeApi = config.ajax.wc_store_api;
 	const rateId = data.selectedShippingOption?.id;
 
 	if ( rateId ) {
-		await postStoreApi( storeApi, storeApi.select_shipping_rate, {
-			rate_id: rateId,
-		} );
+		await selectShippingRate( config, rateId );
 	}
 
 	await updateShipping( config, data.orderId );

--- a/modules/ppcp-sdk-v6/resources/js/test/api.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/api.test.js
@@ -1,4 +1,4 @@
-import { postJson } from '../utils/api';
+import { postJson, postStoreApi } from '../utils/api';
 
 describe( 'postJson', () => {
 	afterEach( () => {
@@ -50,6 +50,80 @@ describe( 'postJson', () => {
 			postJson( { endpoint: '/e', nonce: 'n' } )
 		).rejects.toMatchObject( {
 			isUserFacing: false,
+		} );
+	} );
+} );
+
+describe( 'postStoreApi', () => {
+	const storeApi = { nonce: 'store-nonce' };
+
+	afterEach( () => {
+		global.fetch = undefined;
+	} );
+
+	test( 'authenticates with the Store API nonce header and returns the parsed cart', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: async () => ( { totals: { total_price: '1000' } } ),
+		} );
+
+		const cart = await postStoreApi( storeApi, '/cart/update-customer', {
+			shipping_address: { country: 'US' },
+		} );
+
+		expect( cart ).toEqual( { totals: { total_price: '1000' } } );
+		const [ url, options ] = global.fetch.mock.calls[ 0 ];
+		expect( url ).toBe( '/cart/update-customer' );
+		expect( options.headers.Nonce ).toBe( 'store-nonce' );
+		expect( JSON.parse( options.body ) ).toEqual( {
+			shipping_address: { country: 'US' },
+		} );
+	} );
+
+	test( 'throws a user-facing error built from the Store API code and message', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: false,
+			json: async () => ( {
+				code: 'rate_not_found',
+				message: 'No shipping options were found.',
+			} ),
+		} );
+
+		await expect(
+			postStoreApi( storeApi, '/cart/select-shipping-rate', {} )
+		).rejects.toMatchObject( {
+			message: 'No shipping options were found.',
+			isUserFacing: true,
+			code: 'rate_not_found',
+		} );
+	} );
+
+	test( 'falls back to a generic message when the failed response carries none', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: false,
+			json: async () => ( {} ),
+		} );
+
+		await expect(
+			postStoreApi( storeApi, '/cart/update-customer', {} )
+		).rejects.toMatchObject( {
+			message: 'Store API request failed.',
+			isUserFacing: false,
+		} );
+	} );
+
+	test( 'still throws when the failed response body is not JSON', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: false,
+			json: async () => {
+				throw new Error( 'not json' );
+			},
+		} );
+
+		await expect(
+			postStoreApi( storeApi, '/cart/update-customer', {} )
+		).rejects.toMatchObject( {
+			message: 'Store API request failed.',
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/blocks/V6ExpressComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/blocks/V6ExpressComponent.test.js
@@ -55,7 +55,7 @@ const config = {
 	buyer_country: 'US',
 	amount: '50.00',
 	button_styles: { 'checkout-block': {} },
-	shipping: { handle_in_paypal: false, need_shipping: false },
+	shipping: { in_context: { 'checkout-block': false } },
 	ajax: {
 		get_order: { endpoint: '', nonce: '' },
 		approve_order: { endpoint: '', nonce: '' },
@@ -551,7 +551,7 @@ describe( 'V6ExpressComponent', () => {
 		const props = {
 			config: {
 				...config,
-				shipping: { handle_in_paypal: true, need_shipping: true },
+				shipping: { in_context: { 'checkout-block': true } },
 			},
 			fundingSource: 'paypal',
 			onClick: jest.fn(),
@@ -600,7 +600,7 @@ describe( 'V6ExpressComponent', () => {
 		const props = {
 			config: {
 				...config,
-				shipping: { handle_in_paypal: true, need_shipping: true },
+				shipping: { in_context: { 'checkout-block': true } },
 			},
 			fundingSource: 'paypal',
 			onClick: jest.fn(),

--- a/modules/ppcp-sdk-v6/resources/js/test/shippingHandler.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/shippingHandler.test.js
@@ -1,12 +1,18 @@
 jest.mock( '../endpointsAdapter', () => ( {
 	updateShipping: jest.fn().mockResolvedValue( undefined ),
+	updateCustomerAddress: jest.fn(),
+	selectShippingRate: jest.fn(),
 } ) );
 
 import {
 	handleShippingAddressChange,
 	handleShippingOptionsChange,
 } from '../sessions/shippingHandler';
-import { updateShipping } from '../endpointsAdapter';
+import {
+	updateShipping,
+	updateCustomerAddress,
+	selectShippingRate,
+} from '../endpointsAdapter';
 
 const config = {
 	ajax: {
@@ -19,13 +25,14 @@ const config = {
 	},
 };
 
-describe( 'handleShippingAddressChange', () => {
-	beforeEach( () => {
-		global.fetch = jest.fn().mockResolvedValue( { ok: true } );
-		updateShipping.mockClear();
-	} );
+beforeEach( () => {
+	updateShipping.mockClear();
+	updateCustomerAddress.mockClear().mockResolvedValue( {} );
+	selectShippingRate.mockClear().mockResolvedValue( {} );
+} );
 
-	test( 'maps v6 Orders-v2 address fields to WC state and city', async () => {
+describe( 'handleShippingAddressChange', () => {
+	test( 'maps v6 Orders-v2 address fields to WC state and city before patching the order', async () => {
 		// v6 payloads name these adminArea1/adminArea2 (not state/city);
 		// a wrong key silently posts empty fields and skews tax/shipping.
 		await handleShippingAddressChange(
@@ -41,10 +48,7 @@ describe( 'handleShippingAddressChange', () => {
 			config
 		);
 
-		const [ url, options ] = global.fetch.mock.calls[ 0 ];
-		expect( url ).toBe( config.ajax.wc_store_api.update_customer );
-		expect( options.headers.Nonce ).toBe( 'store-nonce' );
-		expect( JSON.parse( options.body ).shipping_address ).toEqual( {
+		expect( updateCustomerAddress ).toHaveBeenCalledWith( config, {
 			country: 'US',
 			state: 'CA',
 			postcode: '94105',
@@ -53,25 +57,20 @@ describe( 'handleShippingAddressChange', () => {
 		expect( updateShipping ).toHaveBeenCalledWith( config, 'ORDER1' );
 	} );
 
-	test( 'propagates Store API failures to the caller', async () => {
-		global.fetch = jest.fn().mockResolvedValue( { ok: false } );
+	test( 'propagates Store API failures to the caller, without patching the order', async () => {
+		updateCustomerAddress.mockRejectedValueOnce( new Error( 'down' ) );
 
 		await expect(
 			handleShippingAddressChange(
 				{ orderId: 'O', shippingAddress: {} },
 				config
 			)
-		).rejects.toThrow();
+		).rejects.toThrow( 'down' );
 		expect( updateShipping ).not.toHaveBeenCalled();
 	} );
 } );
 
 describe( 'handleShippingOptionsChange', () => {
-	beforeEach( () => {
-		global.fetch = jest.fn().mockResolvedValue( { ok: true } );
-		updateShipping.mockClear();
-	} );
-
 	test( 'selects the rate then patches the order', async () => {
 		await handleShippingOptionsChange(
 			{
@@ -81,18 +80,17 @@ describe( 'handleShippingOptionsChange', () => {
 			config
 		);
 
-		const [ url, options ] = global.fetch.mock.calls[ 0 ];
-		expect( url ).toBe( config.ajax.wc_store_api.select_shipping_rate );
-		expect( JSON.parse( options.body ) ).toEqual( {
-			rate_id: 'flat_rate:1',
-		} );
+		expect( selectShippingRate ).toHaveBeenCalledWith(
+			config,
+			'flat_rate:1'
+		);
 		expect( updateShipping ).toHaveBeenCalledWith( config, 'ORDER2' );
 	} );
 
 	test( 'skips rate selection without a selected option', async () => {
 		await handleShippingOptionsChange( { orderId: 'ORDER3' }, config );
 
-		expect( global.fetch ).not.toHaveBeenCalled();
+		expect( selectShippingRate ).not.toHaveBeenCalled();
 		expect( updateShipping ).toHaveBeenCalledWith( config, 'ORDER3' );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/utils/api.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/api.js
@@ -48,6 +48,7 @@ export async function postJson( { endpoint, nonce }, body = {} ) {
  * @param {Object} storeApi - The wc_store_api config (urls + nonce).
  * @param {string} url      - The endpoint URL.
  * @param {Object} body     - The request body.
+ * @return {Promise<Object|null>} The parsed response body, or null when it is not JSON.
  * @throws {Error} When the response is not OK.
  */
 export async function postStoreApi( storeApi, url, body ) {
@@ -61,9 +62,16 @@ export async function postStoreApi( storeApi, url, body ) {
 		body: JSON.stringify( body ),
 	} );
 
+	const json = await response.json().catch( () => null );
+
 	if ( ! response.ok ) {
-		throw new Error( 'Store API request failed.' );
+		const error = new Error( json?.message || 'Store API request failed.' );
+		error.isUserFacing = Boolean( json?.message );
+		error.code = json?.code;
+		throw error;
 	}
+
+	return json;
 }
 
 /**

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -20,11 +20,16 @@ import { loadScript } from '../utils/scriptLoaders';
 import { revealWalletGateway } from './gatewayPlacement';
 import { APPLE_PAY_VERSION, buildApplePayRequest } from './applePayRequest';
 import { watchSheetTotal } from './applePaySheetTotal';
+import { attachShippingHandlers } from './applePayShipping';
 import { recordDomainValidation } from './applePayValidation';
 import { walletButtonStyle } from './walletButtonStyle';
 import { applePayPayer, applePayShippingAddress } from './walletContacts';
 import { payWithWallet } from './walletPayment';
 import { walletConfig, walletFundingSource } from './walletRegistry';
+import {
+	createShippingController,
+	walletShippingRequired,
+} from './walletShipping';
 import { resolveWalletTotal } from './walletTotal';
 
 /**
@@ -89,6 +94,8 @@ export async function renderApplePay( {
 	revealWalletGateway( gateway, config );
 
 	const sheetTotal = watchSheetTotal( config, context );
+	const requiresShipping = walletShippingRequired( config, context );
+	const shipping = createShippingController( { config } );
 	const spinner = hasJQuery() ? Spinner.fullPage() : null;
 	let paying = false;
 
@@ -126,8 +133,17 @@ export async function renderApplePay( {
 					total,
 					displayName: settings.display_name,
 					context,
+					requiresShipping,
 				} )
 			);
+
+			if ( requiresShipping ) {
+				attachShippingHandlers( appleSession, {
+					config,
+					displayName: settings.display_name,
+					shipping,
+				} );
+			}
 
 			appleSession.onvalidatemerchant = ( event ) => {
 				validateMerchant( appleSession, event );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -13,6 +13,7 @@
  */
 
 import Spinner from '@ppcp-button/Helper/Spinner';
+import { releaseWalletShipping } from '../endpointsAdapter';
 import { hasJQuery } from '../utils/api';
 import { refreshCartUi } from '../utils/cartUi';
 import { handleError } from '../utils/errorHandler';
@@ -20,10 +21,15 @@ import { loadScript } from '../utils/scriptLoaders';
 import { revealWalletGateway } from './gatewayPlacement';
 import { APPLE_PAY_VERSION, buildApplePayRequest } from './applePayRequest';
 import { watchSheetTotal } from './applePaySheetTotal';
-import { attachShippingHandlers } from './applePayShipping';
+import { applePayFailure, attachShippingHandlers } from './applePayShipping';
 import { recordDomainValidation } from './applePayValidation';
 import { walletButtonStyle } from './walletButtonStyle';
-import { applePayPayer, applePayShippingAddress } from './walletContacts';
+import {
+	applePayPayer,
+	applePayShippingAddress,
+	applePayWcBillingAddress,
+	applePayWcShippingAddress,
+} from './walletContacts';
 import { payWithWallet } from './walletPayment';
 import { walletConfig, walletFundingSource } from './walletRegistry';
 import {
@@ -154,10 +160,16 @@ export async function renderApplePay( {
 			};
 
 			// A dismissal is not a failure to report, but it must release
-			// `paying` or the button could never open a second sheet.
+			// `paying` or the button could never open a second sheet. It also
+			// drops the rate this sheet pinned server-side.
 			appleSession.oncancel = () => {
 				paying = false;
 				spinner?.unblock();
+
+				if ( requiresShipping ) {
+					releaseWalletShipping( config ).catch( () => {} );
+				}
+
 				refreshCartUi( context );
 			};
 
@@ -221,6 +233,16 @@ export async function renderApplePay( {
 				context
 			);
 
+			// Before the order exists, because the order is built from the WC
+			// customer rather than from the address posted with the approval.
+			// Throws rather than charge a total the sheet never showed.
+			if ( requiresShipping ) {
+				await shipping.commit(
+					applePayWcShippingAddress( event.payment ),
+					applePayWcBillingAddress( event.payment )
+				);
+			}
+
 			await payWithWallet( {
 				config,
 				context,
@@ -238,6 +260,7 @@ export async function renderApplePay( {
 				contact: {
 					payer: applePayPayer( event.payment ),
 					shippingAddress: applePayShippingAddress( event.payment ),
+					shippingRateId: shipping.current()?.selectedId,
 				},
 			} );
 
@@ -247,9 +270,9 @@ export async function renderApplePay( {
 				window.ApplePaySession.STATUS_SUCCESS
 			);
 		} catch ( error ) {
-			// How Apple shows the shopper that the payment failed.
+			// Apple still has the sheet up, so it can tell the shopper why.
 			appleSession.completePayment(
-				window.ApplePaySession.STATUS_FAILURE
+				applePayFailure( error, window.ApplePaySession.STATUS_FAILURE )
 			);
 
 			paying = false;

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -101,6 +101,15 @@ export async function renderApplePay( {
 	let paying = false;
 
 	/**
+	 * The cart holding what is being bought, resolved once per sheet.
+	 *
+	 * On the product page this is what adds the viewed product, and an empty cart
+	 * offers no rates for the sheet to show. Started rather than awaited at click
+	 * time, because Safari refuses to present a sheet after an await.
+	 */
+	let cartReady = null;
+
+	/**
 	 * Opens the payment sheet and pays with what it returns.
 	 *
 	 * Deliberately not async: everything up to begin() must run in the same task
@@ -122,6 +131,11 @@ export async function renderApplePay( {
 		}
 
 		paying = true;
+
+		cartReady = resolveWalletTotal( config, context );
+
+		// Claimed here so a rejection nothing has awaited yet stays handled.
+		cartReady.catch( () => {} );
 
 		const request = buildApplePayRequest( applePayConfig, {
 			// Stands in when PayPal's config carries no country of its own.
@@ -146,6 +160,7 @@ export async function renderApplePay( {
 					config,
 					displayName: settings.display_name,
 					shipping,
+					cartReady,
 				} );
 			}
 
@@ -223,17 +238,13 @@ export async function renderApplePay( {
 		spinner?.block();
 
 		try {
-			// This is what adds a viewed product to the real cart, and its
-			// units price the order. Its total is ignored: the sheet total
-			// describes the same basket, via the simulate endpoint.
-			const { purchaseUnits } = await resolveWalletTotal(
-				config,
-				context
-			);
+			// Its units price the order; its total is ignored, because the sheet
+			// already described the same basket via the simulate endpoint.
+			const { purchaseUnits } = await cartReady;
 
-			// Before the order exists, because the order is built from the WC
-			// customer rather than from the address posted with the approval.
-			// Throws rather than charge a total the sheet never showed.
+			// Before the order exists, because it is built from the WC customer
+			// rather than the address posted with the approval. Throws rather
+			// than charge a total the sheet never showed.
 			if ( requiresShipping ) {
 				await shipping.commit(
 					applePayWcShippingAddress( event.payment ),

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -261,10 +261,12 @@ export async function renderApplePay( {
 				// PayPal gateway as Venmo's and Pay Later's do.
 				paymentMethod: gateway?.id,
 				purchaseUnits,
+				// No shippingContact: an express order is created with
+				// GET_FROM_FILE (see ShippingPreferenceFactory), and supplying an
+				// address for one fails with APPROVE_APPLE_PAY_VALIDATION_ERROR.
 				confirmData: {
 					token: event.payment.token,
 					billingContact: event.payment.billingContact,
-					shippingContact: event.payment.shippingContact,
 				},
 				contact: {
 					payer: applePayPayer( event.payment ),

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -92,11 +92,6 @@ export async function renderApplePay( {
 		return;
 	}
 
-	// Lowercases the networks and camelCases the capabilities into the spellings
-	// Apple's payment request expects.
-	const sessionConfig =
-		session.formatConfigForPaymentRequest( applePayConfig );
-
 	revealWalletGateway( gateway, config );
 
 	const sheetTotal = watchSheetTotal( config, context );
@@ -128,19 +123,22 @@ export async function renderApplePay( {
 
 		paying = true;
 
+		const request = buildApplePayRequest( applePayConfig, {
+			// Stands in when PayPal's config carries no country of its own.
+			countryCode: config.merchant_country,
+			currencyCode: config.currency,
+			total,
+			displayName: settings.display_name,
+			requiresShipping,
+		} );
+
 		// Apple rejects a malformed request (currency, supportedNetworks) by
 		// throwing synchronously, so `paying` must be released here or the
 		// button would silently ignore every later tap.
 		try {
 			const appleSession = new window.ApplePaySession(
 				APPLE_PAY_VERSION,
-				buildApplePayRequest( sessionConfig, {
-					currencyCode: config.currency,
-					total,
-					displayName: settings.display_name,
-					context,
-					requiresShipping,
-				} )
+				request
 			);
 
 			if ( requiresShipping ) {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
@@ -25,10 +25,16 @@ jest.mock( './walletPayment', () => ( {
 
 const mockApplePayPayer = jest.fn();
 const mockApplePayShippingAddress = jest.fn();
+const mockApplePayWcShippingAddress = jest.fn();
+const mockApplePayWcBillingAddress = jest.fn();
 jest.mock( './walletContacts', () => ( {
 	applePayPayer: ( ...args ) => mockApplePayPayer( ...args ),
 	applePayShippingAddress: ( ...args ) =>
 		mockApplePayShippingAddress( ...args ),
+	applePayWcShippingAddress: ( ...args ) =>
+		mockApplePayWcShippingAddress( ...args ),
+	applePayWcBillingAddress: ( ...args ) =>
+		mockApplePayWcBillingAddress( ...args ),
 } ) );
 
 const mockBuildApplePayRequest = jest.fn();
@@ -63,9 +69,11 @@ jest.mock( './walletShipping', () => ( {
 } ) );
 
 const mockAttachShippingHandlers = jest.fn();
+const mockApplePayFailure = jest.fn();
 jest.mock( './applePayShipping', () => ( {
 	attachShippingHandlers: ( ...args ) =>
 		mockAttachShippingHandlers( ...args ),
+	applePayFailure: ( ...args ) => mockApplePayFailure( ...args ),
 } ) );
 
 const mockSpinnerBlock = jest.fn();
@@ -196,6 +204,7 @@ const paymentEvent = {
 
 let ApplePaySessionMock;
 let mockJQueryTrigger;
+let shippingController;
 
 beforeEach( () => {
 	jest.clearAllMocks();
@@ -205,6 +214,17 @@ beforeEach( () => {
 	mockWatchSheetTotal.mockReturnValue( { get: jest.fn( () => '12.34' ) } );
 	mockApplePayPayer.mockReturnValue( 'PAYER_SENTINEL' );
 	mockApplePayShippingAddress.mockReturnValue( 'SHIP_SENTINEL' );
+	mockApplePayWcShippingAddress.mockReturnValue( 'WC_SHIP_SENTINEL' );
+	mockApplePayWcBillingAddress.mockReturnValue( 'WC_BILLING_SENTINEL' );
+	mockApplePayFailure.mockImplementation( ( error, status ) => ( {
+		status,
+	} ) );
+	shippingController = {
+		quote: jest.fn(),
+		current: jest.fn(),
+		commit: jest.fn(),
+	};
+	mockCreateShippingController.mockReturnValue( shippingController );
 	mockResolveWalletTotal.mockResolvedValue( {
 		purchaseUnits: [ { amount: '12.34' } ],
 	} );
@@ -634,11 +654,91 @@ describe( 'onpaymentauthorized', () => {
 			contact: {
 				payer: 'PAYER_SENTINEL',
 				shippingAddress: 'SHIP_SENTINEL',
+				shippingRateId: undefined,
 			},
 		} );
 		expect( appleSession.completePayment ).toHaveBeenCalledWith(
 			'STATUS_SUCCESS'
 		);
+	} );
+
+	test( "carries the selected rate's id into the contact, when this context collects shipping", async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		shippingController.commit.mockResolvedValue( {
+			selectedId: 'flat_rate:2',
+			total: '12.34',
+		} );
+		shippingController.current.mockReturnValue( {
+			selectedId: 'flat_rate:2',
+		} );
+		const { appleSession } = await clickAndGetSession();
+
+		appleSession.onpaymentauthorized( paymentEvent );
+		await flushPromises();
+
+		expect( mockPayWithWallet ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				contact: expect.objectContaining( {
+					shippingRateId: 'flat_rate:2',
+				} ),
+			} )
+		);
+	} );
+
+	test( 'commits the mapped WC shipping and billing addresses before paying, when this context requires shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		const config = baseConfig();
+		const callOrder = [];
+		shippingController.commit.mockImplementationOnce( async () => {
+			callOrder.push( 'commit' );
+			return { selectedId: null, total: '12.34' };
+		} );
+		mockPayWithWallet.mockImplementationOnce( async () => {
+			callOrder.push( 'payWithWallet' );
+		} );
+		const { appleSession } = await clickAndGetSession( { config } );
+
+		appleSession.onpaymentauthorized( paymentEvent );
+		await flushPromises();
+
+		expect( mockApplePayWcShippingAddress ).toHaveBeenCalledWith(
+			paymentEvent.payment
+		);
+		expect( mockApplePayWcBillingAddress ).toHaveBeenCalledWith(
+			paymentEvent.payment
+		);
+		expect( shippingController.commit ).toHaveBeenCalledWith(
+			'WC_SHIP_SENTINEL',
+			'WC_BILLING_SENTINEL'
+		);
+		expect( callOrder ).toEqual( [ 'commit', 'payWithWallet' ] );
+	} );
+
+	test( 'never commits a shipping address when this context requires no shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( false );
+		const { appleSession } = await clickAndGetSession();
+
+		appleSession.onpaymentauthorized( paymentEvent );
+		await flushPromises();
+
+		expect( shippingController.commit ).not.toHaveBeenCalled();
+		expect( mockPayWithWallet ).toHaveBeenCalled();
+	} );
+
+	test( 'never pays when the committed shipping price no longer matches what the sheet showed', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		shippingController.commit.mockRejectedValueOnce(
+			new Error( 'Shipping price changed after authorization' )
+		);
+		const { appleSession } = await clickAndGetSession();
+
+		appleSession.onpaymentauthorized( paymentEvent );
+		await flushPromises();
+
+		expect( mockPayWithWallet ).not.toHaveBeenCalled();
+		expect( appleSession.completePayment ).toHaveBeenCalledWith( {
+			status: 'STATUS_FAILURE',
+		} );
 	} );
 
 	test( 'pays with the configured gateway id when Apple Pay is its own row', async () => {
@@ -729,5 +829,44 @@ describe( 'oncancel', () => {
 
 		expect( () => appleSession.oncancel() ).not.toThrow();
 		expect( mockJQueryTrigger ).not.toHaveBeenCalled();
+	} );
+
+	test( 'releases the held wallet shipping rate when this context collected shipping, since the sheet already wrote it to the real cart', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		const config = baseConfig();
+		const { appleSession } = await clickAndGetSession( {
+			config,
+			context: 'product',
+		} );
+
+		appleSession.oncancel();
+
+		expect( mockReleaseWalletShipping ).toHaveBeenCalledWith( config );
+	} );
+
+	test( 'never releases wallet shipping when this context collected none', async () => {
+		mockWalletShippingRequired.mockReturnValue( false );
+		const { appleSession } = await clickAndGetSession( {
+			context: 'product',
+		} );
+
+		appleSession.oncancel();
+
+		expect( mockReleaseWalletShipping ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not let a failed shipping release surface an error', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		mockReleaseWalletShipping.mockRejectedValueOnce(
+			new Error( 'release failed' )
+		);
+		const { appleSession } = await clickAndGetSession( {
+			context: 'product',
+		} );
+
+		expect( () => appleSession.oncancel() ).not.toThrow();
+		await flushPromises();
+
+		expect( mockHandleError ).not.toHaveBeenCalled();
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
@@ -644,10 +644,10 @@ describe( 'onpaymentauthorized', () => {
 			fundingSource: 'apple_pay',
 			paymentMethod: undefined,
 			purchaseUnits: [ { amount: '12.34' } ],
+			// No shippingContact: PayPal refuses one for a GET_FROM_FILE order.
 			confirmData: {
 				token: paymentEvent.payment.token,
 				billingContact: paymentEvent.payment.billingContact,
-				shippingContact: paymentEvent.payment.shippingContact,
 			},
 			contact: {
 				payer: 'PAYER_SENTINEL',

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
@@ -139,7 +139,7 @@ const baseConfig = ( overrides = {} ) => ( {
 } );
 
 const applePayConfig = ( overrides = {} ) => ( {
-	merchantCountry: 'US',
+	countryCode: 'US',
 	merchantCapabilities: [ 'supports3DS' ],
 	supportedNetworks: [ 'visa' ],
 	...overrides,
@@ -148,9 +148,6 @@ const applePayConfig = ( overrides = {} ) => ( {
 function makeSession( overrides = {} ) {
 	return {
 		config: jest.fn().mockResolvedValue( applePayConfig() ),
-		formatConfigForPaymentRequest: jest
-			.fn()
-			.mockReturnValue( 'FORMATTED_CONFIG' ),
 		validateMerchant: jest
 			.fn()
 			.mockResolvedValue( { merchantSession: 'MERCHANT_SESSION' } ),
@@ -294,19 +291,6 @@ describe( 'renderApplePay()', () => {
 		} );
 
 		expect( wrapper.childElementCount ).toBe( 1 );
-	} );
-
-	test( 'asks the session to translate the resolved config for the payment request', async () => {
-		const config = applePayConfig( { merchantCountry: 'DE' } );
-		const session = makeSession( {
-			config: jest.fn().mockResolvedValue( config ),
-		} );
-
-		await render( { session } );
-
-		expect( session.formatConfigForPaymentRequest ).toHaveBeenCalledWith(
-			config
-		);
 	} );
 
 	test( 'renders nothing when the config explicitly sets isEligible to false', async () => {
@@ -460,21 +444,30 @@ describe( 'a click on the rendered button', () => {
 		expect( appleSession.begin ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( 'builds the request from the version, the formatted config and the resolved total', async () => {
-		const config = baseConfig();
+	test( 'builds the request from the version, the resolved Apple Pay config and the resolved total', async () => {
+		const config = baseConfig( { merchant_country: 'DE' } );
+		const resolvedConfig = applePayConfig();
+		const session = makeSession( {
+			config: jest.fn().mockResolvedValue( resolvedConfig ),
+		} );
 		const sheetTotal = { get: jest.fn( () => '42.00' ) };
 		mockWatchSheetTotal.mockReturnValue( sheetTotal );
 
-		const { wrapper } = await render( { config, context: 'checkout' } );
+		const { wrapper } = await render( {
+			config,
+			context: 'checkout',
+			session,
+		} );
 		wrapper.querySelector( 'apple-pay-button' ).click();
 
 		expect( mockBuildApplePayRequest ).toHaveBeenCalledWith(
-			'FORMATTED_CONFIG',
+			resolvedConfig,
 			{
+				// The builder decides which country wins; see its own suite.
+				countryCode: config.merchant_country,
 				currencyCode: config.currency,
 				total: '42.00',
 				displayName: config.apple_pay.display_name,
-				context: 'checkout',
 				requiresShipping: false,
 			}
 		);
@@ -491,7 +484,7 @@ describe( 'a click on the rendered button', () => {
 		wrapper.querySelector( 'apple-pay-button' ).click();
 
 		expect( mockBuildApplePayRequest ).toHaveBeenCalledWith(
-			'FORMATTED_CONFIG',
+			expect.anything(),
 			expect.objectContaining( { requiresShipping: true } )
 		);
 	} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
@@ -53,6 +53,21 @@ jest.mock( './gatewayPlacement', () => ( {
 	revealWalletGateway: ( ...args ) => mockRevealWalletGateway( ...args ),
 } ) );
 
+const mockWalletShippingRequired = jest.fn( () => false );
+const mockCreateShippingController = jest.fn();
+jest.mock( './walletShipping', () => ( {
+	walletShippingRequired: ( ...args ) =>
+		mockWalletShippingRequired( ...args ),
+	createShippingController: ( ...args ) =>
+		mockCreateShippingController( ...args ),
+} ) );
+
+const mockAttachShippingHandlers = jest.fn();
+jest.mock( './applePayShipping', () => ( {
+	attachShippingHandlers: ( ...args ) =>
+		mockAttachShippingHandlers( ...args ),
+} ) );
+
 const mockSpinnerBlock = jest.fn();
 const mockSpinnerUnblock = jest.fn();
 jest.mock(
@@ -194,6 +209,8 @@ beforeEach( () => {
 		purchaseUnits: [ { amount: '12.34' } ],
 	} );
 	mockPayWithWallet.mockResolvedValue( undefined );
+	mockWalletShippingRequired.mockReturnValue( false );
+	mockCreateShippingController.mockReturnValue( { quote: jest.fn(), current: jest.fn() } );
 
 	ApplePaySessionMock = jest.fn( function () {
 		this.begin = jest.fn();
@@ -433,12 +450,47 @@ describe( 'a click on the rendered button', () => {
 				total: '42.00',
 				displayName: config.apple_pay.display_name,
 				context: 'checkout',
+				requiresShipping: false,
 			}
 		);
 		expect( ApplePaySessionMock ).toHaveBeenCalledWith(
 			4,
 			'APPLE_REQUEST'
 		);
+	} );
+
+	test( "forwards this context's shipping requirement into the request", async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+
+		const { wrapper } = await render( { context: 'cart' } );
+		wrapper.querySelector( 'apple-pay-button' ).click();
+
+		expect( mockBuildApplePayRequest ).toHaveBeenCalledWith(
+			'FORMATTED_CONFIG',
+			expect.objectContaining( { requiresShipping: true } )
+		);
+	} );
+
+	test( 'attaches the shipping handlers only when this context collects shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+
+		const { wrapper } = await render( { context: 'cart' } );
+		wrapper.querySelector( 'apple-pay-button' ).click();
+
+		const appleSession = ApplePaySessionMock.mock.instances[ 0 ];
+		expect( mockAttachShippingHandlers ).toHaveBeenCalledWith(
+			appleSession,
+			expect.objectContaining( { displayName: 'My Shop' } )
+		);
+	} );
+
+	test( 'never attaches the shipping handlers when this context collects no shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( false );
+
+		const { wrapper } = await render();
+		wrapper.querySelector( 'apple-pay-button' ).click();
+
+		expect( mockAttachShippingHandlers ).not.toHaveBeenCalled();
 	} );
 
 	test( 'refuses to open a sheet when no total has resolved yet', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.test.js
@@ -37,6 +37,11 @@ jest.mock( './walletContacts', () => ( {
 		mockApplePayWcBillingAddress( ...args ),
 } ) );
 
+const mockReleaseWalletShipping = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	releaseWalletShipping: ( ...args ) => mockReleaseWalletShipping( ...args ),
+} ) );
+
 const mockBuildApplePayRequest = jest.fn();
 jest.mock( './applePayRequest', () => ( {
 	APPLE_PAY_VERSION: 4,
@@ -216,6 +221,12 @@ beforeEach( () => {
 	mockApplePayShippingAddress.mockReturnValue( 'SHIP_SENTINEL' );
 	mockApplePayWcShippingAddress.mockReturnValue( 'WC_SHIP_SENTINEL' );
 	mockApplePayWcBillingAddress.mockReturnValue( 'WC_BILLING_SENTINEL' );
+	mockReleaseWalletShipping.mockResolvedValue( undefined );
+	mockResolveWalletTotal.mockResolvedValue( {
+		purchaseUnits: [ { amount: '12.34' } ],
+	} );
+	mockPayWithWallet.mockResolvedValue( undefined );
+	mockWalletShippingRequired.mockReturnValue( false );
 	mockApplePayFailure.mockImplementation( ( error, status ) => ( {
 		status,
 	} ) );
@@ -225,12 +236,6 @@ beforeEach( () => {
 		commit: jest.fn(),
 	};
 	mockCreateShippingController.mockReturnValue( shippingController );
-	mockResolveWalletTotal.mockResolvedValue( {
-		purchaseUnits: [ { amount: '12.34' } ],
-	} );
-	mockPayWithWallet.mockResolvedValue( undefined );
-	mockWalletShippingRequired.mockReturnValue( false );
-	mockCreateShippingController.mockReturnValue( { quote: jest.fn(), current: jest.fn() } );
 
 	ApplePaySessionMock = jest.fn( function () {
 		this.begin = jest.fn();
@@ -768,9 +773,9 @@ describe( 'onpaymentauthorized', () => {
 		appleSession.onpaymentauthorized( paymentEvent );
 		await flushPromises();
 
-		expect( appleSession.completePayment ).toHaveBeenCalledWith(
-			'STATUS_FAILURE'
-		);
+		expect( appleSession.completePayment ).toHaveBeenCalledWith( {
+			status: 'STATUS_FAILURE',
+		} );
 		expect( mockSpinnerUnblock ).toHaveBeenCalledTimes( 1 );
 		expect( mockJQueryTrigger ).toHaveBeenCalledWith(
 			'wc_fragment_refresh'

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.js
@@ -1,42 +1,37 @@
 /**
  * Builder for the ApplePayPaymentRequest that opens the payment sheet.
  *
- * Pure: no DOM, no SDK, no network, so the request shape is unit-testable.
- *
  * @package
  */
 
-/**
- * The ApplePaySession version to construct. Part of the request contract: the
- * fields below are the ones this version accepts.
- */
+// Part of the request contract: the fields below are the ones this version takes.
 export const APPLE_PAY_VERSION = 4;
 
 /**
  * Builds the ApplePayPaymentRequest.
  *
- * Which address fields the sheet collects depends on who supplies the address. On
- * classic checkout the shopper already typed one into the WC form, so asking again
- * would be a second entry of the same data; everywhere else the sheet is the only
- * source. Apple never returns a billing email or phone, hence postalAddress alone
- * for billing — walletContacts.js backfills the email from the shipping contact.
+ * On classic checkout the shopper already typed an address into the WC form, so
+ * the sheet does not ask for it a second time. Apple never returns a billing email
+ * or phone, hence postalAddress alone for billing — walletContacts.js backfills the
+ * email from the shipping contact.
  *
- * @param {Object} sessionConfig            - The v6 session config, as returned by
- *                                          formatConfigForPaymentRequest().
- * @param {Object} transaction              - What the shopper is about to pay.
- * @param {string} transaction.currencyCode - The shop currency.
- * @param {string} transaction.total        - The total as a decimal string.
- * @param {string} transaction.displayName  - The shop name, labelling the total.
- * @param {string} transaction.context      - The page context.
+ * @param {Object}  sessionConfig                  - The v6 session config, as returned
+ *                                                   by formatConfigForPaymentRequest().
+ * @param {Object}  transaction                    - What the shopper is about to pay.
+ * @param {string}  transaction.currencyCode       - The shop currency.
+ * @param {string}  transaction.total              - The total as a decimal string.
+ * @param {string}  transaction.displayName        - The shop name, labelling the total.
+ * @param {string}  transaction.context            - The page context.
+ * @param {boolean} [transaction.requiresShipping] - Whether to collect shipping
+ *                                                   in the sheet.
  * @return {Object} The ApplePayPaymentRequest.
  */
 export function buildApplePayRequest(
 	sessionConfig,
-	{ currencyCode, total, displayName, context }
+	{ currencyCode, total, displayName, context, requiresShipping = false }
 ) {
-	return {
-		// The session config calls it merchantCountry; Apple's request wants
-		// countryCode.
+	const request = {
+		// The session config calls this one merchantCountry.
 		countryCode: sessionConfig.merchantCountry,
 		merchantCapabilities: sessionConfig.merchantCapabilities,
 		supportedNetworks: sessionConfig.supportedNetworks,
@@ -52,4 +47,14 @@ export function buildApplePayRequest(
 				? [ 'email', 'phone' ]
 				: [ 'postalAddress', 'email', 'phone' ],
 	};
+
+	if ( requiresShipping ) {
+		request.shippingType = 'shipping';
+
+		// Deliberately empty: the first onshippingcontactselected fills it, once
+		// there is an address to price against.
+		request.shippingMethods = [];
+	}
+
+	return request;
 }

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.js
@@ -10,31 +10,36 @@ export const APPLE_PAY_VERSION = 4;
 /**
  * Builds the ApplePayPaymentRequest.
  *
- * On classic checkout the shopper already typed an address into the WC form, so
- * the sheet does not ask for it a second time. Apple never returns a billing email
+ * The postal address is asked for only where the sheet prices shipping with it;
+ * everywhere else the page already holds one. Apple never returns a billing email
  * or phone, hence postalAddress alone for billing — walletContacts.js backfills the
  * email from the shipping contact.
  *
- * @param {Object}  sessionConfig                  - The v6 session config, as returned
- *                                                   by formatConfigForPaymentRequest().
+ * Built from PayPal's Apple Pay config exactly as it arrives, never from
+ * formatConfigForPaymentRequest(): that helper lowercases the merchant
+ * capabilities, and ApplePayMerchantCapability is a case-sensitive enum, so
+ * "supports3ds" makes the session constructor throw before any sheet appears.
+ * v5 reads the raw config for the same three fields.
+ *
+ * @param {Object}  applePayConfig                 - PayPal's Apple Pay config, as
+ *                                                   returned by session.config().
  * @param {Object}  transaction                    - What the shopper is about to pay.
+ * @param {string}  transaction.countryCode        - The merchant's country.
  * @param {string}  transaction.currencyCode       - The shop currency.
  * @param {string}  transaction.total              - The total as a decimal string.
  * @param {string}  transaction.displayName        - The shop name, labelling the total.
- * @param {string}  transaction.context            - The page context.
  * @param {boolean} [transaction.requiresShipping] - Whether to collect shipping
  *                                                   in the sheet.
  * @return {Object} The ApplePayPaymentRequest.
  */
 export function buildApplePayRequest(
-	sessionConfig,
-	{ currencyCode, total, displayName, context, requiresShipping = false }
+	applePayConfig,
+	{ countryCode, currencyCode, total, displayName, requiresShipping = false }
 ) {
 	const request = {
-		// The session config calls this one merchantCountry.
-		countryCode: sessionConfig.merchantCountry,
-		merchantCapabilities: sessionConfig.merchantCapabilities,
-		supportedNetworks: sessionConfig.supportedNetworks,
+		countryCode: applePayConfig.countryCode || countryCode,
+		merchantCapabilities: applePayConfig.merchantCapabilities,
+		supportedNetworks: applePayConfig.supportedNetworks,
 		currencyCode,
 		total: {
 			label: displayName,
@@ -42,10 +47,9 @@ export function buildApplePayRequest(
 			amount: total,
 		},
 		requiredBillingContactFields: [ 'postalAddress' ],
-		requiredShippingContactFields:
-			'checkout' === context
-				? [ 'email', 'phone' ]
-				: [ 'postalAddress', 'email', 'phone' ],
+		requiredShippingContactFields: requiresShipping
+			? [ 'postalAddress', 'email', 'phone' ]
+			: [ 'email', 'phone' ],
 	};
 
 	if ( requiresShipping ) {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.test.js
@@ -83,4 +83,21 @@ describe( 'buildApplePayRequest()', () => {
 			);
 		}
 	);
+
+	test( 'omits shippingType and shippingMethods when the sheet does not collect shipping', () => {
+		const request = buildApplePayRequest( sessionConfig(), transaction() );
+
+		expect( request ).not.toHaveProperty( 'shippingType' );
+		expect( request ).not.toHaveProperty( 'shippingMethods' );
+	} );
+
+	test( 'sets shippingType and an empty shippingMethods list when the sheet collects shipping, since the rates depend on an address not given yet', () => {
+		const request = buildApplePayRequest(
+			sessionConfig(),
+			transaction( { requiresShipping: true } )
+		);
+
+		expect( request.shippingType ).toBe( 'shipping' );
+		expect( request.shippingMethods ).toEqual( [] );
+	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayRequest.test.js
@@ -1,7 +1,7 @@
 import { buildApplePayRequest } from './applePayRequest';
 
-const sessionConfig = ( overrides = {} ) => ( {
-	merchantCountry: 'US',
+const applePayConfig = ( overrides = {} ) => ( {
+	countryCode: 'US',
 	merchantCapabilities: [ 'supports3DS' ],
 	supportedNetworks: [ 'visa', 'masterCard' ],
 	...overrides,
@@ -11,30 +11,49 @@ const transaction = ( overrides = {} ) => ( {
 	currencyCode: 'USD',
 	total: '12.34',
 	displayName: 'WooShop',
-	context: 'checkout',
 	...overrides,
 } );
 
 describe( 'buildApplePayRequest()', () => {
-	test( 'maps merchantCountry from the session config to countryCode', () => {
-		const request = buildApplePayRequest(
-			sessionConfig( { merchantCountry: 'DE' } ),
-			transaction()
-		);
+	describe( 'resolving countryCode', () => {
+		test( "prefers PayPal's own config over the plugin setting", () => {
+			const request = buildApplePayRequest(
+				applePayConfig( { countryCode: 'US' } ),
+				transaction( { countryCode: 'DE' } )
+			);
 
-		expect( request.countryCode ).toBe( 'DE' );
+			expect( request.countryCode ).toBe( 'US' );
+		} );
+
+		test( 'falls back to the passed-in countryCode when the config has none', () => {
+			// Regression: the config does not guarantee a country and the plugin
+			// setting can be empty. An undefined countryCode makes the
+			// ApplePaySession constructor throw before any sheet opens.
+			const request = buildApplePayRequest(
+				applePayConfig( { countryCode: undefined } ),
+				transaction( { countryCode: 'DE' } )
+			);
+
+			expect( request.countryCode ).toBe( 'DE' );
+		} );
 	} );
 
-	test( 'passes merchantCapabilities and supportedNetworks through from the session config', () => {
+	test( 'passes merchantCapabilities and supportedNetworks through from the raw config, untouched', () => {
+		// Regression: session.formatConfigForPaymentRequest() used to run over
+		// this config first and lowercase merchantCapabilities, which makes
+		// Apple's case-sensitive enum throw. The raw config must survive as-is.
 		const request = buildApplePayRequest(
-			sessionConfig( {
-				merchantCapabilities: [ 'supportsCredit' ],
+			applePayConfig( {
+				merchantCapabilities: [ 'supports3DS', 'supportsCredit' ],
 				supportedNetworks: [ 'amex' ],
 			} ),
 			transaction()
 		);
 
-		expect( request.merchantCapabilities ).toEqual( [ 'supportsCredit' ] );
+		expect( request.merchantCapabilities ).toEqual( [
+			'supports3DS',
+			'supportsCredit',
+		] );
 		expect( request.supportedNetworks ).toEqual( [ 'amex' ] );
 	} );
 
@@ -42,7 +61,7 @@ describe( 'buildApplePayRequest()', () => {
 		'builds a final total labelled with the shop display name, passing %s through without rounding',
 		( total ) => {
 			const request = buildApplePayRequest(
-				sessionConfig(),
+				applePayConfig(),
 				transaction( { total, displayName: 'Acme Store' } )
 			);
 
@@ -55,7 +74,7 @@ describe( 'buildApplePayRequest()', () => {
 	);
 
 	test( 'always requires only the postal address for billing', () => {
-		const request = buildApplePayRequest( sessionConfig(), transaction() );
+		const request = buildApplePayRequest( applePayConfig(), transaction() );
 
 		expect( request.requiredBillingContactFields ).toEqual( [
 			'postalAddress',
@@ -63,19 +82,14 @@ describe( 'buildApplePayRequest()', () => {
 	} );
 
 	test.each( [
-		[ 'checkout', [ 'email', 'phone' ] ],
-		[ 'product', [ 'postalAddress', 'email', 'phone' ] ],
-		[ 'cart', [ 'postalAddress', 'email', 'phone' ] ],
-		[ 'mini-cart', [ 'postalAddress', 'email', 'phone' ] ],
-		[ '', [ 'postalAddress', 'email', 'phone' ] ],
+		[ false, [ 'email', 'phone' ] ],
+		[ true, [ 'postalAddress', 'email', 'phone' ] ],
 	] )(
-		// 'checkout' already has the address from the WC form, so it skips
-		// postalAddress; every other (express) context needs it as the only source.
-		'for context %s requires shipping fields %j',
-		( context, expectedFields ) => {
+		'when requiresShipping is %s, requires shipping fields %j',
+		( requiresShipping, expectedFields ) => {
 			const request = buildApplePayRequest(
-				sessionConfig(),
-				transaction( { context } )
+				applePayConfig(),
+				transaction( { requiresShipping } )
 			);
 
 			expect( request.requiredShippingContactFields ).toEqual(
@@ -85,7 +99,7 @@ describe( 'buildApplePayRequest()', () => {
 	);
 
 	test( 'omits shippingType and shippingMethods when the sheet does not collect shipping', () => {
-		const request = buildApplePayRequest( sessionConfig(), transaction() );
+		const request = buildApplePayRequest( applePayConfig(), transaction() );
 
 		expect( request ).not.toHaveProperty( 'shippingType' );
 		expect( request ).not.toHaveProperty( 'shippingMethods' );
@@ -93,7 +107,7 @@ describe( 'buildApplePayRequest()', () => {
 
 	test( 'sets shippingType and an empty shippingMethods list when the sheet collects shipping, since the rates depend on an address not given yet', () => {
 		const request = buildApplePayRequest(
-			sessionConfig(),
+			applePayConfig(),
 			transaction( { requiresShipping: true } )
 		);
 
@@ -101,3 +115,4 @@ describe( 'buildApplePayRequest()', () => {
 		expect( request.shippingMethods ).toEqual( [] );
 	} );
 } );
+

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.js
@@ -97,6 +97,14 @@ export function watchSheetTotal( config, context ) {
 	// Seeded so a click that beats the first resolve still has a number to show.
 	let total = config.amount || '';
 
+	// An existing order is being paid, so the localized amount is that order's
+	// total and nothing on this page can change it.
+	if ( context === 'pay-now' ) {
+		return {
+			get: () => total,
+		};
+	}
+
 	// Refreshes overlap and can resolve out of order, letting a slow answer about
 	// an older variation overwrite a fresh one: the stale total the debounce
 	// exists to prevent.

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePaySheetTotal.test.js
@@ -103,6 +103,23 @@ describe( 'watchSheetTotal()', () => {
 		expect( mockSimulateCart ).not.toHaveBeenCalled();
 	} );
 
+	describe( 'on the pay-now context', () => {
+		test( 'returns the configured amount without resolving or refreshing from the cart', async () => {
+			const watcher = watchSheetTotal(
+				config( { amount: '42.00' } ),
+				'pay-now'
+			);
+
+			expect( watcher.get() ).toBe( '42.00' );
+
+			await flushPromises();
+
+			expect( watcher.get() ).toBe( '42.00' );
+			expect( mockSimulateCart ).not.toHaveBeenCalled();
+			expect( mockFetchCartTotal ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	test( 'does not throw when the page has no product form', async () => {
 		mockSimulateCart.mockResolvedValueOnce( { total: '' } );
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js
@@ -1,0 +1,217 @@
+/**
+ * Apple Pay's in-sheet shipping callbacks.
+ *
+ * Translates between Apple's ApplePaySession protocol and the shared shipping
+ * quote; everything about pricing lives in walletShipping.js.
+ *
+ * @package
+ */
+
+import { resolveOptionId } from './shippingQuote';
+import { walletAddressToWc } from './walletContacts';
+
+/**
+ * Builds the line items the sheet itemises the total with.
+ *
+ * @param {Object} quote  - The shipping quote.
+ * @param {Object} labels - The shopper-facing labels.
+ * @return {Object[]} Apple line items.
+ */
+function lineItems( quote, labels ) {
+	const items = [ { label: labels.subtotal, amount: quote.subtotal } ];
+
+	if ( parseFloat( quote.shippingFee ) > 0 ) {
+		items.push( { label: labels.shipping, amount: quote.shippingFee } );
+	}
+
+	if ( parseFloat( quote.tax ) > 0 ) {
+		items.push( { label: labels.tax, amount: quote.tax } );
+	}
+
+	if ( parseFloat( quote.discount ) > 0 ) {
+		// Negative, because Apple sums the line items it is given.
+		items.push( {
+			label: labels.discount,
+			amount: `-${ quote.discount }`,
+		} );
+	}
+
+	return items.map( ( item ) => ( { ...item, type: 'final' } ) );
+}
+
+/**
+ * Maps a quote's options to Apple's shape.
+ *
+ * The selected one goes first: Apple presents the head of the list as chosen.
+ *
+ * @param {Object} quote - The shipping quote.
+ * @return {Object[]} Apple shipping methods.
+ */
+function shippingMethods( quote ) {
+	const methods = quote.options.map( ( option ) => ( {
+		label: option.label,
+		detail: '',
+		amount: option.cost,
+		identifier: option.id,
+	} ) );
+
+	const selectedAt = methods.findIndex(
+		( method ) => method.identifier === quote.selectedId
+	);
+
+	if ( selectedAt > 0 ) {
+		methods.unshift( methods.splice( selectedAt, 1 )[ 0 ] );
+	}
+
+	return methods;
+}
+
+/**
+ * Builds the sheet update that describes a priced quote.
+ *
+ * @param {Object} quote            - The shipping quote.
+ * @param {Object} args             - Presentation inputs.
+ * @param {string} args.displayName - The shop name, labelling the total.
+ * @param {Object} args.labels      - The shopper-facing labels.
+ * @return {Object} The Apple sheet update.
+ */
+export function applePayShippingUpdate( quote, { displayName, labels } ) {
+	return {
+		newTotal: {
+			label: displayName,
+			type: 'final',
+			amount: quote.total,
+		},
+		newLineItems: lineItems( quote, labels ),
+		newShippingMethods: shippingMethods( quote ),
+	};
+}
+
+/**
+ * Builds the update that tells the sheet an address cannot be shipped to.
+ *
+ * Carries whatever last priced, because Apple rejects a completion with no total
+ * at all. The error goes against the address field, so the shopper can correct it.
+ *
+ * @param {?Object} lastQuote        - The last quote that priced, if any.
+ * @param {Object}  args             - Presentation inputs.
+ * @param {string}  args.displayName - The shop name.
+ * @param {Object}  args.labels      - The shopper-facing labels.
+ * @param {string}  args.message     - The error to show.
+ * @return {Object} The Apple sheet update.
+ */
+export function applePayUnserviceableUpdate(
+	lastQuote,
+	{ displayName, labels, message }
+) {
+	const errors = [];
+
+	// Guarded: ApplePayError is only defined inside a live session.
+	if ( typeof window.ApplePayError === 'function' ) {
+		errors.push(
+			new window.ApplePayError(
+				'shippingContactInvalid',
+				'postalAddress',
+				message
+			)
+		);
+	}
+
+	const base = lastQuote
+		? applePayShippingUpdate( lastQuote, { displayName, labels } )
+		: {
+				newTotal: {
+					label: displayName,
+					type: 'pending',
+					amount: '0',
+				},
+				newLineItems: [],
+		  };
+
+	return {
+		...base,
+		newShippingMethods: [],
+		errors,
+	};
+}
+
+/**
+ * Wires an ApplePaySession's shipping callbacks to the shared controller.
+ *
+ * @param {Object} appleSession     - The live ApplePaySession.
+ * @param {Object} args             - The wiring inputs.
+ * @param {Object} args.config      - The wc_ppcp_sdk_v6 config object.
+ * @param {string} args.displayName - The shop name.
+ * @param {Object} args.shipping    - The shared shipping controller.
+ */
+export function attachShippingHandlers(
+	appleSession,
+	{ config, displayName, shipping }
+) {
+	const labels = {
+		subtotal: config.labels?.subtotal ?? 'Subtotal',
+		shipping: config.labels?.shipping ?? 'Shipping',
+		tax: config.labels?.tax ?? 'Tax',
+		discount: config.labels?.discount ?? 'Discount',
+	};
+	const message = config.labels?.shipping_unserviceable ?? '';
+
+	// Remembered for the method callback, which prices against whatever address
+	// the contact callback last set.
+	let address = null;
+
+	/**
+	 * Prices a selection and answers the sheet, or reports it cannot be shipped.
+	 *
+	 * @param {Function} complete  - The session's completion method.
+	 * @param {Object}   selection - What to price.
+	 */
+	async function respond( complete, selection ) {
+		try {
+			const quote = await shipping.quote( selection );
+
+			if ( ! quote.options.length ) {
+				complete(
+					applePayUnserviceableUpdate( shipping.current(), {
+						displayName,
+						labels,
+						message,
+					} )
+				);
+				return;
+			}
+
+			complete( applePayShippingUpdate( quote, { displayName, labels } ) );
+		} catch ( error ) {
+			// A sheet that cannot price what it is about to charge must not go on,
+			// and nothing can be shown to the shopper behind it.
+			// eslint-disable-next-line no-console
+			console.error(
+				'[PPCP SDK v6] Apple Pay shipping update failed: ' +
+					error.message
+			);
+			appleSession.abort();
+		}
+	}
+
+	appleSession.onshippingcontactselected = ( event ) => {
+		address = walletAddressToWc( event.shippingContact );
+
+		respond(
+			( update ) => appleSession.completeShippingContactSelection( update ),
+			{ address }
+		);
+	};
+
+	appleSession.onshippingmethodselected = ( event ) => {
+		const rateId = resolveOptionId(
+			shipping.current(),
+			event.shippingMethod?.identifier
+		);
+
+		respond(
+			( update ) => appleSession.completeShippingMethodSelection( update ),
+			{ address, rateId }
+		);
+	};
+}

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js
@@ -136,6 +136,29 @@ export function applePayUnserviceableUpdate(
 }
 
 /**
+ * Builds the authorization result that reports a failure to the open sheet.
+ *
+ * Only a message the server marked shopper-facing is passed through; anything
+ * else is internal, and Apple's own wording serves better.
+ *
+ * @param {Error}  error  - What went wrong.
+ * @param {number} status - ApplePaySession.STATUS_FAILURE.
+ * @return {Object} The ApplePayPaymentAuthorizationResult.
+ */
+export function applePayFailure( error, status ) {
+	const result = { status };
+
+	// ApplePayError is only defined inside a live session.
+	if ( error?.isUserFacing && typeof window.ApplePayError === 'function' ) {
+		result.errors = [
+			new window.ApplePayError( 'unknown', undefined, error.message ),
+		];
+	}
+
+	return result;
+}
+
+/**
  * Wires an ApplePaySession's shipping callbacks to the shared controller.
  *
  * @param {Object} appleSession     - The live ApplePaySession.

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.js
@@ -161,15 +161,17 @@ export function applePayFailure( error, status ) {
 /**
  * Wires an ApplePaySession's shipping callbacks to the shared controller.
  *
- * @param {Object} appleSession     - The live ApplePaySession.
- * @param {Object} args             - The wiring inputs.
- * @param {Object} args.config      - The wc_ppcp_sdk_v6 config object.
- * @param {string} args.displayName - The shop name.
- * @param {Object} args.shipping    - The shared shipping controller.
+ * @param {Object}   appleSession     - The live ApplePaySession.
+ * @param {Object}   args             - The wiring inputs.
+ * @param {Object}   args.config      - The wc_ppcp_sdk_v6 config object.
+ * @param {string}   args.displayName - The shop name.
+ * @param {Object}   args.shipping    - The shared shipping controller.
+ * @param {?Promise} [args.cartReady] - Settles once the cart holds what is being
+ *                                    bought; nothing may be priced before then.
  */
 export function attachShippingHandlers(
 	appleSession,
-	{ config, displayName, shipping }
+	{ config, displayName, shipping, cartReady = null }
 ) {
 	const labels = {
 		subtotal: config.labels?.subtotal ?? 'Subtotal',
@@ -191,6 +193,9 @@ export function attachShippingHandlers(
 	 */
 	async function respond( complete, selection ) {
 		try {
+			// An empty cart offers no rates, so it would reject every address.
+			await cartReady;
+
 			const quote = await shipping.quote( selection );
 
 			if ( ! quote.options.length ) {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.test.js
@@ -1,4 +1,5 @@
 import {
+	applePayFailure,
 	applePayShippingUpdate,
 	applePayUnserviceableUpdate,
 	attachShippingHandlers,
@@ -178,6 +179,52 @@ describe( 'applePayUnserviceableUpdate()', () => {
 		} );
 
 		expect( update.errors ).toEqual( [] );
+	} );
+} );
+
+describe( 'applePayFailure()', () => {
+	afterEach( () => {
+		delete window.ApplePayError;
+	} );
+
+	test( 'reports only the status when the error is not marked user-facing', () => {
+		const result = applePayFailure(
+			new Error( 'Internal failure' ),
+			'STATUS_FAILURE'
+		);
+
+		expect( result ).toEqual( { status: 'STATUS_FAILURE' } );
+	} );
+
+	test( 'adds an ApplePayError carrying the message when the error is user-facing', () => {
+		window.ApplePayError = function ( code, field, message ) {
+			this.code = code;
+			this.field = field;
+			this.message = message;
+		};
+		const error = new Error( 'This card is not supported.' );
+		error.isUserFacing = true;
+
+		const result = applePayFailure( error, 'STATUS_FAILURE' );
+
+		expect( result.status ).toBe( 'STATUS_FAILURE' );
+		expect( result.errors ).toHaveLength( 1 );
+		expect( result.errors[ 0 ] ).toMatchObject( {
+			code: 'unknown',
+			message: 'This card is not supported.',
+		} );
+	} );
+
+	test( 'reports only the status for a user-facing error when ApplePayError is unavailable, as outside a live session', () => {
+		const error = new Error( 'This card is not supported.' );
+		error.isUserFacing = true;
+
+		expect( () =>
+			applePayFailure( error, 'STATUS_FAILURE' )
+		).not.toThrow();
+		expect( applePayFailure( error, 'STATUS_FAILURE' ) ).toEqual( {
+			status: 'STATUS_FAILURE',
+		} );
 	} );
 } );
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePayShipping.test.js
@@ -1,0 +1,321 @@
+import {
+	applePayShippingUpdate,
+	applePayUnserviceableUpdate,
+	attachShippingHandlers,
+} from './applePayShipping';
+
+/**
+ * Drains pending microtasks.
+ *
+ * @return {Promise<void>}
+ */
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+const labels = {
+	subtotal: 'Subtotal',
+	shipping: 'Shipping',
+	tax: 'Tax',
+	discount: 'Discount',
+};
+
+const quote = ( overrides = {} ) => ( {
+	total: '110.50',
+	shippingFee: '5.00',
+	subtotal: '100.00',
+	tax: '5.50',
+	discount: '0.00',
+	selectedId: 'flat_rate:1',
+	options: [
+		{ id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' },
+		{ id: 'flat_rate:2', label: 'Express', cost: '15.00' },
+	],
+	...overrides,
+} );
+
+describe( 'applePayShippingUpdate()', () => {
+	test( 'builds a final total from the quote and the display name', () => {
+		const update = applePayShippingUpdate( quote(), {
+			displayName: 'WooShop',
+			labels,
+		} );
+
+		expect( update.newTotal ).toEqual( {
+			label: 'WooShop',
+			type: 'final',
+			amount: '110.50',
+		} );
+	} );
+
+	test( 'always includes the subtotal line item', () => {
+		const update = applePayShippingUpdate(
+			quote( { shippingFee: '0.00', tax: '0.00', discount: '0.00' } ),
+			{ displayName: 'WooShop', labels }
+		);
+
+		expect( update.newLineItems ).toEqual( [
+			{ label: 'Subtotal', amount: '100.00', type: 'final' },
+		] );
+	} );
+
+	test( 'adds shipping, tax and discount line items only when each is greater than zero, negating the discount', () => {
+		const update = applePayShippingUpdate(
+			quote( {
+				shippingFee: '5.00',
+				tax: '5.50',
+				discount: '2.00',
+			} ),
+			{ displayName: 'WooShop', labels }
+		);
+
+		expect( update.newLineItems ).toEqual( [
+			{ label: 'Subtotal', amount: '100.00', type: 'final' },
+			{ label: 'Shipping', amount: '5.00', type: 'final' },
+			{ label: 'Tax', amount: '5.50', type: 'final' },
+			{ label: 'Discount', amount: '-2.00', type: 'final' },
+		] );
+	} );
+
+	test( 'moves the selected shipping method to the head of the list', () => {
+		const update = applePayShippingUpdate(
+			quote( { selectedId: 'flat_rate:2' } ),
+			{ displayName: 'WooShop', labels }
+		);
+
+		expect( update.newShippingMethods ).toEqual( [
+			{
+				label: 'Express',
+				detail: '',
+				amount: '15.00',
+				identifier: 'flat_rate:2',
+			},
+			{
+				label: 'Flat rate',
+				detail: '',
+				amount: '5.00',
+				identifier: 'flat_rate:1',
+			},
+		] );
+	} );
+
+	test( 'leaves the order unchanged when the first option is already selected', () => {
+		const update = applePayShippingUpdate( quote(), {
+			displayName: 'WooShop',
+			labels,
+		} );
+
+		expect( update.newShippingMethods.map( ( m ) => m.identifier ) ).toEqual( [
+			'flat_rate:1',
+			'flat_rate:2',
+		] );
+	} );
+} );
+
+describe( 'applePayUnserviceableUpdate()', () => {
+	afterEach( () => {
+		delete window.ApplePayError;
+	} );
+
+	test( 'carries the last good total and line items, with no shipping methods', () => {
+		const lastQuote = quote();
+
+		const update = applePayUnserviceableUpdate( lastQuote, {
+			displayName: 'WooShop',
+			labels,
+			message: 'Cannot ship here.',
+		} );
+
+		expect( update.newTotal ).toEqual( {
+			label: 'WooShop',
+			type: 'final',
+			amount: '110.50',
+		} );
+		expect( update.newShippingMethods ).toEqual( [] );
+	} );
+
+	test( 'reports a zero, pending total when no quote has ever priced', () => {
+		const update = applePayUnserviceableUpdate( null, {
+			displayName: 'WooShop',
+			labels,
+			message: 'Cannot ship here.',
+		} );
+
+		expect( update.newTotal ).toEqual( {
+			label: 'WooShop',
+			type: 'pending',
+			amount: '0',
+		} );
+		expect( update.newLineItems ).toEqual( [] );
+		expect( update.newShippingMethods ).toEqual( [] );
+	} );
+
+	test( 'adds an ApplePayError describing the address problem when the class is available', () => {
+		window.ApplePayError = function ( code, field, message ) {
+			this.code = code;
+			this.field = field;
+			this.message = message;
+		};
+
+		const update = applePayUnserviceableUpdate( quote(), {
+			displayName: 'WooShop',
+			labels,
+			message: 'Cannot ship here.',
+		} );
+
+		expect( update.errors ).toHaveLength( 1 );
+		expect( update.errors[ 0 ] ).toMatchObject( {
+			code: 'shippingContactInvalid',
+			field: 'postalAddress',
+			message: 'Cannot ship here.',
+		} );
+	} );
+
+	test( 'reports no errors when ApplePayError is unavailable, as outside a live session', () => {
+		const update = applePayUnserviceableUpdate( quote(), {
+			displayName: 'WooShop',
+			labels,
+			message: 'Cannot ship here.',
+		} );
+
+		expect( update.errors ).toEqual( [] );
+	} );
+} );
+
+function makeAppleSession() {
+	return {
+		completeShippingContactSelection: jest.fn(),
+		completeShippingMethodSelection: jest.fn(),
+		abort: jest.fn(),
+	};
+}
+
+function makeShipping( quoteImpl, current = null ) {
+	return { quote: jest.fn( quoteImpl ), current: jest.fn( () => current ) };
+}
+
+describe( 'attachShippingHandlers()', () => {
+	const config = { labels: { shipping_unserviceable: 'Cannot ship here.' } };
+
+	test( 'onshippingcontactselected maps the contact to a WC address, prices it, and completes with the shipping update', async () => {
+		const appleSession = makeAppleSession();
+		const shipping = makeShipping( async () => quote() );
+
+		attachShippingHandlers( appleSession, {
+			config,
+			displayName: 'WooShop',
+			shipping,
+		} );
+
+		appleSession.onshippingcontactselected( {
+			shippingContact: {
+				countryCode: 'US',
+				administrativeArea: 'CA',
+				postalCode: '94105',
+				locality: 'San Francisco',
+			},
+		} );
+		await flushPromises();
+
+		expect( shipping.quote ).toHaveBeenCalledWith( {
+			address: {
+				country: 'US',
+				state: 'CA',
+				postcode: '94105',
+				city: 'San Francisco',
+			},
+		} );
+		expect(
+			appleSession.completeShippingContactSelection
+		).toHaveBeenCalledWith(
+			applePayShippingUpdate( quote(), {
+				displayName: 'WooShop',
+				labels,
+			} )
+		);
+	} );
+
+	test( 'completes with the unserviceable update, carrying the last good quote, when the address has no options', async () => {
+		window.ApplePayError = function () {};
+		const lastGood = quote();
+		const appleSession = makeAppleSession();
+		const shipping = makeShipping(
+			async () => quote( { options: [], selectedId: null } ),
+			lastGood
+		);
+
+		attachShippingHandlers( appleSession, {
+			config,
+			displayName: 'WooShop',
+			shipping,
+		} );
+
+		appleSession.onshippingcontactselected( { shippingContact: {} } );
+		await flushPromises();
+
+		expect(
+			appleSession.completeShippingContactSelection
+		).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				newShippingMethods: [],
+				errors: expect.any( Array ),
+			} )
+		);
+
+		delete window.ApplePayError;
+	} );
+
+	test( 'onshippingmethodselected resolves the picked rate against the current quote and completes with the shipping update', async () => {
+		const current = quote();
+		const appleSession = makeAppleSession();
+		const shipping = makeShipping(
+			async () => quote( { selectedId: 'flat_rate:2' } ),
+			current
+		);
+
+		attachShippingHandlers( appleSession, {
+			config,
+			displayName: 'WooShop',
+			shipping,
+		} );
+
+		appleSession.onshippingmethodselected( {
+			shippingMethod: { identifier: 'flat_rate:2' },
+		} );
+		await flushPromises();
+
+		expect( shipping.quote ).toHaveBeenCalledWith( {
+			address: null,
+			rateId: 'flat_rate:2',
+		} );
+		expect(
+			appleSession.completeShippingMethodSelection
+		).toHaveBeenCalledWith(
+			applePayShippingUpdate( quote( { selectedId: 'flat_rate:2' } ), {
+				displayName: 'WooShop',
+				labels,
+			} )
+		);
+	} );
+
+	test( 'aborts the session and reports the error when pricing throws', async () => {
+		const appleSession = makeAppleSession();
+		const shipping = makeShipping( async () => {
+			throw new Error( 'Store API down' );
+		} );
+
+		attachShippingHandlers( appleSession, {
+			config,
+			displayName: 'WooShop',
+			shipping,
+		} );
+
+		appleSession.onshippingcontactselected( { shippingContact: {} } );
+		await flushPromises();
+
+		expect( appleSession.abort ).toHaveBeenCalledTimes( 1 );
+		expect(
+			appleSession.completeShippingContactSelection
+		).not.toHaveBeenCalled();
+		expect( console ).toHaveErrored();
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
@@ -10,6 +10,7 @@
  */
 
 import Spinner from '@ppcp-button/Helper/Spinner';
+import { releaseWalletShipping } from '../endpointsAdapter';
 import { hasJQuery } from '../utils/api';
 import { refreshCartUi } from '../utils/cartUi';
 import { handleError } from '../utils/errorHandler';
@@ -21,7 +22,12 @@ import {
 } from './googlePayRequest';
 import { buildPaymentDataCallbacks } from './googlePayShipping';
 import { walletButtonStyle } from './walletButtonStyle';
-import { googlePayPayer, googlePayShippingAddress } from './walletContacts';
+import {
+	googlePayPayer,
+	googlePayShippingAddress,
+	googlePayWcBillingAddress,
+	googlePayWcShippingAddress,
+} from './walletContacts';
 import { payWithWallet } from './walletPayment';
 import { walletConfig, walletFundingSource } from './walletRegistry';
 import {
@@ -143,6 +149,16 @@ export async function renderGooglePay( {
 			// Only after the sheet closes, so it is not covered.
 			spinner?.block();
 
+			// Before the order exists, because it is built from the WC customer
+			// rather than the address posted with the approval. Throws rather
+			// than charge a total the sheet never showed.
+			if ( requiresShipping ) {
+				await shipping.commit(
+					googlePayWcShippingAddress( paymentData ),
+					googlePayWcBillingAddress( paymentData )
+				);
+			}
+
 			await payWithWallet( {
 				config,
 				context,
@@ -159,13 +175,15 @@ export async function renderGooglePay( {
 				contact: {
 					payer: googlePayPayer( paymentData ),
 					shippingAddress: googlePayShippingAddress( paymentData ),
+					shippingRateId: shipping.current()?.selectedId,
 				},
 			} );
 		} catch ( error ) {
 			// A dismissed sheet is not a failure to report, but one that priced
-			// shipping has already written the address and rate to the real cart.
+			// shipping has already written to the real cart and pinned its rate.
 			if ( error?.statusCode === 'CANCELED' ) {
 				if ( requiresShipping ) {
+					await releaseWalletShipping( config ).catch( () => {} );
 					refreshCartUi( context );
 				}
 			} else {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
@@ -11,6 +11,7 @@
 
 import Spinner from '@ppcp-button/Helper/Spinner';
 import { hasJQuery } from '../utils/api';
+import { refreshCartUi } from '../utils/cartUi';
 import { handleError } from '../utils/errorHandler';
 import { loadGoogleSdk } from '../utils/scriptLoaders';
 import { revealWalletGateway } from './gatewayPlacement';
@@ -18,10 +19,16 @@ import {
 	buildPaymentDataRequest,
 	buildReadyToPayRequest,
 } from './googlePayRequest';
+import { buildPaymentDataCallbacks } from './googlePayShipping';
 import { walletButtonStyle } from './walletButtonStyle';
 import { googlePayPayer, googlePayShippingAddress } from './walletContacts';
 import { payWithWallet } from './walletPayment';
 import { walletConfig, walletFundingSource } from './walletRegistry';
+import {
+	createShippingController,
+	walletShippingCountries,
+	walletShippingRequired,
+} from './walletShipping';
 import { resolveWalletTotal } from './walletTotal';
 
 /**
@@ -69,9 +76,23 @@ export async function renderGooglePay( {
 		session.getGooglePayConfig(),
 	] );
 
-	const client = new window.google.payments.api.PaymentsClient( {
-		environment: settings.environment,
-	} );
+	const requiresShipping = walletShippingRequired( config, context );
+	const shipping = createShippingController( { config } );
+
+	const clientOptions = { environment: settings.environment };
+
+	if ( requiresShipping ) {
+		clientOptions.paymentDataCallbacks = buildPaymentDataCallbacks( {
+			config,
+			currencyCode: config.currency,
+			countryCode: config.merchant_country,
+			shipping,
+		} );
+	}
+
+	const client = new window.google.payments.api.PaymentsClient(
+		clientOptions
+	);
 
 	const { result } = await client.isReadyToPay(
 		buildReadyToPayRequest( sessionConfig )
@@ -114,6 +135,8 @@ export async function renderGooglePay( {
 					countryCode: config.merchant_country,
 					currencyCode: config.currency,
 					total,
+					requiresShipping,
+					countries: walletShippingCountries( config ),
 				} )
 			);
 
@@ -139,8 +162,13 @@ export async function renderGooglePay( {
 				},
 			} );
 		} catch ( error ) {
-			// The buyer dismissing the sheet is not a failure to report.
-			if ( error?.statusCode !== 'CANCELED' ) {
+			// A dismissed sheet is not a failure to report, but one that priced
+			// shipping has already written the address and rate to the real cart.
+			if ( error?.statusCode === 'CANCELED' ) {
+				if ( requiresShipping ) {
+					refreshCartUi( context );
+				}
+			} else {
 				handleError( error );
 			}
 		} finally {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.test.js
@@ -25,10 +25,21 @@ jest.mock( './walletPayment', () => ( {
 
 const mockGooglePayPayer = jest.fn();
 const mockGooglePayShippingAddress = jest.fn();
+const mockGooglePayWcShippingAddress = jest.fn();
+const mockGooglePayWcBillingAddress = jest.fn();
 jest.mock( './walletContacts', () => ( {
 	googlePayPayer: ( ...args ) => mockGooglePayPayer( ...args ),
 	googlePayShippingAddress: ( ...args ) =>
 		mockGooglePayShippingAddress( ...args ),
+	googlePayWcShippingAddress: ( ...args ) =>
+		mockGooglePayWcShippingAddress( ...args ),
+	googlePayWcBillingAddress: ( ...args ) =>
+		mockGooglePayWcBillingAddress( ...args ),
+} ) );
+
+const mockReleaseWalletShipping = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	releaseWalletShipping: ( ...args ) => mockReleaseWalletShipping( ...args ),
 } ) );
 
 const mockBuildReadyToPayRequest = jest.fn();
@@ -140,6 +151,7 @@ let mockIsReadyToPay;
 let mockCreateButton;
 let mockLoadPaymentData;
 let createButtonOptions;
+let shippingController;
 
 /**
  * Installs a fake window.google.payments.api.PaymentsClient that records
@@ -196,11 +208,14 @@ beforeEach( () => {
 	mockBuildPaymentDataRequest.mockReturnValue( 'PAYMENT_DATA_REQUEST' );
 	mockWalletShippingRequired.mockReturnValue( false );
 	mockWalletShippingCountries.mockReturnValue( [] );
-	mockCreateShippingController.mockReturnValue( {
+	shippingController = {
 		quote: jest.fn(),
 		current: jest.fn(),
-	} );
+		commit: jest.fn(),
+	};
+	mockCreateShippingController.mockReturnValue( shippingController );
 	mockBuildPaymentDataCallbacks.mockReturnValue( 'PAYMENT_DATA_CALLBACKS' );
+	mockReleaseWalletShipping.mockResolvedValue( undefined );
 	installPaymentsClient();
 } );
 
@@ -402,6 +417,8 @@ describe( 'a click on the rendered button', () => {
 		mockLoadPaymentData.mockResolvedValue( paymentData );
 		mockGooglePayPayer.mockReturnValue( 'PAYER_SENTINEL' );
 		mockGooglePayShippingAddress.mockReturnValue( 'SHIP_SENTINEL' );
+		mockGooglePayWcShippingAddress.mockReturnValue( 'WC_SHIP_SENTINEL' );
+		mockGooglePayWcBillingAddress.mockReturnValue( 'WC_BILLING_SENTINEL' );
 	} );
 
 	test(
@@ -472,8 +489,82 @@ describe( 'a click on the rendered button', () => {
 			contact: {
 				payer: 'PAYER_SENTINEL',
 				shippingAddress: 'SHIP_SENTINEL',
+				shippingRateId: undefined,
 			},
 		} );
+	} );
+
+	test( "carries the selected rate's id into the contact, when this context collects shipping", async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		shippingController.commit.mockResolvedValue( {
+			selectedId: 'flat_rate:2',
+			total: '12.34',
+		} );
+		shippingController.current.mockReturnValue( {
+			selectedId: 'flat_rate:2',
+		} );
+
+		await render( { context: 'cart' } );
+		await createButtonOptions.onClick();
+
+		expect( mockPayWithWallet ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				contact: expect.objectContaining( {
+					shippingRateId: 'flat_rate:2',
+				} ),
+			} )
+		);
+	} );
+
+	test( 'commits the mapped WC shipping and billing addresses before paying, when this context requires shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		const config = baseConfig();
+		const callOrder = [];
+		shippingController.commit.mockImplementationOnce( async () => {
+			callOrder.push( 'commit' );
+			return { selectedId: null, total: '12.34' };
+		} );
+		mockPayWithWallet.mockImplementationOnce( async () => {
+			callOrder.push( 'payWithWallet' );
+		} );
+
+		await render( { config, context: 'cart' } );
+		await createButtonOptions.onClick();
+
+		expect( mockGooglePayWcShippingAddress ).toHaveBeenCalledWith(
+			paymentData
+		);
+		expect( mockGooglePayWcBillingAddress ).toHaveBeenCalledWith(
+			paymentData
+		);
+		expect( shippingController.commit ).toHaveBeenCalledWith(
+			'WC_SHIP_SENTINEL',
+			'WC_BILLING_SENTINEL'
+		);
+		expect( callOrder ).toEqual( [ 'commit', 'payWithWallet' ] );
+	} );
+
+	test( 'never commits a shipping address when this context requires no shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( false );
+		await render( { context: 'product' } );
+
+		await createButtonOptions.onClick();
+
+		expect( shippingController.commit ).not.toHaveBeenCalled();
+		expect( mockPayWithWallet ).toHaveBeenCalled();
+	} );
+
+	test( 'never pays when the committed shipping price no longer matches what the sheet showed', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		shippingController.commit.mockRejectedValueOnce(
+			new Error( 'Shipping price changed after authorization' )
+		);
+
+		await render( { context: 'cart' } );
+		await createButtonOptions.onClick();
+
+		expect( mockPayWithWallet ).not.toHaveBeenCalled();
+		expect( mockHandleError ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test(
@@ -524,24 +615,40 @@ describe( 'a click on the rendered button', () => {
 		}
 	);
 
-	test( 'refreshes the cart UI after a cancelation when this context collected shipping, since the sheet already wrote it to the real cart', async () => {
+	test( 'refreshes the cart UI and releases the held shipping rate after a cancelation when this context collected shipping, since the sheet already wrote it to the real cart', async () => {
 		mockWalletShippingRequired.mockReturnValue( true );
 		mockLoadPaymentData.mockRejectedValueOnce( { statusCode: 'CANCELED' } );
+		const config = baseConfig();
 
-		await render( { context: 'product' } );
+		await render( { config, context: 'product' } );
 		await createButtonOptions.onClick();
 
+		expect( mockReleaseWalletShipping ).toHaveBeenCalledWith( config );
 		expect( mockRefreshCartUi ).toHaveBeenCalledWith( 'product' );
 	} );
 
-	test( 'does not refresh the cart UI after a cancelation when this context never collected shipping', async () => {
+	test( 'does not refresh the cart UI or release shipping after a cancelation when this context never collected shipping', async () => {
 		mockWalletShippingRequired.mockReturnValue( false );
 		mockLoadPaymentData.mockRejectedValueOnce( { statusCode: 'CANCELED' } );
 
 		await render( { context: 'product' } );
 		await createButtonOptions.onClick();
 
+		expect( mockReleaseWalletShipping ).not.toHaveBeenCalled();
 		expect( mockRefreshCartUi ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not let a failed shipping release surface an error on cancelation', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		mockLoadPaymentData.mockRejectedValueOnce( { statusCode: 'CANCELED' } );
+		mockReleaseWalletShipping.mockRejectedValueOnce(
+			new Error( 'release failed' )
+		);
+
+		await render( { context: 'product' } );
+
+		await expect( createButtonOptions.onClick() ).resolves.toBeUndefined();
+		expect( mockHandleError ).not.toHaveBeenCalled();
 	} );
 
 	test( 'blocks the spinner only once the sheet has closed', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.test.js
@@ -45,6 +45,29 @@ jest.mock( './gatewayPlacement', () => ( {
 	revealWalletGateway: ( ...args ) => mockRevealWalletGateway( ...args ),
 } ) );
 
+const mockRefreshCartUi = jest.fn();
+jest.mock( '../utils/cartUi', () => ( {
+	refreshCartUi: ( ...args ) => mockRefreshCartUi( ...args ),
+} ) );
+
+const mockWalletShippingRequired = jest.fn( () => false );
+const mockWalletShippingCountries = jest.fn( () => [] );
+const mockCreateShippingController = jest.fn();
+jest.mock( './walletShipping', () => ( {
+	walletShippingRequired: ( ...args ) =>
+		mockWalletShippingRequired( ...args ),
+	walletShippingCountries: ( ...args ) =>
+		mockWalletShippingCountries( ...args ),
+	createShippingController: ( ...args ) =>
+		mockCreateShippingController( ...args ),
+} ) );
+
+const mockBuildPaymentDataCallbacks = jest.fn();
+jest.mock( './googlePayShipping', () => ( {
+	buildPaymentDataCallbacks: ( ...args ) =>
+		mockBuildPaymentDataCallbacks( ...args ),
+} ) );
+
 const mockSpinnerBlock = jest.fn();
 const mockSpinnerUnblock = jest.fn();
 jest.mock(
@@ -171,6 +194,13 @@ beforeEach( () => {
 	mockLoadGoogleSdk.mockResolvedValue( undefined );
 	mockBuildReadyToPayRequest.mockReturnValue( 'READY_REQUEST' );
 	mockBuildPaymentDataRequest.mockReturnValue( 'PAYMENT_DATA_REQUEST' );
+	mockWalletShippingRequired.mockReturnValue( false );
+	mockWalletShippingCountries.mockReturnValue( [] );
+	mockCreateShippingController.mockReturnValue( {
+		quote: jest.fn(),
+		current: jest.fn(),
+	} );
+	mockBuildPaymentDataCallbacks.mockReturnValue( 'PAYMENT_DATA_CALLBACKS' );
 	installPaymentsClient();
 } );
 
@@ -203,15 +233,39 @@ describe( 'renderGooglePay()', () => {
 
 	test(
 		'constructs PaymentsClient with the config environment ' +
-			'and no paymentDataCallbacks',
+			'and no paymentDataCallbacks when this context collects no shipping',
 		async () => {
 			const config = baseConfig();
 			config.google_pay.environment = 'PRODUCTION';
+			mockWalletShippingRequired.mockReturnValue( false );
 
 			await render( { config } );
 
 			expect( paymentsClientOptions ).toEqual( {
 				environment: 'PRODUCTION',
+			} );
+		}
+	);
+
+	test(
+		'constructs PaymentsClient with the built paymentDataCallbacks ' +
+			'when this context collects shipping, since Google rejects callbacks added later',
+		async () => {
+			const config = baseConfig();
+			mockWalletShippingRequired.mockReturnValue( true );
+
+			await render( { config, context: 'cart' } );
+
+			expect( mockBuildPaymentDataCallbacks ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					config,
+					currencyCode: config.currency,
+					countryCode: config.merchant_country,
+				} )
+			);
+			expect( paymentsClientOptions ).toEqual( {
+				environment: config.google_pay.environment,
+				paymentDataCallbacks: 'PAYMENT_DATA_CALLBACKS',
 			} );
 		}
 	);
@@ -369,6 +423,8 @@ describe( 'a click on the rendered button', () => {
 					countryCode: config.merchant_country,
 					currencyCode: config.currency,
 					total: '12.34',
+					requiresShipping: false,
+					countries: [],
 				}
 			);
 			expect( mockLoadPaymentData ).toHaveBeenCalledWith(
@@ -376,6 +432,23 @@ describe( 'a click on the rendered button', () => {
 			);
 		}
 	);
+
+	test( "forwards this context's shipping requirement and the store's shippable countries into the payment data request", async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		mockWalletShippingCountries.mockReturnValue( [ 'US', 'CA' ] );
+		const config = baseConfig();
+
+		await render( { config, context: 'cart' } );
+		await createButtonOptions.onClick();
+
+		expect( mockBuildPaymentDataRequest ).toHaveBeenCalledWith(
+			sessionConfig,
+			expect.objectContaining( {
+				requiresShipping: true,
+				countries: [ 'US', 'CA' ],
+			} )
+		);
+	} );
 
 	test( 'pays with the resolved units, confirm data and mapped contact', async () => {
 		const config = baseConfig();
@@ -450,6 +523,26 @@ describe( 'a click on the rendered button', () => {
 			expect( mockPayWithWallet ).not.toHaveBeenCalled();
 		}
 	);
+
+	test( 'refreshes the cart UI after a cancelation when this context collected shipping, since the sheet already wrote it to the real cart', async () => {
+		mockWalletShippingRequired.mockReturnValue( true );
+		mockLoadPaymentData.mockRejectedValueOnce( { statusCode: 'CANCELED' } );
+
+		await render( { context: 'product' } );
+		await createButtonOptions.onClick();
+
+		expect( mockRefreshCartUi ).toHaveBeenCalledWith( 'product' );
+	} );
+
+	test( 'does not refresh the cart UI after a cancelation when this context never collected shipping', async () => {
+		mockWalletShippingRequired.mockReturnValue( false );
+		mockLoadPaymentData.mockRejectedValueOnce( { statusCode: 'CANCELED' } );
+
+		await render( { context: 'product' } );
+		await createButtonOptions.onClick();
+
+		expect( mockRefreshCartUi ).not.toHaveBeenCalled();
+	} );
 
 	test( 'blocks the spinner only once the sheet has closed', async () => {
 		// spinner.block() must run after loadPaymentData resolves, or it

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.js
@@ -27,6 +27,32 @@ export function buildReadyToPayRequest( sessionConfig ) {
 }
 
 /**
+ * The card method with a complete billing address requested.
+ *
+ * Google's default is a MIN address: a name, a country and a postal code. A store
+ * taxing on the billing address needs the state too.
+ *
+ * Cloned rather than mutated: the same config object also renders the button.
+ *
+ * @param {Object[]} allowedPaymentMethods - The session config's methods.
+ * @return {Object[]} The methods, card billing address requested.
+ */
+function withBillingAddress( allowedPaymentMethods ) {
+	return allowedPaymentMethods.map( ( method ) =>
+		method?.type === 'CARD'
+			? {
+					...method,
+					parameters: {
+						...method.parameters,
+						billingAddressRequired: true,
+						billingAddressParameters: { format: 'FULL' },
+					},
+			  }
+			: method
+	);
+}
+
+/**
  * Builds the loadPaymentData request that opens the payment sheet.
  *
  * With shipping on, the PaymentsClient must also carry an onPaymentDataChanged
@@ -57,7 +83,9 @@ export function buildPaymentDataRequest(
 ) {
 	const request = {
 		...API_VERSION,
-		allowedPaymentMethods: sessionConfig.allowedPaymentMethods,
+		allowedPaymentMethods: withBillingAddress(
+			sessionConfig.allowedPaymentMethods
+		),
 		merchantInfo: sessionConfig.merchantInfo,
 		transactionInfo: {
 			countryCode,

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.js
@@ -1,18 +1,12 @@
 /**
- * Builders for the two request objects Google's PaymentsClient takes.
- *
- * Both live here because the wallet bridge needs them together: one to decide
- * whether to render a button at all, one to open the sheet.
- *
- * Pure: no DOM, no SDK, no network, so the request shape is unit-testable.
+ * Builders for the two request objects Google's PaymentsClient takes: one to
+ * decide whether to render a button at all, one to open the sheet.
  *
  * @package
  */
 
-/**
- * Fixed rather than read from the session config, which carries only the major
- * version while Google requires both.
- */
+// Fixed rather than read from the session config, which carries only the major
+// version while Google requires both.
 const API_VERSION = {
 	apiVersion: 2,
 	apiVersionMinor: 0,
@@ -35,24 +29,31 @@ export function buildReadyToPayRequest( sessionConfig ) {
 /**
  * Builds the loadPaymentData request that opens the payment sheet.
  *
- * Shipping on requires the caller to also pass an onPaymentDataChanged
- * callback, or Google rejects the request. It does not restrict countries via
- * shippingAddressParameters yet. Shipping off: the address comes off the
- * payment token instead, see walletContacts.js.
+ * With shipping on, the PaymentsClient must also carry an onPaymentDataChanged
+ * callback or Google rejects the request. With it off, the address comes off the
+ * payment token instead; see walletContacts.js.
  *
- * @param {Object}  sessionConfig                     - The v6 session config, from
- *                                                      formatConfigForPaymentRequest().
- * @param {Object}  transaction                       - What the buyer is about to pay.
- * @param {string}  transaction.countryCode           - The merchant country.
- * @param {string}  transaction.currencyCode          - The shop currency.
- * @param {string}  transaction.total                 - The total as a decimal string.
- * @param {boolean} [transaction.requiresShipping]    - Whether to collect shipping
- *                                                      in the sheet.
+ * @param {Object}   sessionConfig                  - The v6 session config, from
+ *                                                    formatConfigForPaymentRequest().
+ * @param {Object}   transaction                    - What the buyer is about to pay.
+ * @param {string}   transaction.countryCode        - The merchant country.
+ * @param {string}   transaction.currencyCode       - The shop currency.
+ * @param {string}   transaction.total              - The total as a decimal string.
+ * @param {boolean}  [transaction.requiresShipping] - Whether to collect shipping
+ *                                                    in the sheet.
+ * @param {string[]} [transaction.countries]        - Shippable countries, when the
+ *                                                    store restricts them.
  * @return {Object} The loadPaymentData request.
  */
 export function buildPaymentDataRequest(
 	sessionConfig,
-	{ countryCode, currencyCode, total, requiresShipping = false }
+	{
+		countryCode,
+		currencyCode,
+		total,
+		requiresShipping = false,
+		countries = [],
+	}
 ) {
 	const request = {
 		...API_VERSION,
@@ -67,14 +68,21 @@ export function buildPaymentDataRequest(
 		emailRequired: true,
 	};
 
-	// Omitted rather than sent empty: Google pairs callbackIntents with the
-	// PaymentsClient's paymentDataCallbacks, and rejects loadPaymentData with
-	// "paymentDataCallbacks must be set" whenever the key is present at all,
-	// an empty array included. The shipping flags default to false.
+	// Omitted rather than sent empty: Google rejects loadPaymentData with
+	// "paymentDataCallbacks must be set" whenever callbackIntents is present
+	// at all, an empty array included.
 	if ( requiresShipping ) {
 		request.callbackIntents = [ 'SHIPPING_ADDRESS', 'SHIPPING_OPTION' ];
 		request.shippingAddressRequired = true;
 		request.shippingOptionRequired = true;
+		request.shippingAddressParameters = {
+			phoneNumberRequired: true,
+		};
+
+		// An exhaustive list would tell Google nothing.
+		if ( countries.length ) {
+			request.shippingAddressParameters.allowedCountryCodes = countries;
+		}
 	}
 
 	return request;

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.test.js
@@ -160,4 +160,55 @@ describe( 'buildPaymentDataRequest()', () => {
 		expect( request ).not.toHaveProperty( 'shippingAddressParameters' );
 		expect( request ).not.toHaveProperty( 'callbackIntents' );
 	} );
+
+	test( 'requests a full billing address on the card payment method, keeping its other parameters', () => {
+		const allowedPaymentMethods = [
+			{
+				type: 'CARD',
+				parameters: { allowedCardNetworks: [ 'VISA', 'MASTERCARD' ] },
+			},
+		];
+
+		const request = buildPaymentDataRequest(
+			sessionConfig( { allowedPaymentMethods } ),
+			transaction()
+		);
+
+		expect( request.allowedPaymentMethods[ 0 ] ).toEqual( {
+			type: 'CARD',
+			parameters: {
+				allowedCardNetworks: [ 'VISA', 'MASTERCARD' ],
+				billingAddressRequired: true,
+				billingAddressParameters: { format: 'FULL' },
+			},
+		} );
+	} );
+
+	test( 'leaves non-card payment methods untouched', () => {
+		const allowedPaymentMethods = [
+			{ type: 'PAYPAL', parameters: { purchase_context: {} } },
+		];
+
+		const request = buildPaymentDataRequest(
+			sessionConfig( { allowedPaymentMethods } ),
+			transaction()
+		);
+
+		expect( request.allowedPaymentMethods[ 0 ] ).toEqual(
+			allowedPaymentMethods[ 0 ]
+		);
+	} );
+
+	test( 'does not mutate the session config allowedPaymentMethods, since the same object also renders the button', () => {
+		const allowedPaymentMethods = [
+			{ type: 'CARD', parameters: { allowedCardNetworks: [ 'VISA' ] } },
+		];
+		const config = sessionConfig( { allowedPaymentMethods } );
+
+		buildPaymentDataRequest( config, transaction() );
+
+		expect( config.allowedPaymentMethods ).toEqual( [
+			{ type: 'CARD', parameters: { allowedCardNetworks: [ 'VISA' ] } },
+		] );
+	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayRequest.test.js
@@ -121,4 +121,43 @@ describe( 'buildPaymentDataRequest()', () => {
 		expect( request.shippingAddressRequired ).toBe( true );
 		expect( request.shippingOptionRequired ).toBe( true );
 	} );
+
+	test( 'always requires a phone number when shipping is requested', () => {
+		const request = buildPaymentDataRequest(
+			sessionConfig(),
+			transaction( { requiresShipping: true } )
+		);
+
+		expect( request.shippingAddressParameters ).toEqual(
+			expect.objectContaining( { phoneNumberRequired: true } )
+		);
+	} );
+
+	test( 'restricts the shippable countries only when the store supplies a non-empty list', () => {
+		const restricted = buildPaymentDataRequest(
+			sessionConfig(),
+			transaction( { requiresShipping: true, countries: [ 'US', 'CA' ] } )
+		);
+		const unrestricted = buildPaymentDataRequest(
+			sessionConfig(),
+			transaction( { requiresShipping: true, countries: [] } )
+		);
+
+		expect( restricted.shippingAddressParameters.allowedCountryCodes ).toEqual(
+			[ 'US', 'CA' ]
+		);
+		expect(
+			unrestricted.shippingAddressParameters
+		).not.toHaveProperty( 'allowedCountryCodes' );
+	} );
+
+	test( 'omits the entire shipping block, including shippingAddressParameters, when shipping is not requested', () => {
+		const request = buildPaymentDataRequest(
+			sessionConfig(),
+			transaction( { countries: [ 'US' ] } )
+		);
+
+		expect( request ).not.toHaveProperty( 'shippingAddressParameters' );
+		expect( request ).not.toHaveProperty( 'callbackIntents' );
+	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.js
@@ -1,0 +1,147 @@
+/**
+ * Google Pay's in-sheet shipping callback.
+ *
+ * Translates between Google's paymentDataCallbacks protocol and the shared
+ * shipping quote; everything about pricing lives in walletShipping.js.
+ *
+ * @package
+ */
+
+import { resolveOptionId } from './shippingQuote';
+import { walletAddressToWc } from './walletContacts';
+
+// Google rejects newShippingOptionParameters on a SHIPPING_OPTION trigger: the
+// shopper is picking from the list it already has.
+const OPTION_LIST_TRIGGERS = [ 'INITIALIZE', 'SHIPPING_ADDRESS' ];
+
+/**
+ * Formats a rate cost into the option's description.
+ *
+ * Google renders no price of its own beside a shipping option, so without this
+ * the shopper cannot tell the options apart by cost.
+ *
+ * @param {string} cost         - The cost as a decimal string.
+ * @param {string} currencyCode - The shop currency.
+ * @return {string} The formatted cost.
+ */
+function formatCost( cost, currencyCode ) {
+	const amount = parseFloat( cost );
+
+	if ( isNaN( amount ) ) {
+		return '';
+	}
+
+	try {
+		return new Intl.NumberFormat( undefined, {
+			style: 'currency',
+			currency: currencyCode,
+		} ).format( amount );
+	} catch ( error ) {
+		// An unknown currency code must not take the sheet down with it.
+		return `${ cost } ${ currencyCode }`;
+	}
+}
+
+/**
+ * Maps a quote's options to Google's shape.
+ *
+ * Stripped to the three keys Google accepts: it throws on any other.
+ *
+ * @param {Object} quote        - The shipping quote.
+ * @param {string} currencyCode - The shop currency.
+ * @return {Object[]} Google shipping options.
+ */
+function googleOptions( quote, currencyCode ) {
+	return quote.options.map( ( option ) => ( {
+		id: option.id,
+		label: option.label,
+		description: formatCost( option.cost, currencyCode ),
+	} ) );
+}
+
+/**
+ * Builds the paymentDataCallbacks for a Google Pay sheet that collects shipping.
+ *
+ * Must be handed to the PaymentsClient constructor: Google does not accept
+ * callbacks added to an existing client.
+ *
+ * @param {Object}   args              - The callback inputs.
+ * @param {Object}   args.config       - The wc_ppcp_sdk_v6 config object.
+ * @param {string}   args.currencyCode - The shop currency.
+ * @param {string}   args.countryCode  - The merchant country.
+ * @param {Object}   args.shipping     - The shared shipping controller.
+ * @param {Function} [args.onQuote]    - Called with every fresh quote.
+ * @return {Object} The paymentDataCallbacks object.
+ */
+export function buildPaymentDataCallbacks( {
+	config,
+	currencyCode,
+	countryCode,
+	shipping,
+	onQuote,
+} ) {
+	return {
+		onPaymentDataChanged: async ( paymentData ) => {
+			const address = walletAddressToWc( paymentData.shippingAddress );
+
+			let quote;
+
+			try {
+				// Priced without an option first: which options exist
+				// depends on the address just picked.
+				quote = await shipping.quote( { address } );
+
+				const rateId = resolveOptionId(
+					quote,
+					paymentData.shippingOptionData?.id
+				);
+
+				if ( rateId && rateId !== quote.selectedId ) {
+					quote = await shipping.quote( { address, rateId } );
+				}
+			} catch ( error ) {
+				// Rethrown so Google keeps the sheet open on its own message;
+				// a toast would be hidden behind the sheet anyway.
+				// eslint-disable-next-line no-console
+				console.error(
+					'[PPCP SDK v6] Google Pay shipping update failed: ' +
+						error.message
+				);
+				throw error;
+			}
+
+			onQuote?.( quote, address );
+
+			if ( ! quote.options.length ) {
+				return {
+					error: {
+						reason: 'SHIPPING_ADDRESS_UNSERVICEABLE',
+						intent: 'SHIPPING_ADDRESS',
+						message: config.labels?.shipping_unserviceable ?? '',
+					},
+				};
+			}
+
+			const update = {
+				newTransactionInfo: {
+					countryCode,
+					currencyCode,
+					totalPriceStatus: 'FINAL',
+					totalPrice: quote.total,
+				},
+			};
+
+			if (
+				OPTION_LIST_TRIGGERS.includes( paymentData.callbackTrigger )
+			) {
+				update.newShippingOptionParameters = {
+					defaultSelectedOptionId:
+						quote.selectedId ?? quote.options[ 0 ].id,
+					shippingOptions: googleOptions( quote, currencyCode ),
+				};
+			}
+
+			return update;
+		},
+	};
+}

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.js
@@ -87,18 +87,17 @@ export function buildPaymentDataCallbacks( {
 			let quote;
 
 			try {
-				// Priced without an option first: which options exist
-				// depends on the address just picked.
-				quote = await shipping.quote( { address } );
-
-				const rateId = resolveOptionId(
-					quote,
-					paymentData.shippingOptionData?.id
-				);
-
-				if ( rateId && rateId !== quote.selectedId ) {
-					quote = await shipping.quote( { address, rateId } );
-				}
+				// One request for both, so the options and the total describe the
+				// same cart. Resolved against the previous quote, since the new
+				// destination's options are not known yet; the endpoint answers
+				// with the rate it actually applied.
+				quote = await shipping.quote( {
+					address,
+					rateId: resolveOptionId(
+						shipping.current(),
+						paymentData.shippingOptionData?.id
+					),
+				} );
 			} catch ( error ) {
 				// Rethrown so Google keeps the sheet open on its own message;
 				// a toast would be hidden behind the sheet anyway.

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.test.js
@@ -1,0 +1,155 @@
+import { buildPaymentDataCallbacks } from './googlePayShipping';
+
+const config = ( overrides = {} ) => ( {
+	labels: { shipping_unserviceable: 'We cannot ship to this address.' },
+	...overrides,
+} );
+
+const quote = ( overrides = {} ) => ( {
+	total: '10.00',
+	selectedId: 'flat_rate:1',
+	options: [
+		{ id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' },
+		{ id: 'flat_rate:2', label: 'Express', cost: '15.00' },
+	],
+	...overrides,
+} );
+
+const paymentData = ( overrides = {} ) => ( {
+	shippingAddress: {
+		countryCode: 'US',
+		administrativeArea: 'CA',
+		postalCode: '94105',
+		locality: 'San Francisco',
+	},
+	callbackTrigger: 'INITIALIZE',
+	...overrides,
+} );
+
+function makeShipping( implementation ) {
+	return { quote: jest.fn( implementation ) };
+}
+
+function callbacks( { shipping, currencyCode = 'USD', countryCode = 'US', overrideConfig } ) {
+	return buildPaymentDataCallbacks( {
+		config: overrideConfig ?? config(),
+		currencyCode,
+		countryCode,
+		shipping,
+	} ).onPaymentDataChanged;
+}
+
+describe( 'buildPaymentDataCallbacks().onPaymentDataChanged()', () => {
+	test( 'prices the address, then answers with the transaction total and mapped options', async () => {
+		const shipping = makeShipping( async () => quote() );
+
+		const result = await callbacks( { shipping } )( paymentData() );
+
+		expect( shipping.quote ).toHaveBeenCalledTimes( 1 );
+		expect( result.newTransactionInfo ).toEqual( {
+			countryCode: 'US',
+			currencyCode: 'USD',
+			totalPriceStatus: 'FINAL',
+			totalPrice: '10.00',
+		} );
+		expect( result.newShippingOptionParameters ).toEqual( {
+			defaultSelectedOptionId: 'flat_rate:1',
+			shippingOptions: [
+				{ id: 'flat_rate:1', label: 'Flat rate', description: '$5.00' },
+				{ id: 'flat_rate:2', label: 'Express', description: '$15.00' },
+			],
+		} );
+	} );
+
+	test( 're-quotes with the resolved rate when the shopper picked an option other than the default', async () => {
+		const answers = [
+			quote( { selectedId: 'flat_rate:1' } ),
+			quote( { selectedId: 'flat_rate:2', total: '20.00' } ),
+		];
+		const shipping = makeShipping( async () => answers.shift() );
+
+		const result = await callbacks( { shipping } )(
+			paymentData( { shippingOptionData: { id: 'flat_rate:2' } } )
+		);
+
+		expect( shipping.quote ).toHaveBeenCalledTimes( 2 );
+		expect( shipping.quote ).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining( { rateId: 'flat_rate:2' } )
+		);
+		expect( result.newTransactionInfo.totalPrice ).toBe( '20.00' );
+	} );
+
+	test( 'does not re-quote when the requested option already matches the quote', async () => {
+		const shipping = makeShipping( async () => quote() );
+
+		await callbacks( { shipping } )(
+			paymentData( { shippingOptionData: { id: 'flat_rate:1' } } )
+		);
+
+		expect( shipping.quote ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( "treats Google's unselected sentinel as no request, and does not re-quote", async () => {
+		const shipping = makeShipping( async () => quote() );
+
+		await callbacks( { shipping } )(
+			paymentData( {
+				shippingOptionData: { id: 'shipping_option_unselected' },
+			} )
+		);
+
+		expect( shipping.quote ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'answers with SHIPPING_ADDRESS_UNSERVICEABLE when the address has no shippable options', async () => {
+		const shipping = makeShipping( async () =>
+			quote( { options: [], selectedId: null } )
+		);
+
+		const result = await callbacks( {
+			shipping,
+			overrideConfig: config( {
+				labels: { shipping_unserviceable: 'Cannot ship here.' },
+			} ),
+		} )( paymentData() );
+
+		expect( result ).toEqual( {
+			error: {
+				reason: 'SHIPPING_ADDRESS_UNSERVICEABLE',
+				intent: 'SHIPPING_ADDRESS',
+				message: 'Cannot ship here.',
+			},
+		} );
+	} );
+
+	test.each( [
+		[ 'INITIALIZE', true ],
+		[ 'SHIPPING_ADDRESS', true ],
+		[ 'SHIPPING_OPTION', false ],
+	] )(
+		'includes newShippingOptionParameters for trigger %s: %s',
+		async ( trigger, included ) => {
+			const shipping = makeShipping( async () => quote() );
+
+			const result = await callbacks( { shipping } )(
+				paymentData( { callbackTrigger: trigger } )
+			);
+
+			expect( 'newShippingOptionParameters' in result ).toBe(
+				included
+			);
+		}
+	);
+
+	test( 'rethrows when pricing the address fails', async () => {
+		const shipping = makeShipping( async () => {
+			throw new Error( 'cart down' );
+		} );
+
+		await expect(
+			callbacks( { shipping } )( paymentData() )
+		).rejects.toThrow( 'cart down' );
+		expect( console ).toHaveErrored();
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePayShipping.test.js
@@ -26,8 +26,11 @@ const paymentData = ( overrides = {} ) => ( {
 	...overrides,
 } );
 
-function makeShipping( implementation ) {
-	return { quote: jest.fn( implementation ) };
+function makeShipping( implementation, current = null ) {
+	return {
+		quote: jest.fn( implementation ),
+		current: jest.fn( () => current ),
+	};
 }
 
 function callbacks( { shipping, currencyCode = 'USD', countryCode = 'US', overrideConfig } ) {
@@ -61,37 +64,35 @@ describe( 'buildPaymentDataCallbacks().onPaymentDataChanged()', () => {
 		} );
 	} );
 
-	test( 're-quotes with the resolved rate when the shopper picked an option other than the default', async () => {
-		const answers = [
-			quote( { selectedId: 'flat_rate:1' } ),
-			quote( { selectedId: 'flat_rate:2', total: '20.00' } ),
-		];
-		const shipping = makeShipping( async () => answers.shift() );
+	test( "prices the address against the sheet's picked option, resolved from the previous quote", async () => {
+		const shipping = makeShipping(
+			async () => quote( { selectedId: 'flat_rate:2', total: '20.00' } ),
+			quote()
+		);
 
 		const result = await callbacks( { shipping } )(
 			paymentData( { shippingOptionData: { id: 'flat_rate:2' } } )
 		);
 
-		expect( shipping.quote ).toHaveBeenCalledTimes( 2 );
-		expect( shipping.quote ).toHaveBeenNthCalledWith(
-			2,
+		expect( shipping.quote ).toHaveBeenCalledTimes( 1 );
+		expect( shipping.quote ).toHaveBeenCalledWith(
 			expect.objectContaining( { rateId: 'flat_rate:2' } )
 		);
 		expect( result.newTransactionInfo.totalPrice ).toBe( '20.00' );
 	} );
 
-	test( 'does not re-quote when the requested option already matches the quote', async () => {
-		const shipping = makeShipping( async () => quote() );
+	test( "falls back to the previous quote's selected rate when the sheet reports no option", async () => {
+		const shipping = makeShipping( async () => quote(), quote() );
 
-		await callbacks( { shipping } )(
-			paymentData( { shippingOptionData: { id: 'flat_rate:1' } } )
+		await callbacks( { shipping } )( paymentData() );
+
+		expect( shipping.quote ).toHaveBeenCalledWith(
+			expect.objectContaining( { rateId: 'flat_rate:1' } )
 		);
-
-		expect( shipping.quote ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( "treats Google's unselected sentinel as no request, and does not re-quote", async () => {
-		const shipping = makeShipping( async () => quote() );
+	test( "treats Google's unselected sentinel as no request, falling back to the previous selection", async () => {
+		const shipping = makeShipping( async () => quote(), quote() );
 
 		await callbacks( { shipping } )(
 			paymentData( {
@@ -99,7 +100,9 @@ describe( 'buildPaymentDataCallbacks().onPaymentDataChanged()', () => {
 			} )
 		);
 
-		expect( shipping.quote ).toHaveBeenCalledTimes( 1 );
+		expect( shipping.quote ).toHaveBeenCalledWith(
+			expect.objectContaining( { rateId: 'flat_rate:1' } )
+		);
 	} );
 
 	test( 'answers with SHIPPING_ADDRESS_UNSERVICEABLE when the address has no shippable options', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/wallets/renderWallets.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/renderWallets.js
@@ -21,6 +21,10 @@ const RENDERERS = {
 	[ FundingSources.APPLEPAY ]: renderApplePay,
 };
 
+// The pages that print a payment-method list a wallet can own a row in. PHP
+// mirrors this and already refuses a gateway elsewhere.
+const CONTEXTS_WITH_GATEWAY_ROWS = [ 'checkout', 'pay-now' ];
+
 /**
  * Renders every wallet that is switched on and has somewhere to render.
  *
@@ -58,9 +62,9 @@ function resolveTarget( wrapper, gateway, context ) {
 		return wrapper;
 	}
 
-	// One row, one button: the mini-cart target would otherwise resolve the same
-	// container and render a second one into it.
-	if ( 'checkout' !== context ) {
+	// One row, one button: on a page with rows, the mini-cart target would
+	// otherwise resolve the same container and render a second button into it.
+	if ( ! CONTEXTS_WITH_GATEWAY_ROWS.includes( context ) ) {
 		return null;
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.js
@@ -1,0 +1,116 @@
+/**
+ * Normalises the WC Store API cart into the one shipping shape every wallet
+ * adapter reads.
+ *
+ * @package
+ */
+
+import { minorUnitsToDecimal } from '../utils/amount';
+
+// What Google sends as the option id before the shopper has picked one.
+const GOOGLE_UNSELECTED = 'shipping_option_unselected';
+
+/**
+ * @typedef {Object} ShippingOption
+ * @property {string} id    - The WC rate id, e.g. flat_rate:3.
+ * @property {string} label - The method name, shopper-facing.
+ * @property {string} cost  - The cost as a decimal string; each sheet formats it.
+ */
+
+/**
+ * @typedef {Object} ShippingQuote
+ * @property {string}           total         - What the sheet displays and the order charges.
+ * @property {string}           shippingFee   - The shipping portion of the total.
+ * @property {string}           subtotal      - Items before shipping and tax.
+ * @property {string}           tax           - Total tax.
+ * @property {string}           discount      - Total discount, non-negative.
+ * @property {boolean}          needsShipping - Whether anything needs shipping at all.
+ * @property {?string}          selectedId    - The rate WC currently has chosen.
+ * @property {ShippingOption[]} options       - The rates the shopper may pick.
+ */
+
+let warnedAboutPackages = false;
+
+/**
+ * Normalises a WC Store API cart into a quote.
+ *
+ * Store API amounts are minor-unit integers carrying their own exponent, so a
+ * plain divide by 100 would break 3-decimal currencies.
+ *
+ * Only the first shipping package is read: neither pay sheet can express a
+ * per-package choice; PayPal does not support this either.
+ *
+ * @param {?Object} cart - The Store API cart response.
+ * @return {ShippingQuote} The normalised quote.
+ */
+export function quoteFromCart( cart ) {
+	const totals = cart?.totals ?? {};
+	const minorUnit = totals.currency_minor_unit;
+	const toDecimal = ( value ) => minorUnitsToDecimal( value, minorUnit );
+
+	const packages = Array.isArray( cart?.shipping_rates )
+		? cart.shipping_rates
+		: [];
+
+	if ( packages.length > 1 && ! warnedAboutPackages ) {
+		warnedAboutPackages = true;
+		// eslint-disable-next-line no-console
+		console.warn(
+			'[PPCP SDK v6] the cart has more than one shipping package; the payment sheet shows the first only.'
+		);
+	}
+
+	const rates = packages[ 0 ]?.shipping_rates ?? [];
+
+	const options = rates.map( ( rate ) => ( {
+		id: String( rate.rate_id ?? '' ),
+		label: String( rate.name ?? '' ),
+		// Each rate carries its own exponent, which need not match the cart's.
+		cost: minorUnitsToDecimal( rate.price, rate.currency_minor_unit ),
+	} ) );
+
+	const selected = rates.find( ( rate ) => rate.selected );
+
+	return {
+		total: toDecimal( totals.total_price ),
+		shippingFee: toDecimal( totals.total_shipping ),
+		subtotal: toDecimal( totals.total_items ),
+		tax: toDecimal( totals.total_tax ),
+		discount: toDecimal( totals.total_discount ),
+		needsShipping: Boolean( cart?.needs_shipping ),
+		selectedId: selected ? String( selected.rate_id ) : null,
+		options,
+	};
+}
+
+/**
+ * Resolves which option a sheet's selection refers to.
+ *
+ * The sheet may name a rate that no longer exists after an address change, or
+ * none at all, so the request never carries an id the cart cannot honour.
+ *
+ * @param {ShippingQuote} quote         - The quote to resolve against.
+ * @param {?string}       [requestedId] - What the sheet reported.
+ * @return {?string} A usable rate id, or null when there is none.
+ */
+export function resolveOptionId( quote, requestedId ) {
+	const options = quote?.options ?? [];
+
+	if ( ! options.length ) {
+		return null;
+	}
+
+	if ( requestedId && requestedId !== GOOGLE_UNSELECTED ) {
+		const match = options.find( ( option ) => option.id === requestedId );
+
+		if ( match ) {
+			return match.id;
+		}
+	}
+
+	if ( quote.selectedId ) {
+		return quote.selectedId;
+	}
+
+	return options[ 0 ].id;
+}

--- a/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.js
@@ -1,11 +1,8 @@
 /**
- * Normalises the WC Store API cart into the one shipping shape every wallet
- * adapter reads.
+ * Normalises a shipping quote into the one shape every wallet adapter reads.
  *
  * @package
  */
-
-import { minorUnitsToDecimal } from '../utils/amount';
 
 // What Google sends as the option id before the shopper has picked one.
 const GOOGLE_UNSELECTED = 'shipping_option_unselected';
@@ -29,57 +26,25 @@ const GOOGLE_UNSELECTED = 'shipping_option_unselected';
  * @property {ShippingOption[]} options       - The rates the shopper may pick.
  */
 
-let warnedAboutPackages = false;
-
 /**
- * Normalises a WC Store API cart into a quote.
+ * Normalises the wallet-shipping endpoint's response into a quote.
  *
- * Store API amounts are minor-unit integers carrying their own exponent, so a
- * plain divide by 100 would break 3-decimal currencies.
+ * Every figure is already a decimal string at the shop's precision, and the total
+ * is the one the purchase unit will carry, so nothing is recomputed here.
  *
- * Only the first shipping package is read: neither pay sheet can express a
- * per-package choice; PayPal does not support this either.
- *
- * @param {?Object} cart - The Store API cart response.
+ * @param {?Object} data - The ppc-sdk-v6-wallet-shipping response.
  * @return {ShippingQuote} The normalised quote.
  */
-export function quoteFromCart( cart ) {
-	const totals = cart?.totals ?? {};
-	const minorUnit = totals.currency_minor_unit;
-	const toDecimal = ( value ) => minorUnitsToDecimal( value, minorUnit );
-
-	const packages = Array.isArray( cart?.shipping_rates )
-		? cart.shipping_rates
-		: [];
-
-	if ( packages.length > 1 && ! warnedAboutPackages ) {
-		warnedAboutPackages = true;
-		// eslint-disable-next-line no-console
-		console.warn(
-			'[PPCP SDK v6] the cart has more than one shipping package; the payment sheet shows the first only.'
-		);
-	}
-
-	const rates = packages[ 0 ]?.shipping_rates ?? [];
-
-	const options = rates.map( ( rate ) => ( {
-		id: String( rate.rate_id ?? '' ),
-		label: String( rate.name ?? '' ),
-		// Each rate carries its own exponent, which need not match the cart's.
-		cost: minorUnitsToDecimal( rate.price, rate.currency_minor_unit ),
-	} ) );
-
-	const selected = rates.find( ( rate ) => rate.selected );
-
+export function quoteFromResponse( data ) {
 	return {
-		total: toDecimal( totals.total_price ),
-		shippingFee: toDecimal( totals.total_shipping ),
-		subtotal: toDecimal( totals.total_items ),
-		tax: toDecimal( totals.total_tax ),
-		discount: toDecimal( totals.total_discount ),
-		needsShipping: Boolean( cart?.needs_shipping ),
-		selectedId: selected ? String( selected.rate_id ) : null,
-		options,
+		total: data?.total ?? '',
+		shippingFee: data?.shipping_fee ?? '',
+		subtotal: data?.subtotal ?? '',
+		tax: data?.tax ?? '',
+		discount: data?.discount ?? '',
+		needsShipping: Boolean( data?.needs_shipping ),
+		selectedId: data?.selected_rate_id || null,
+		options: Array.isArray( data?.options ) ? data.options : [],
 	};
 }
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.test.js
@@ -1,0 +1,193 @@
+import { quoteFromCart, resolveOptionId } from './shippingQuote';
+
+const cart = ( overrides = {} ) => ( {
+	needs_shipping: true,
+	totals: {
+		total_price: '11050',
+		total_shipping: '500',
+		total_items: '10000',
+		total_tax: '550',
+		total_discount: '0',
+		currency_minor_unit: 2,
+	},
+	shipping_rates: [
+		{
+			shipping_rates: [
+				{
+					rate_id: 'flat_rate:1',
+					name: 'Flat rate',
+					price: '500',
+					currency_minor_unit: 2,
+					selected: true,
+				},
+				{
+					rate_id: 'flat_rate:2',
+					name: 'Express',
+					price: '1500',
+					currency_minor_unit: 2,
+					selected: false,
+				},
+			],
+		},
+	],
+	...overrides,
+} );
+
+describe( 'quoteFromCart()', () => {
+	test( 'normalises the Store API totals into decimal strings', () => {
+		const quote = quoteFromCart( cart() );
+
+		expect( quote.total ).toBe( '110.50' );
+		expect( quote.shippingFee ).toBe( '5.00' );
+		expect( quote.subtotal ).toBe( '100.00' );
+		expect( quote.tax ).toBe( '5.50' );
+		expect( quote.discount ).toBe( '0.00' );
+	} );
+
+	test( 'carries needsShipping straight from the cart', () => {
+		expect( quoteFromCart( cart( { needs_shipping: true } ) ).needsShipping ).toBe(
+			true
+		);
+		expect(
+			quoteFromCart( cart( { needs_shipping: false } ) ).needsShipping
+		).toBe( false );
+	} );
+
+	test( 'maps the first package rates to options, each with its own exponent', () => {
+		const quote = quoteFromCart(
+			cart( {
+				shipping_rates: [
+					{
+						shipping_rates: [
+							{
+								rate_id: 'flat_rate:1',
+								name: 'Flat rate',
+								price: '500',
+								currency_minor_unit: 3,
+								selected: true,
+							},
+						],
+					},
+				],
+			} )
+		);
+
+		expect( quote.options ).toEqual( [
+			{ id: 'flat_rate:1', label: 'Flat rate', cost: '0.500' },
+		] );
+	} );
+
+	test( 'reports the selected rate id, or null when nothing is selected', () => {
+		expect( quoteFromCart( cart() ).selectedId ).toBe( 'flat_rate:1' );
+
+		const noneSelected = cart();
+		noneSelected.shipping_rates[ 0 ].shipping_rates.forEach(
+			( rate ) => ( rate.selected = false )
+		);
+		expect( quoteFromCart( noneSelected ).selectedId ).toBeNull();
+	} );
+
+	test( 'reads only the first shipping package when there is more than one', () => {
+		const quote = quoteFromCart(
+			cart( {
+				shipping_rates: [
+					{
+						shipping_rates: [
+							{
+								rate_id: 'flat_rate:1',
+								name: 'Flat rate',
+								price: '500',
+								currency_minor_unit: 2,
+								selected: true,
+							},
+						],
+					},
+					{
+						shipping_rates: [
+							{
+								rate_id: 'flat_rate:9',
+								name: 'Second package rate',
+								price: '900',
+								currency_minor_unit: 2,
+								selected: false,
+							},
+						],
+					},
+				],
+			} )
+		);
+
+		expect( quote.options ).toEqual( [
+			{ id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' },
+		] );
+		expect( console ).toHaveWarned();
+	} );
+
+	test( 'does not throw and returns empty totals/options for a null cart', () => {
+		expect( () => quoteFromCart( null ) ).not.toThrow();
+
+		const quote = quoteFromCart( null );
+
+		expect( quote.total ).toBe( '' );
+		expect( quote.needsShipping ).toBe( false );
+		expect( quote.selectedId ).toBeNull();
+		expect( quote.options ).toEqual( [] );
+	} );
+
+	test( 'returns no options when the cart has no shipping packages', () => {
+		const quote = quoteFromCart( cart( { shipping_rates: [] } ) );
+
+		expect( quote.options ).toEqual( [] );
+		expect( quote.selectedId ).toBeNull();
+	} );
+} );
+
+describe( 'resolveOptionId()', () => {
+	const quote = ( overrides = {} ) => ( {
+		selectedId: 'flat_rate:1',
+		options: [
+			{ id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' },
+			{ id: 'flat_rate:2', label: 'Express', cost: '15.00' },
+		],
+		...overrides,
+	} );
+
+	test( 'returns null when the quote has no options at all', () => {
+		expect(
+			resolveOptionId( quote( { options: [] } ), 'flat_rate:1' )
+		).toBeNull();
+	} );
+
+	test( 'returns the requested id when it matches an existing option', () => {
+		expect( resolveOptionId( quote(), 'flat_rate:2' ) ).toBe(
+			'flat_rate:2'
+		);
+	} );
+
+	test( "treats Google's unselected sentinel as no request and falls back to the current selection", () => {
+		expect(
+			resolveOptionId( quote(), 'shipping_option_unselected' )
+		).toBe( 'flat_rate:1' );
+	} );
+
+	test( 'falls back to the current selection when the requested id no longer exists', () => {
+		expect( resolveOptionId( quote(), 'flat_rate:stale' ) ).toBe(
+			'flat_rate:1'
+		);
+	} );
+
+	test( 'falls back to the first option when nothing is requested and nothing is selected', () => {
+		expect(
+			resolveOptionId( quote( { selectedId: null } ), null )
+		).toBe( 'flat_rate:1' );
+	} );
+
+	test( 'falls back to the first option when neither the request nor the current selection can be honoured', () => {
+		expect(
+			resolveOptionId(
+				quote( { selectedId: null } ),
+				'flat_rate:stale'
+			)
+		).toBe( 'flat_rate:1' );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/shippingQuote.test.js
@@ -1,144 +1,63 @@
-import { quoteFromCart, resolveOptionId } from './shippingQuote';
+import { quoteFromResponse, resolveOptionId } from './shippingQuote';
 
-const cart = ( overrides = {} ) => ( {
-	needs_shipping: true,
-	totals: {
-		total_price: '11050',
-		total_shipping: '500',
-		total_items: '10000',
-		total_tax: '550',
-		total_discount: '0',
-		currency_minor_unit: 2,
-	},
-	shipping_rates: [
-		{
-			shipping_rates: [
-				{
-					rate_id: 'flat_rate:1',
-					name: 'Flat rate',
-					price: '500',
-					currency_minor_unit: 2,
-					selected: true,
-				},
-				{
-					rate_id: 'flat_rate:2',
-					name: 'Express',
-					price: '1500',
-					currency_minor_unit: 2,
-					selected: false,
-				},
+describe( 'quoteFromResponse()', () => {
+	const response = ( overrides = {} ) => ( {
+		total: '110.50',
+		shipping_fee: '5.00',
+		subtotal: '100.00',
+		tax: '5.50',
+		discount: '0.00',
+		needs_shipping: true,
+		selected_rate_id: 'flat_rate:1',
+		options: [ { id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' } ],
+		...overrides,
+	} );
+
+	test( 'maps the snake_case endpoint fields onto the camelCase quote shape', () => {
+		expect( quoteFromResponse( response() ) ).toEqual( {
+			total: '110.50',
+			shippingFee: '5.00',
+			subtotal: '100.00',
+			tax: '5.50',
+			discount: '0.00',
+			needsShipping: true,
+			selectedId: 'flat_rate:1',
+			options: [
+				{ id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' },
 			],
-		},
-	],
-	...overrides,
-} );
-
-describe( 'quoteFromCart()', () => {
-	test( 'normalises the Store API totals into decimal strings', () => {
-		const quote = quoteFromCart( cart() );
-
-		expect( quote.total ).toBe( '110.50' );
-		expect( quote.shippingFee ).toBe( '5.00' );
-		expect( quote.subtotal ).toBe( '100.00' );
-		expect( quote.tax ).toBe( '5.50' );
-		expect( quote.discount ).toBe( '0.00' );
+		} );
 	} );
 
-	test( 'carries needsShipping straight from the cart', () => {
-		expect( quoteFromCart( cart( { needs_shipping: true } ) ).needsShipping ).toBe(
-			true
-		);
+	test.each( [
+		[ 'null', null ],
+		[ 'an empty string', '' ],
+		[ 'undefined', undefined ],
+	] )(
+		'reports selectedId as null when selected_rate_id is %s',
+		( label, selectedRateId ) => {
+			expect(
+				quoteFromResponse(
+					response( { selected_rate_id: selectedRateId } )
+				).selectedId
+			).toBeNull();
+		}
+	);
+
+	test( 'defaults options to an empty list when the response carries none', () => {
 		expect(
-			quoteFromCart( cart( { needs_shipping: false } ) ).needsShipping
-		).toBe( false );
+			quoteFromResponse( response( { options: undefined } ) ).options
+		).toEqual( [] );
 	} );
 
-	test( 'maps the first package rates to options, each with its own exponent', () => {
-		const quote = quoteFromCart(
-			cart( {
-				shipping_rates: [
-					{
-						shipping_rates: [
-							{
-								rate_id: 'flat_rate:1',
-								name: 'Flat rate',
-								price: '500',
-								currency_minor_unit: 3,
-								selected: true,
-							},
-						],
-					},
-				],
-			} )
-		);
+	test( 'does not throw and returns empty totals/options for a null response', () => {
+		expect( () => quoteFromResponse( null ) ).not.toThrow();
 
-		expect( quote.options ).toEqual( [
-			{ id: 'flat_rate:1', label: 'Flat rate', cost: '0.500' },
-		] );
-	} );
-
-	test( 'reports the selected rate id, or null when nothing is selected', () => {
-		expect( quoteFromCart( cart() ).selectedId ).toBe( 'flat_rate:1' );
-
-		const noneSelected = cart();
-		noneSelected.shipping_rates[ 0 ].shipping_rates.forEach(
-			( rate ) => ( rate.selected = false )
-		);
-		expect( quoteFromCart( noneSelected ).selectedId ).toBeNull();
-	} );
-
-	test( 'reads only the first shipping package when there is more than one', () => {
-		const quote = quoteFromCart(
-			cart( {
-				shipping_rates: [
-					{
-						shipping_rates: [
-							{
-								rate_id: 'flat_rate:1',
-								name: 'Flat rate',
-								price: '500',
-								currency_minor_unit: 2,
-								selected: true,
-							},
-						],
-					},
-					{
-						shipping_rates: [
-							{
-								rate_id: 'flat_rate:9',
-								name: 'Second package rate',
-								price: '900',
-								currency_minor_unit: 2,
-								selected: false,
-							},
-						],
-					},
-				],
-			} )
-		);
-
-		expect( quote.options ).toEqual( [
-			{ id: 'flat_rate:1', label: 'Flat rate', cost: '5.00' },
-		] );
-		expect( console ).toHaveWarned();
-	} );
-
-	test( 'does not throw and returns empty totals/options for a null cart', () => {
-		expect( () => quoteFromCart( null ) ).not.toThrow();
-
-		const quote = quoteFromCart( null );
+		const quote = quoteFromResponse( null );
 
 		expect( quote.total ).toBe( '' );
 		expect( quote.needsShipping ).toBe( false );
 		expect( quote.selectedId ).toBeNull();
 		expect( quote.options ).toEqual( [] );
-	} );
-
-	test( 'returns no options when the cart has no shipping packages', () => {
-		const quote = quoteFromCart( cart( { shipping_rates: [] } ) );
-
-		expect( quote.options ).toEqual( [] );
-		expect( quote.selectedId ).toBeNull();
 	} );
 } );
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.js
@@ -35,6 +35,99 @@ export function walletAddressToWc( source ) {
 }
 
 /**
+ * Maps an authorized wallet address to complete WC address fields.
+ *
+ * The street and the recipient are known only once the buyer authorizes. Writing
+ * them completes the customer record, which is what PurchaseUnitFactory sends to
+ * PayPal: an incomplete one is dropped (no street, no city or no postcode), and a
+ * stale one would ship the order to whatever address WooCommerce already held.
+ *
+ * @param {Object}   source         - A wallet address or contact.
+ * @param {string[]} addressLines   - Its street lines, most significant first.
+ * @param {string}   [fullName]     - The recipient, as the wallet spells it.
+ * @return {Object} WC address fields.
+ */
+function walletAddressToWcComplete( source, addressLines, fullName ) {
+	const [ firstName, lastName ] = splitFullName( fullName ?? '' );
+
+	return {
+		...walletAddressToWc( source ),
+		address_1: addressLines?.[ 0 ] || '',
+		address_2: addressLines?.[ 1 ] || '',
+		first_name: firstName,
+		last_name: lastName,
+	};
+}
+
+/**
+ * The complete WC shipping address from a Google Pay payment response.
+ *
+ * @param {Object} response - The Google Pay payment response.
+ * @return {Object} WC address fields.
+ */
+export function googlePayWcShippingAddress( response ) {
+	const shipping = response?.shippingAddress;
+
+	return walletAddressToWcComplete(
+		shipping,
+		[ shipping?.address1, shipping?.address2 ],
+		shipping?.name
+	);
+}
+
+/**
+ * The complete WC billing address from a Google Pay payment response.
+ *
+ * The card's own billing address, which is what the order is created with. Known
+ * only at authorization, so the sheet's own quotes cannot price against it: send
+ * it with the final quote and the cart then taxes on the basis the order will.
+ *
+ * @param {Object} response - The Google Pay payment response.
+ * @return {Object} WC address fields.
+ */
+export function googlePayWcBillingAddress( response ) {
+	const billing = response?.paymentMethodData?.info?.billingAddress;
+
+	return walletAddressToWcComplete(
+		billing,
+		[ billing?.address1, billing?.address2 ],
+		billing?.name
+	);
+}
+
+/**
+ * The complete WC shipping address from an authorized Apple Pay payment.
+ *
+ * @param {Object} payment - The ApplePayPayment from onpaymentauthorized.
+ * @return {Object} WC address fields.
+ */
+export function applePayWcShippingAddress( payment ) {
+	const shipping = payment?.shippingContact;
+
+	return walletAddressToWcComplete(
+		shipping,
+		shipping?.addressLines,
+		applePayFullName( shipping )
+	);
+}
+
+/**
+ * The complete WC billing address from an authorized Apple Pay payment.
+ *
+ * @param {Object} payment - The ApplePayPayment from onpaymentauthorized.
+ * @return {Object} WC address fields.
+ */
+export function applePayWcBillingAddress( payment ) {
+	const billing = payment?.billingContact;
+
+	return walletAddressToWcComplete(
+		billing,
+		billing?.addressLines,
+		applePayFullName( billing )
+	);
+}
+
+/**
  * Maps a wallet address to the PayPal address shape.
  *
  * Both wallets name every field the same way bar the street, which they are asked

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.js
@@ -14,6 +14,27 @@
 import { splitFullName } from '../utils/name';
 
 /**
+ * Maps a wallet address to WC address fields, for pricing shipping.
+ *
+ * Only the four fields a shipping zone resolves from, which is all either sheet
+ * exposes before authorization: Apple redacts the street. The Store API merges
+ * partial addresses, so the omitted ones are not cleared.
+ *
+ * `administrativeArea` must land on `state`, or state-scoped zones stop matching.
+ *
+ * @param {Object} source - A wallet address or contact.
+ * @return {Object} WC address fields.
+ */
+export function walletAddressToWc( source ) {
+	return {
+		country: source?.countryCode || '',
+		state: source?.administrativeArea || '',
+		postcode: source?.postalCode || '',
+		city: source?.locality || '',
+	};
+}
+
+/**
  * Maps a wallet address to the PayPal address shape.
  *
  * Both wallets name every field the same way bar the street, which they are asked
@@ -53,8 +74,8 @@ function googlePayAddress( data ) {
  */
 export function googlePayPayer( response ) {
 	const billing = response?.paymentMethodData?.info?.billingAddress;
-	// Defaulted rather than assumed present: a sheet that collects no billing
-	// address must not take the payment down with a TypeError.
+	// splitFullName() trims, so a sheet without a billing address must not reach
+	// it undefined.
 	const [ givenName, surname ] = splitFullName( billing?.name ?? '' );
 
 	return {
@@ -70,8 +91,8 @@ export function googlePayPayer( response ) {
 /**
  * Derives the PayPal shipping address from a Google Pay payment response.
  *
- * Falls back to the billing address: with the shipping callbacks disabled the
- * sheet returns no shippingAddress, and a physical-goods order still needs one.
+ * Falls back to the billing address: where the sheet collects no shipping it
+ * returns no shippingAddress, and a physical-goods order still needs one.
  *
  * @param {Object} response - The Google Pay payment response.
  * @return {Object} The PayPal shipping address.
@@ -116,9 +137,8 @@ function applePayFullName( contact ) {
 /**
  * Derives the PayPal payer from an authorized Apple Pay payment.
  *
- * Apple sends the name pre-split as givenName/familyName, so no splitting is
- * needed. It never returns a billing email or phone, so those come off the
- * shipping contact.
+ * Apple never returns a billing email or phone, so those come off the shipping
+ * contact.
  *
  * @param {Object} payment - The ApplePayPayment from onpaymentauthorized.
  * @return {Object} The PayPal payer.
@@ -140,16 +160,14 @@ export function applePayPayer( payment ) {
 /**
  * Derives the PayPal shipping address from an authorized Apple Pay payment.
  *
- * Falls back to the billing contact: on classic checkout no postal address is
- * requested in the sheet, and a physical-goods order still needs one.
+ * Falls back to the billing contact when the shipping one carries no postal
+ * address, which is the classic checkout sheet: it asks only for an email and
+ * phone, and a physical-goods order still needs somewhere to ship.
  *
  * @param {Object} payment - The ApplePayPayment from onpaymentauthorized.
  * @return {Object} The PayPal shipping address.
  */
 export function applePayShippingAddress( payment ) {
-	// Only the postal half falls back: a shippingContact that carries just an
-	// email and phone (which is all the checkout sheet asks for) has no address
-	// to ship to, so the billing one stands in.
 	const shipping = payment?.shippingContact?.countryCode
 		? payment.shippingContact
 		: payment?.billingContact;

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.test.js
@@ -3,7 +3,45 @@ import {
 	googlePayShippingAddress,
 	applePayPayer,
 	applePayShippingAddress,
+	walletAddressToWc,
 } from './walletContacts';
+
+describe( 'walletAddressToWc()', () => {
+	test( 'maps countryCode/administrativeArea/postalCode/locality to WC address fields', () => {
+		expect(
+			walletAddressToWc( {
+				countryCode: 'US',
+				administrativeArea: 'CA',
+				postalCode: '94105',
+				locality: 'San Francisco',
+			} )
+		).toEqual( {
+			country: 'US',
+			state: 'CA',
+			postcode: '94105',
+			city: 'San Francisco',
+		} );
+	} );
+
+	test( 'defaults every field to an empty string when the source carries none of them', () => {
+		expect( walletAddressToWc( {} ) ).toEqual( {
+			country: '',
+			state: '',
+			postcode: '',
+			city: '',
+		} );
+	} );
+
+	test( 'does not throw and defaults every field when the source is absent', () => {
+		expect( () => walletAddressToWc( null ) ).not.toThrow();
+		expect( walletAddressToWc( undefined ) ).toEqual( {
+			country: '',
+			state: '',
+			postcode: '',
+			city: '',
+		} );
+	} );
+} );
 
 const googlePayResponse = ( overrides = {} ) => ( {
 	email: 'jane@example.test',

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletContacts.test.js
@@ -1,8 +1,12 @@
 import {
 	googlePayPayer,
 	googlePayShippingAddress,
+	googlePayWcShippingAddress,
+	googlePayWcBillingAddress,
 	applePayPayer,
 	applePayShippingAddress,
+	applePayWcShippingAddress,
+	applePayWcBillingAddress,
 	walletAddressToWc,
 } from './walletContacts';
 
@@ -153,6 +157,100 @@ describe( 'googlePayShippingAddress', () => {
 	} );
 } );
 
+describe( 'googlePayWcShippingAddress', () => {
+	test( 'maps the shippingAddress to complete WC fields, including administrativeArea to state', () => {
+		const address = googlePayWcShippingAddress( {
+			shippingAddress: {
+				name: 'Jane Van Doe',
+				countryCode: 'US',
+				address1: 'WooVille 12',
+				address2: 'Suite 4',
+				administrativeArea: 'IA',
+				locality: 'Des Moines',
+				postalCode: '12862',
+			},
+		} );
+
+		expect( address ).toEqual( {
+			country: 'US',
+			state: 'IA',
+			postcode: '12862',
+			city: 'Des Moines',
+			address_1: 'WooVille 12',
+			address_2: 'Suite 4',
+			first_name: 'Jane Van',
+			last_name: 'Doe',
+		} );
+	} );
+
+	test( 'defaults every field to an empty string when shippingAddress is absent', () => {
+		expect( googlePayWcShippingAddress( {} ) ).toEqual( {
+			country: '',
+			state: '',
+			postcode: '',
+			city: '',
+			address_1: '',
+			address_2: '',
+			first_name: '',
+			last_name: '',
+		} );
+	} );
+
+	test( 'does not throw when the response is absent', () => {
+		expect( () => googlePayWcShippingAddress( null ) ).not.toThrow();
+		expect( () => googlePayWcShippingAddress( undefined ) ).not.toThrow();
+	} );
+} );
+
+describe( 'googlePayWcBillingAddress', () => {
+	test( 'maps the billing address to complete WC fields, including administrativeArea to state', () => {
+		const address = googlePayWcBillingAddress( {
+			paymentMethodData: {
+				info: {
+					billingAddress: {
+						name: 'Jane Van Doe',
+						countryCode: 'US',
+						address1: 'WooVille 12',
+						address2: 'Suite 4',
+						administrativeArea: 'IA',
+						locality: 'Des Moines',
+						postalCode: '12862',
+					},
+				},
+			},
+		} );
+
+		expect( address ).toEqual( {
+			country: 'US',
+			state: 'IA',
+			postcode: '12862',
+			city: 'Des Moines',
+			address_1: 'WooVille 12',
+			address_2: 'Suite 4',
+			first_name: 'Jane Van',
+			last_name: 'Doe',
+		} );
+	} );
+
+	test( 'defaults every field to an empty string when the wallet returns no billing address', () => {
+		expect( googlePayWcBillingAddress( {} ) ).toEqual( {
+			country: '',
+			state: '',
+			postcode: '',
+			city: '',
+			address_1: '',
+			address_2: '',
+			first_name: '',
+			last_name: '',
+		} );
+	} );
+
+	test( 'does not throw when the response is absent', () => {
+		expect( () => googlePayWcBillingAddress( null ) ).not.toThrow();
+		expect( () => googlePayWcBillingAddress( undefined ) ).not.toThrow();
+	} );
+} );
+
 const applePayPayment = ( overrides = {} ) => ( {
 	billingContact: {
 		givenName: 'Jane',
@@ -255,5 +353,95 @@ describe( 'applePayShippingAddress', () => {
 
 		expect( shipping.name.full_name ).toBeUndefined();
 		expect( shipping.address.country_code ).toBe( 'US' );
+	} );
+} );
+
+describe( 'applePayWcShippingAddress', () => {
+	test( 'maps the shippingContact to complete WC fields, including administrativeArea to state', () => {
+		const address = applePayWcShippingAddress( {
+			shippingContact: {
+				givenName: 'Jane',
+				familyName: 'Doe',
+				countryCode: 'US',
+				addressLines: [ 'WooVille 12', 'Suite 4' ],
+				administrativeArea: 'IA',
+				locality: 'Des Moines',
+				postalCode: '12862',
+			},
+		} );
+
+		expect( address ).toEqual( {
+			country: 'US',
+			state: 'IA',
+			postcode: '12862',
+			city: 'Des Moines',
+			address_1: 'WooVille 12',
+			address_2: 'Suite 4',
+			first_name: 'Jane',
+			last_name: 'Doe',
+		} );
+	} );
+
+	test( 'defaults every field to an empty string when shippingContact is absent', () => {
+		expect( applePayWcShippingAddress( {} ) ).toEqual( {
+			country: '',
+			state: '',
+			postcode: '',
+			city: '',
+			address_1: '',
+			address_2: '',
+			first_name: '',
+			last_name: '',
+		} );
+	} );
+
+	test( 'does not throw when the payment is absent', () => {
+		expect( () => applePayWcShippingAddress( null ) ).not.toThrow();
+		expect( () => applePayWcShippingAddress( undefined ) ).not.toThrow();
+	} );
+} );
+
+describe( 'applePayWcBillingAddress', () => {
+	test( 'maps the billingContact to complete WC fields, including administrativeArea to state', () => {
+		const address = applePayWcBillingAddress( {
+			billingContact: {
+				givenName: 'Jane',
+				familyName: 'Doe',
+				countryCode: 'US',
+				addressLines: [ 'WooVille 12', 'Suite 4' ],
+				administrativeArea: 'IA',
+				locality: 'Des Moines',
+				postalCode: '12862',
+			},
+		} );
+
+		expect( address ).toEqual( {
+			country: 'US',
+			state: 'IA',
+			postcode: '12862',
+			city: 'Des Moines',
+			address_1: 'WooVille 12',
+			address_2: 'Suite 4',
+			first_name: 'Jane',
+			last_name: 'Doe',
+		} );
+	} );
+
+	test( 'defaults every field to an empty string when the wallet returns no billing contact', () => {
+		expect( applePayWcBillingAddress( {} ) ).toEqual( {
+			country: '',
+			state: '',
+			postcode: '',
+			city: '',
+			address_1: '',
+			address_2: '',
+			first_name: '',
+			last_name: '',
+		} );
+	} );
+
+	test( 'does not throw when the payment is absent', () => {
+		expect( () => applePayWcBillingAddress( null ) ).not.toThrow();
+		expect( () => applePayWcBillingAddress( undefined ) ).not.toThrow();
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js
@@ -1,0 +1,107 @@
+/**
+ * Quoting shipping for an open wallet payment sheet.
+ *
+ * The sheet asks mid-payment, before any PayPal order exists, so it cannot use the
+ * popup's handlers in sessions/shippingHandler.js: those patch an order that is not
+ * there yet. Each selection is written to the real cart instead, and the Store API
+ * answers cart routes with the full cart, so the write and the read are one request
+ * and the sheet's total is what ppc-create-order will charge.
+ *
+ * Wallet-agnostic; the per-wallet files translate a quote into their own sheet shape.
+ *
+ * @package
+ */
+
+import {
+	fetchCart,
+	selectShippingRate,
+	updateCustomerAddress,
+} from '../endpointsAdapter';
+import { quoteFromCart } from './shippingQuote';
+
+/**
+ * Whether the sheet in this context collects shipping.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} context - The page context.
+ * @return {boolean} True when the sheet must ask for an address.
+ */
+export function walletShippingRequired( config, context ) {
+	return Boolean( config.shipping?.in_context?.[ context ] );
+}
+
+/**
+ * The countries the sheet may offer, or an empty list when unrestricted.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {string[]} ISO-2 country codes.
+ */
+export function walletShippingCountries( config ) {
+	return config.shipping?.countries ?? [];
+}
+
+/**
+ * Creates the shipping controller for one render of one wallet button.
+ *
+ * Every quote writes to the shopper's real cart, so rapid selections are chained
+ * rather than merely raced, and a superseded one resolves against the newest answer.
+ *
+ * @param {Object} args        - The controller inputs.
+ * @param {Object} args.config - The wc_ppcp_sdk_v6 config object.
+ * @return {Object} The controller.
+ */
+export function createShippingController( { config } ) {
+	let writeChain = Promise.resolve();
+	let latestRequest = 0;
+
+	// Also read back through current(): Apple must be handed a total even while it
+	// is rejecting an address.
+	let lastQuote = null;
+
+	/**
+	 * Prices a selection, keeping the result as the sheet's current answer.
+	 *
+	 * The rate is selected after the address, because which rates a destination
+	 * offers is only known once the address is set.
+	 *
+	 * @param {Object}  selection          - What the sheet reported.
+	 * @param {Object}  selection.address  - WC address fields.
+	 * @param {?string} [selection.rateId] - The rate the sheet selected.
+	 * @return {Promise<Object>} The quote for the newest selection.
+	 */
+	function quote( { address, rateId = null } ) {
+		const request = ++latestRequest;
+
+		// Swallowed, so one failed selection does not skip the next one.
+		writeChain = writeChain.catch( () => {} ).then( async () => {
+			// Superseded while queued; the newer request speaks for it.
+			if ( request !== latestRequest ) {
+				return;
+			}
+
+			// Writing an empty address would blank the one WooCommerce holds.
+			let cart = address?.country
+				? await updateCustomerAddress( config, address )
+				: await fetchCart( config );
+
+			if ( rateId ) {
+				cart = await selectShippingRate( config, rateId );
+			}
+
+			lastQuote = quoteFromCart( cart );
+		} );
+
+		return writeChain.then( () => {
+			if ( ! lastQuote ) {
+				throw new Error( 'Shipping could not be priced.' );
+			}
+
+			return lastQuote;
+		} );
+	}
+
+	return {
+		quote,
+		current: () => lastQuote,
+	};
+}

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js
@@ -22,6 +22,10 @@ import { quoteFromCart } from './shippingQuote';
 /**
  * Whether the sheet in this context collects shipping.
  *
+ * Decided per context by PHP. Where it is true the sheet's address becomes the
+ * WC order's, because approveOrder() creates that order itself rather than
+ * submitting the form the page may carry.
+ *
  * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
  * @param {string} context - The page context.
  * @return {boolean} True when the sheet must ask for an address.

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.js
@@ -3,21 +3,17 @@
  *
  * The sheet asks mid-payment, before any PayPal order exists, so it cannot use the
  * popup's handlers in sessions/shippingHandler.js: those patch an order that is not
- * there yet. Each selection is written to the real cart instead, and the Store API
- * answers cart routes with the full cart, so the write and the read are one request
- * and the sheet's total is what ppc-create-order will charge.
+ * there yet. Each selection goes to the real cart through ppc-sdk-v6-wallet-shipping,
+ * which applies the address and the rate together and answers with the total the
+ * purchase unit will carry, so the sheet shows what ppc-create-order charges.
  *
  * Wallet-agnostic; the per-wallet files translate a quote into their own sheet shape.
  *
  * @package
  */
 
-import {
-	fetchCart,
-	selectShippingRate,
-	updateCustomerAddress,
-} from '../endpointsAdapter';
-import { quoteFromCart } from './shippingQuote';
+import { quoteWalletShipping } from '../endpointsAdapter';
+import { quoteFromResponse } from './shippingQuote';
 
 /**
  * Whether the sheet in this context collects shipping.
@@ -65,15 +61,21 @@ export function createShippingController( { config } ) {
 	/**
 	 * Prices a selection, keeping the result as the sheet's current answer.
 	 *
-	 * The rate is selected after the address, because which rates a destination
-	 * offers is only known once the address is set.
-	 *
-	 * @param {Object}  selection          - What the sheet reported.
-	 * @param {Object}  selection.address  - WC address fields.
-	 * @param {?string} [selection.rateId] - The rate the sheet selected.
+	 * @param {Object}  selection                  - What the sheet reported.
+	 * @param {Object}  selection.address          - WC shipping address fields.
+	 * @param {?string} [selection.rateId]         - The rate the sheet selected.
+	 * @param {?Object} [selection.billingAddress] - The card's billing address, at
+	 *                                             commit time only.
+	 * @param {?string} [selection.expectedTotal]  - The total to hold the server to,
+	 *                                             at commit time only.
 	 * @return {Promise<Object>} The quote for the newest selection.
 	 */
-	function quote( { address, rateId = null } ) {
+	function quote( {
+		address,
+		rateId = null,
+		billingAddress = null,
+		expectedTotal = null,
+	} ) {
 		const request = ++latestRequest;
 
 		// Swallowed, so one failed selection does not skip the next one.
@@ -83,16 +85,14 @@ export function createShippingController( { config } ) {
 				return;
 			}
 
-			// Writing an empty address would blank the one WooCommerce holds.
-			let cart = address?.country
-				? await updateCustomerAddress( config, address )
-				: await fetchCart( config );
-
-			if ( rateId ) {
-				cart = await selectShippingRate( config, rateId );
-			}
-
-			lastQuote = quoteFromCart( cart );
+			lastQuote = quoteFromResponse(
+				await quoteWalletShipping( config, {
+					address,
+					rateId,
+					billingAddress,
+					expectedTotal,
+				} )
+			);
 		} );
 
 		return writeChain.then( () => {
@@ -104,8 +104,37 @@ export function createShippingController( { config } ) {
 		} );
 	}
 
+	/**
+	 * Applies the authorized addresses and takes the server's verdict on the price.
+	 *
+	 * Authorization is the first point where the shipping street, the recipient and
+	 * the card's billing address are known, so this is the first and last quote
+	 * priced on exactly the basis the order will be created with.
+	 *
+	 * The total the sheet displayed goes with it, and the endpoint refuses a higher
+	 * one: the shopper is charged the correct tax, and never more than they
+	 * approved. Comparing there rather than here leaves nothing to bypass.
+	 *
+	 * @param {Object}  address          - Complete WC shipping address fields.
+	 * @param {?Object} [billingAddress] - The card's WC billing address.
+	 * @return {Promise<Object>} The committed quote.
+	 * @throws {Error} When the endpoint refuses the new total.
+	 */
+	function commit( address, billingAddress = null ) {
+		return quote( {
+			address,
+			rateId: lastQuote?.selectedId ?? null,
+			// Mirrors WooCommerceOrderCreator::configure_addresses(), which bills
+			// to the shipping address when the wallet reports none. Pricing has to
+			// use whichever of the two the order will, not merely a plausible one.
+			billingAddress: billingAddress?.country ? billingAddress : address,
+			expectedTotal: lastQuote?.total ?? null,
+		} );
+	}
+
 	return {
 		quote,
+		commit,
 		current: () => lastQuote,
 	};
 }

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.test.js
@@ -1,15 +1,11 @@
-const mockUpdateCustomerAddress = jest.fn();
-const mockSelectShippingRate = jest.fn();
-const mockFetchCart = jest.fn();
+const mockQuoteWalletShipping = jest.fn();
 jest.mock( '../endpointsAdapter', () => ( {
-	updateCustomerAddress: ( ...args ) => mockUpdateCustomerAddress( ...args ),
-	selectShippingRate: ( ...args ) => mockSelectShippingRate( ...args ),
-	fetchCart: ( ...args ) => mockFetchCart( ...args ),
+	quoteWalletShipping: ( ...args ) => mockQuoteWalletShipping( ...args ),
 } ) );
 
-const mockQuoteFromCart = jest.fn();
+const mockQuoteFromResponse = jest.fn();
 jest.mock( './shippingQuote', () => ( {
-	quoteFromCart: ( ...args ) => mockQuoteFromCart( ...args ),
+	quoteFromResponse: ( ...args ) => mockQuoteFromResponse( ...args ),
 } ) );
 
 import {
@@ -64,144 +60,233 @@ describe( 'walletShippingCountries()', () => {
 } );
 
 describe( 'createShippingController()', () => {
-	const address = { country: 'US', state: 'CA', postcode: '94105', city: 'SF' };
-	const cartAfterAddress = { totals: {} };
-	const cartAfterRate = { totals: {}, rate: true };
-	const priced = { total: '10.00', options: [ { id: 'flat_rate:1' } ] };
+	const address = {
+		country: 'US',
+		state: 'CA',
+		postcode: '94105',
+		city: 'SF',
+	};
+	const response = { total: '10.00' };
+	const priced = { total: '10.00', selectedId: null, options: [] };
 
-	test( 'current() is null before any quote has resolved', () => {
-		expect( createShippingController( { config: config() } ).current() ).toBeNull();
-	} );
-
-	test( 'writes the address when it carries a country, and quotes off the recalculated cart', async () => {
-		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
-		mockQuoteFromCart.mockReturnValue( priced );
-
-		const controller = createShippingController( { config: config() } );
-		const result = await controller.quote( { address } );
-
-		expect( mockUpdateCustomerAddress ).toHaveBeenCalledWith(
-			config(),
-			address
-		);
-		expect( mockFetchCart ).not.toHaveBeenCalled();
-		expect( mockSelectShippingRate ).not.toHaveBeenCalled();
-		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cartAfterAddress );
-		expect( result ).toEqual( priced );
-		expect( controller.current() ).toEqual( priced );
-	} );
-
-	test( 'reads the cart instead of writing when the address carries no country, as when the sheet opens with nothing selected yet', async () => {
-		const cart = { totals: {} };
-		mockFetchCart.mockResolvedValue( cart );
-		mockQuoteFromCart.mockReturnValue( priced );
-
-		const controller = createShippingController( { config: config() } );
-		const result = await controller.quote( {
-			address: { country: '', state: '', postcode: '', city: '' },
+	describe( 'quote()', () => {
+		test( 'current() is null before any quote has resolved', () => {
+			expect(
+				createShippingController( { config: config() } ).current()
+			).toBeNull();
 		} );
 
-		expect( mockFetchCart ).toHaveBeenCalledWith( config() );
-		expect( mockUpdateCustomerAddress ).not.toHaveBeenCalled();
-		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cart );
-		expect( result ).toEqual( priced );
-	} );
+		test( 'prices the address and rate in a single request and keeps the result as the current answer', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse.mockReturnValue( priced );
 
-	test( 'still selects the rate after reading the cart when a country-less selection carries one', async () => {
-		const cart = { totals: {} };
-		mockFetchCart.mockResolvedValue( cart );
-		mockSelectShippingRate.mockResolvedValue( cartAfterRate );
-		mockQuoteFromCart.mockReturnValue( priced );
+			const controller = createShippingController( { config: config() } );
+			const result = await controller.quote( {
+				address,
+				rateId: 'flat_rate:1',
+			} );
 
-		const controller = createShippingController( { config: config() } );
-		const result = await controller.quote( {
-			address: { country: '' },
-			rateId: 'flat_rate:1',
+			expect( mockQuoteWalletShipping ).toHaveBeenCalledTimes( 1 );
+			expect( mockQuoteWalletShipping ).toHaveBeenCalledWith( config(), {
+				address,
+				rateId: 'flat_rate:1',
+				billingAddress: null,
+					expectedTotal: null,
+			} );
+			expect( mockQuoteFromResponse ).toHaveBeenCalledWith( response );
+			expect( result ).toEqual( priced );
+			expect( controller.current() ).toEqual( priced );
 		} );
 
-		expect( mockFetchCart ).toHaveBeenCalledWith( config() );
-		expect( mockUpdateCustomerAddress ).not.toHaveBeenCalled();
-		expect( mockSelectShippingRate ).toHaveBeenCalledWith(
-			config(),
-			'flat_rate:1'
-		);
-		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cartAfterRate );
-		expect( result ).toEqual( priced );
-	} );
+		test( 'defaults rateId to null when the selection carries none', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse.mockReturnValue( priced );
 
-	test( 'selects the rate after the address, and quotes off the rate response', async () => {
-		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
-		mockSelectShippingRate.mockResolvedValue( cartAfterRate );
-		mockQuoteFromCart.mockReturnValue( priced );
+			const controller = createShippingController( { config: config() } );
+			await controller.quote( { address } );
 
-		const controller = createShippingController( { config: config() } );
-		const result = await controller.quote( {
-			address,
-			rateId: 'flat_rate:1',
+			expect( mockQuoteWalletShipping ).toHaveBeenCalledWith( config(), {
+				address,
+				rateId: null,
+				billingAddress: null,
+					expectedTotal: null,
+			} );
 		} );
 
-		expect( mockUpdateCustomerAddress ).toHaveBeenCalledWith(
-			config(),
-			address
-		);
-		expect( mockSelectShippingRate ).toHaveBeenCalledWith(
-			config(),
-			'flat_rate:1'
-		);
-		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cartAfterRate );
-		expect( result ).toEqual( priced );
+		test( 'a rejected selection rejects, but does not poison later selections', async () => {
+			mockQuoteWalletShipping
+				.mockRejectedValueOnce( new Error( 'Endpoint down' ) )
+				.mockResolvedValueOnce( response );
+			mockQuoteFromResponse.mockReturnValue( priced );
+
+			const controller = createShippingController( { config: config() } );
+
+			await expect( controller.quote( { address } ) ).rejects.toThrow(
+				'Endpoint down'
+			);
+
+			const second = await controller.quote( { address } );
+
+			expect( second ).toEqual( priced );
+			expect( mockQuoteWalletShipping ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		test( 'writes only the last of several selections made before any of them settles', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse.mockReturnValue( priced );
+
+			const controller = createShippingController( { config: config() } );
+
+			const first = controller.quote( {
+				address: { ...address, country: 'US' },
+			} );
+			const second = controller.quote( {
+				address: { ...address, country: 'DE' },
+			} );
+			const third = controller.quote( {
+				address: { ...address, country: 'FR' },
+			} );
+
+			await Promise.allSettled( [ first, second, third ] );
+
+			expect( mockQuoteWalletShipping ).toHaveBeenCalledTimes( 1 );
+			expect( mockQuoteWalletShipping ).toHaveBeenCalledWith(
+				config(),
+				expect.objectContaining( {
+					address: expect.objectContaining( { country: 'FR' } ),
+				} )
+			);
+			await expect( third ).resolves.toEqual( priced );
+		} );
+
+		test( 'a superseded selection rejects with the generic message when nothing has been priced yet', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse.mockReturnValue( priced );
+
+			const controller = createShippingController( { config: config() } );
+
+			const first = controller.quote( {
+				address: { ...address, country: 'US' },
+			} );
+			const second = controller.quote( {
+				address: { ...address, country: 'FR' },
+			} );
+
+			await expect( first ).rejects.toThrow(
+				'Shipping could not be priced.'
+			);
+			await expect( second ).resolves.toEqual( priced );
+		} );
 	} );
 
-	test( 'a rejected selection rejects, but does not poison later selections', async () => {
-		mockUpdateCustomerAddress
-			.mockRejectedValueOnce( new Error( 'Store API down' ) )
-			.mockResolvedValueOnce( cartAfterAddress );
-		mockQuoteFromCart.mockReturnValue( priced );
+	describe( 'commit()', () => {
+		test( 'resolves with the committed quote', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:1' } )
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:1' } );
 
-		const controller = createShippingController( { config: config() } );
+			const controller = createShippingController( { config: config() } );
+			await controller.quote( { address, rateId: 'flat_rate:1' } );
 
-		await expect( controller.quote( { address } ) ).rejects.toThrow(
-			'Store API down'
-		);
+			const committed = await controller.commit( address );
 
-		const second = await controller.quote( { address } );
+			expect( committed ).toEqual( {
+				total: '10.00',
+				selectedId: 'flat_rate:1',
+			} );
+		} );
 
-		expect( second ).toEqual( priced );
-		expect( mockUpdateCustomerAddress ).toHaveBeenCalledTimes( 2 );
-	} );
+		test( "quotes with the complete address, the previous quote's selected rate, and the previously displayed total as expectedTotal", async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:9' } )
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:9' } );
 
-	test( 'writes only the last of several selections made before any of them settles', async () => {
-		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
-		mockQuoteFromCart.mockReturnValue( priced );
+			const controller = createShippingController( { config: config() } );
+			await controller.quote( { address, rateId: 'flat_rate:9' } );
 
-		const controller = createShippingController( { config: config() } );
+			await controller.commit( address );
 
-		const first = controller.quote( { address: { country: 'US' } } );
-		const second = controller.quote( { address: { country: 'DE' } } );
-		const third = controller.quote( { address: { country: 'FR' } } );
+			expect( mockQuoteWalletShipping ).toHaveBeenLastCalledWith(
+				config(),
+				{
+					address,
+					rateId: 'flat_rate:9',
+					billingAddress: address,
+					expectedTotal: '10.00',
+				}
+			);
+		} );
 
-		await Promise.allSettled( [ first, second, third ] );
+		test( 'sends the shipping address as the billing address when the given one carries no country', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:1' } )
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:1' } );
+			const billingAddressWithNoCountry = { state: 'NY' };
 
-		expect( mockUpdateCustomerAddress ).toHaveBeenCalledTimes( 1 );
-		expect( mockUpdateCustomerAddress ).toHaveBeenCalledWith(
-			config(),
-			{ country: 'FR' }
-		);
-		await expect( third ).resolves.toEqual( priced );
-	} );
+			const controller = createShippingController( { config: config() } );
+			await controller.quote( { address, rateId: 'flat_rate:1' } );
 
-	test( 'a superseded selection rejects with the generic message when nothing has been priced yet', async () => {
-		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
-		mockQuoteFromCart.mockReturnValue( priced );
+			await controller.commit( address, billingAddressWithNoCountry );
 
-		const controller = createShippingController( { config: config() } );
+			expect( mockQuoteWalletShipping ).toHaveBeenLastCalledWith(
+				config(),
+				expect.objectContaining( { billingAddress: address } )
+			);
+		} );
 
-		const first = controller.quote( { address: { country: 'US' } } );
-		const second = controller.quote( { address: { country: 'FR' } } );
+		test( 'forwards the billing address to the quote when authorization revealed one', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:1' } )
+				.mockReturnValueOnce( { total: '10.00', selectedId: 'flat_rate:1' } );
+			const billingAddress = { ...address, state: 'NY' };
 
-		await expect( first ).rejects.toThrow(
-			'Shipping could not be priced.'
-		);
-		await expect( second ).resolves.toEqual( priced );
+			const controller = createShippingController( { config: config() } );
+			await controller.quote( { address, rateId: 'flat_rate:1' } );
+
+			await controller.commit( address, billingAddress );
+
+			expect( mockQuoteWalletShipping ).toHaveBeenLastCalledWith(
+				config(),
+				expect.objectContaining( { billingAddress } )
+			);
+		} );
+
+		test( 'propagates a rejection from the endpoint, so a total higher than the sheet displayed never charges the shopper', async () => {
+			mockQuoteWalletShipping
+				.mockResolvedValueOnce( response )
+				.mockRejectedValueOnce(
+					new Error( 'Shipping price changed after authorization' )
+				);
+			mockQuoteFromResponse.mockReturnValueOnce( {
+				total: '10.00',
+				selectedId: 'flat_rate:1',
+			} );
+
+			const controller = createShippingController( { config: config() } );
+			await controller.quote( { address, rateId: 'flat_rate:1' } );
+
+			await expect( controller.commit( address ) ).rejects.toThrow(
+				'Shipping price changed after authorization'
+			);
+		} );
+
+		test( 'does not throw when there is no previous quote to compare against', async () => {
+			mockQuoteWalletShipping.mockResolvedValue( response );
+			mockQuoteFromResponse.mockReturnValue( {
+				total: '10.00',
+				selectedId: null,
+			} );
+
+			const controller = createShippingController( { config: config() } );
+
+			await expect( controller.commit( address ) ).resolves.toEqual( {
+				total: '10.00',
+				selectedId: null,
+			} );
+		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletShipping.test.js
@@ -1,0 +1,207 @@
+const mockUpdateCustomerAddress = jest.fn();
+const mockSelectShippingRate = jest.fn();
+const mockFetchCart = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	updateCustomerAddress: ( ...args ) => mockUpdateCustomerAddress( ...args ),
+	selectShippingRate: ( ...args ) => mockSelectShippingRate( ...args ),
+	fetchCart: ( ...args ) => mockFetchCart( ...args ),
+} ) );
+
+const mockQuoteFromCart = jest.fn();
+jest.mock( './shippingQuote', () => ( {
+	quoteFromCart: ( ...args ) => mockQuoteFromCart( ...args ),
+} ) );
+
+import {
+	createShippingController,
+	walletShippingCountries,
+	walletShippingRequired,
+} from './walletShipping';
+
+const config = ( overrides = {} ) => ( {
+	shipping: {
+		in_context: { checkout: true, product: false },
+		countries: [ 'US', 'DE' ],
+	},
+	...overrides,
+} );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'walletShippingRequired()', () => {
+	test.each( [
+		[ 'checkout', true ],
+		[ 'product', false ],
+		[ 'cart', false ],
+	] )( 'reports %s as required: %s', ( context, expected ) => {
+		expect( walletShippingRequired( config(), context ) ).toBe( expected );
+	} );
+
+	test( 'is false when the config carries no shipping section at all', () => {
+		expect( walletShippingRequired( {}, 'checkout' ) ).toBe( false );
+	} );
+} );
+
+describe( 'walletShippingCountries()', () => {
+	test( 'returns the configured countries', () => {
+		expect( walletShippingCountries( config() ) ).toEqual( [
+			'US',
+			'DE',
+		] );
+	} );
+
+	test( 'returns an empty list when the store does not restrict countries', () => {
+		expect(
+			walletShippingCountries( config( { shipping: {} } ) )
+		).toEqual( [] );
+	} );
+
+	test( 'returns an empty list when the config carries no shipping section at all', () => {
+		expect( walletShippingCountries( {} ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'createShippingController()', () => {
+	const address = { country: 'US', state: 'CA', postcode: '94105', city: 'SF' };
+	const cartAfterAddress = { totals: {} };
+	const cartAfterRate = { totals: {}, rate: true };
+	const priced = { total: '10.00', options: [ { id: 'flat_rate:1' } ] };
+
+	test( 'current() is null before any quote has resolved', () => {
+		expect( createShippingController( { config: config() } ).current() ).toBeNull();
+	} );
+
+	test( 'writes the address when it carries a country, and quotes off the recalculated cart', async () => {
+		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+		const result = await controller.quote( { address } );
+
+		expect( mockUpdateCustomerAddress ).toHaveBeenCalledWith(
+			config(),
+			address
+		);
+		expect( mockFetchCart ).not.toHaveBeenCalled();
+		expect( mockSelectShippingRate ).not.toHaveBeenCalled();
+		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cartAfterAddress );
+		expect( result ).toEqual( priced );
+		expect( controller.current() ).toEqual( priced );
+	} );
+
+	test( 'reads the cart instead of writing when the address carries no country, as when the sheet opens with nothing selected yet', async () => {
+		const cart = { totals: {} };
+		mockFetchCart.mockResolvedValue( cart );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+		const result = await controller.quote( {
+			address: { country: '', state: '', postcode: '', city: '' },
+		} );
+
+		expect( mockFetchCart ).toHaveBeenCalledWith( config() );
+		expect( mockUpdateCustomerAddress ).not.toHaveBeenCalled();
+		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cart );
+		expect( result ).toEqual( priced );
+	} );
+
+	test( 'still selects the rate after reading the cart when a country-less selection carries one', async () => {
+		const cart = { totals: {} };
+		mockFetchCart.mockResolvedValue( cart );
+		mockSelectShippingRate.mockResolvedValue( cartAfterRate );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+		const result = await controller.quote( {
+			address: { country: '' },
+			rateId: 'flat_rate:1',
+		} );
+
+		expect( mockFetchCart ).toHaveBeenCalledWith( config() );
+		expect( mockUpdateCustomerAddress ).not.toHaveBeenCalled();
+		expect( mockSelectShippingRate ).toHaveBeenCalledWith(
+			config(),
+			'flat_rate:1'
+		);
+		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cartAfterRate );
+		expect( result ).toEqual( priced );
+	} );
+
+	test( 'selects the rate after the address, and quotes off the rate response', async () => {
+		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
+		mockSelectShippingRate.mockResolvedValue( cartAfterRate );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+		const result = await controller.quote( {
+			address,
+			rateId: 'flat_rate:1',
+		} );
+
+		expect( mockUpdateCustomerAddress ).toHaveBeenCalledWith(
+			config(),
+			address
+		);
+		expect( mockSelectShippingRate ).toHaveBeenCalledWith(
+			config(),
+			'flat_rate:1'
+		);
+		expect( mockQuoteFromCart ).toHaveBeenCalledWith( cartAfterRate );
+		expect( result ).toEqual( priced );
+	} );
+
+	test( 'a rejected selection rejects, but does not poison later selections', async () => {
+		mockUpdateCustomerAddress
+			.mockRejectedValueOnce( new Error( 'Store API down' ) )
+			.mockResolvedValueOnce( cartAfterAddress );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+
+		await expect( controller.quote( { address } ) ).rejects.toThrow(
+			'Store API down'
+		);
+
+		const second = await controller.quote( { address } );
+
+		expect( second ).toEqual( priced );
+		expect( mockUpdateCustomerAddress ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'writes only the last of several selections made before any of them settles', async () => {
+		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+
+		const first = controller.quote( { address: { country: 'US' } } );
+		const second = controller.quote( { address: { country: 'DE' } } );
+		const third = controller.quote( { address: { country: 'FR' } } );
+
+		await Promise.allSettled( [ first, second, third ] );
+
+		expect( mockUpdateCustomerAddress ).toHaveBeenCalledTimes( 1 );
+		expect( mockUpdateCustomerAddress ).toHaveBeenCalledWith(
+			config(),
+			{ country: 'FR' }
+		);
+		await expect( third ).resolves.toEqual( priced );
+	} );
+
+	test( 'a superseded selection rejects with the generic message when nothing has been priced yet', async () => {
+		mockUpdateCustomerAddress.mockResolvedValue( cartAfterAddress );
+		mockQuoteFromCart.mockReturnValue( priced );
+
+		const controller = createShippingController( { config: config() } );
+
+		const first = controller.quote( { address: { country: 'US' } } );
+		const second = controller.quote( { address: { country: 'FR' } } );
+
+		await expect( first ).rejects.toThrow(
+			'Shipping could not be priced.'
+		);
+		await expect( second ).resolves.toEqual( priced );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletTotal.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletTotal.js
@@ -33,6 +33,16 @@ export async function resolveWalletTotal( config, context ) {
 		};
 	}
 
+	if ( context === 'pay-now' ) {
+		// An existing order is being paid, priced server-side from the order itself.
+		// The cart holds an unrelated basket, so asking it would show a price this
+		// page cannot charge.
+		return {
+			total: config.amount,
+			purchaseUnits: [],
+		};
+	}
+
 	return {
 		// fetchCartTotal returns '' when the Store API call fails; the
 		// localized amount is the page's own total.

--- a/modules/ppcp-sdk-v6/resources/js/wallets/walletTotal.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/walletTotal.test.js
@@ -51,6 +51,22 @@ describe( 'resolveWalletTotal()', () => {
 		} );
 	} );
 
+	describe( 'on the pay-now context', () => {
+		test( 'returns the configured amount with empty purchase units, without asking the cart', async () => {
+			const result = await resolveWalletTotal(
+				config( { amount: '42.00' } ),
+				'pay-now'
+			);
+
+			expect( result ).toEqual( {
+				total: '42.00',
+				purchaseUnits: [],
+			} );
+			expect( changeCart ).not.toHaveBeenCalled();
+			expect( fetchCartTotal ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( 'on a non-product context (cart, checkout, or unset)', () => {
 		test.each( [
 			[ 'a normal value', '19.99', '19.99' ],

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -103,7 +103,6 @@ return array(
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'settings.environment' ),
 			$container->get( 'sdk-v6.button-style-mapper' ),
-			$container->get( 'order-endpoints.handle-shipping-in-paypal' ),
 			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'button.helper.context' ),
 			$container->get( 'session.handler' ),

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -17,10 +17,14 @@ use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Blocks\V6PaymentMethod;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\WalletShippingEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedShippingRate;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedQuote;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedTaxBasis;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
@@ -161,6 +165,29 @@ return array(
 			$container->get( 'order-endpoints.request-data' ),
 			$container->get( 'order-endpoints.helper.cart-products' ),
 			$container->get( 'button.helper.isolated-cart-simulator' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
+		);
+	},
+
+	'sdk-v6.recorded-shipping-rate'     => static function (): RecordedShippingRate {
+		return new RecordedShippingRate();
+	},
+
+	'sdk-v6.recorded-tax-basis'         => static function (): RecordedTaxBasis {
+		return new RecordedTaxBasis();
+	},
+
+	'sdk-v6.recorded-quote'             => static function (): RecordedQuote {
+		return new RecordedQuote();
+	},
+
+	'sdk-v6.endpoint.wallet-shipping'   => static function ( ContainerInterface $container ): WalletShippingEndpoint {
+		return new WalletShippingEndpoint(
+			$container->get( 'order-endpoints.request-data' ),
+			$container->get( 'api.factory.amount' ),
+			$container->get( 'sdk-v6.recorded-shipping-rate' ),
+			$container->get( 'sdk-v6.recorded-tax-basis' ),
+			$container->get( 'sdk-v6.recorded-quote' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -22,6 +22,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\WalletShippingEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
@@ -466,6 +467,10 @@ class SdkV6Manager {
 				'simulate_cart'   => array(
 					'endpoint' => \WC_AJAX::get_endpoint( SimulateCartEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( SimulateCartEndpoint::nonce() ),
+				),
+				'wallet_shipping' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( WalletShippingEndpoint::ENDPOINT ),
+					'nonce'    => wp_create_nonce( WalletShippingEndpoint::nonce() ),
 				),
 				'create_order'    => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreateOrderEndpoint::ENDPOINT ),

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -42,13 +42,6 @@ class SdkV6Manager {
 	public const GOOGLE_PAY_WRAPPER_ID = 'ppc-button-ppcp-googlepay-v6';
 	public const APPLE_PAY_WRAPPER_ID  = 'ppc-button-ppcp-applepay-v6';
 
-	/**
-	 * The height every payment button on the page renders at.
-	 *
-	 * Not a merchant setting: the styling DTOs carry no height (see
-	 * ButtonStyleMapper), and the buttons are meant to match each other. Hence one
-	 * value for all of them, rather than one per button type or context.
-	 */
 	public const PAYMENT_BUTTON_HEIGHT = '48px';
 
 	/**

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -710,9 +710,9 @@ class SdkV6Manager {
 	/**
 	 * Whether the given context collects a shipping address and shipping options.
 	 *
-	 * Not collected when the buyer gets another chance to choose it ("Pay Now"
-	 * disabled, so continuation mode ends on a final review), or when there is
-	 * nothing to ship.
+	 * Requires the "Pay Now" experience, which builds the WC order from the approved
+	 * PayPal order and the address collected during payment. Continuation mode ends
+	 * on a final review page instead, and that page collects shipping itself.
 	 *
 	 * The product page judges the product rather than the cart, because the product
 	 * is what gets bought there: it is added to the cart on click, so the cart's

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -51,6 +51,11 @@ class SdkV6Manager {
 	 */
 	public const PAYMENT_BUTTON_HEIGHT = '48px';
 
+	/**
+	 * The contexts that print a payment-method radio list a wallet can own a row in.
+	 */
+	private const CONTEXTS_WITH_GATEWAY_ROWS = array( 'checkout', 'pay-now' );
+
 	// Existing WC credit-card-form field IDs (see CardFieldsModule's
 	// woocommerce_credit_card_form_fields filter and WC core's own
 	// card-number/expiry/cvc fields) that the v6 card fields mount into,
@@ -275,9 +280,7 @@ class SdkV6Manager {
 	/**
 	 * Whether a wallet renders as its own payment-method row.
 	 *
-	 * True only on classic checkout with the gateway actually available: the
-	 * other contexts have no payment-method list, and the block checkout
-	 * registers its methods through the block registry instead.
+	 * True only where there is a list to join and the gateway is available there.
 	 *
 	 * Only the gateway walk is memoized, never a refusal from the context check,
 	 * so a call made before the context resolves cannot poison the answer. The
@@ -289,7 +292,7 @@ class SdkV6Manager {
 			return $wallet->is_gateway;
 		}
 
-		if ( 'checkout' !== $this->get_page_context() || $this->is_block_context() ) {
+		if ( ! in_array( $this->get_page_context(), self::CONTEXTS_WITH_GATEWAY_ROWS, true ) || $this->is_block_context() ) {
 			return false;
 		}
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -731,6 +731,13 @@ class SdkV6Manager {
 			return false;
 		}
 
+		// Both pages already own the address and the total the order will use, so
+		// the wallet only authorizes what the page shows. This prevents conflicting
+		// addresses/details between checkout form and payment sheet.
+		if ( in_array( $context, array( 'checkout', 'pay-now' ), true ) ) {
+			return false;
+		}
+
 		// Block surfaces read needsShipping live from the React cart and combine it
 		// with this value themselves, so answering with the cart as it stood when the
 		// page was built would gate them twice, on a snapshot that goes stale the

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
 
+use WC_Product;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
@@ -62,7 +63,6 @@ class SdkV6Manager {
 	private string $version;
 	private Environment $environment;
 	private ButtonStyleMapper $style_mapper;
-	private bool $should_handle_shipping;
 	private SettingsStatus $settings_status;
 	private Context $context;
 	private SessionHandler $session_handler;
@@ -100,7 +100,6 @@ class SdkV6Manager {
 		string $version,
 		Environment $environment,
 		ButtonStyleMapper $style_mapper,
-		bool $should_handle_shipping,
 		SettingsStatus $settings_status,
 		Context $context,
 		SessionHandler $session_handler,
@@ -119,7 +118,6 @@ class SdkV6Manager {
 		$this->version                     = $version;
 		$this->environment                 = $environment;
 		$this->style_mapper                = $style_mapper;
-		$this->should_handle_shipping      = $should_handle_shipping;
 		$this->settings_status             = $settings_status;
 		$this->context                     = $context;
 		$this->session_handler             = $session_handler;
@@ -431,13 +429,7 @@ class SdkV6Manager {
 
 		$page_context = $this->get_page_context();
 
-		// Must stay in lockstep with ShippingPreferenceFactory, which marks only
-		// 'checkout' and 'pay-now' as fixed-address (SET_PROVIDED_ADDRESS, no
-		// callbacks needed). Every other context, 'checkout-block' included,
-		// gets GET_FROM_FILE, where PayPal offers the buyer's own addresses and
-		// the popup callbacks must stay attached to sync the choice back.
-		$shipping_enabled = $this->should_handle_shipping
-			&& ! in_array( $page_context, array( 'checkout', 'pay-now' ), true );
+		$shipping_contexts = $this->shipping_contexts( $page_context );
 
 		$store_api_base = rtrim( rest_url( 'wc/store/v1/cart' ), '/' );
 
@@ -502,14 +494,23 @@ class SdkV6Manager {
 				'checkout' => wc_get_checkout_url(),
 			),
 			'labels'            => array(
-				'generic_error' => __(
+				'generic_error'          => __(
 					'Something went wrong. Please try again or choose another payment source.',
 					'woocommerce-paypal-payments'
 				),
+				'shipping_unserviceable' => __(
+					'Cannot ship to the selected address.',
+					'woocommerce-paypal-payments'
+				),
+				// The Apple Pay sheet itemises the total with these.
+				'subtotal'               => __( 'Subtotal', 'woocommerce-paypal-payments' ),
+				'shipping'               => __( 'Shipping', 'woocommerce-paypal-payments' ),
+				'tax'                    => __( 'Tax', 'woocommerce-paypal-payments' ),
+				'discount'               => __( 'Discount', 'woocommerce-paypal-payments' ),
 			),
 			'shipping'          => array(
-				'handle_in_paypal' => $shipping_enabled,
-				'need_shipping'    => $this->need_shipping(),
+				'in_context' => $shipping_contexts,
+				'countries'  => $this->shipping_countries( $shipping_contexts ),
 			),
 			'button_styles'     => $button_styles,
 			'button_height'     => self::PAYMENT_BUTTON_HEIGHT,
@@ -684,14 +685,85 @@ class SdkV6Manager {
 	}
 
 	/**
-	 * Whether the current cart needs shipping.
+	 * Whether shipping details are collected, per context.
 	 *
+	 * One decision per context, shared by every surface that asks it: the PayPal
+	 * popup and the wallet payment sheets. A map rather than a single flag because
+	 * the mini-cart renders on any page, so two contexts can be live at once and
+	 * answer differently.
+	 *
+	 * @param string $page_context The context of the current page.
+	 * @return array<string, bool> Keyed by context.
+	 */
+	private function shipping_contexts( string $page_context ): array {
+		$contexts = array();
+
+		if ( $page_context ) {
+			$contexts[ $page_context ] = $this->shipping_for_context( $page_context );
+		}
+
+		$contexts['mini-cart'] = $this->shipping_for_context( 'mini-cart' );
+
+		return $contexts;
+	}
+
+	/**
+	 * Whether the given context collects a shipping address and shipping options.
+	 *
+	 * Not collected when the buyer gets another chance to choose it ("Pay Now"
+	 * disabled, so continuation mode ends on a final review), or when there is
+	 * nothing to ship.
+	 *
+	 * The product page judges the product rather than the cart, because the product
+	 * is what gets bought there: it is added to the cart on click, so the cart's
+	 * current contents describe a basket that is about to be replaced.
+	 *
+	 * @param string $context The context to judge.
 	 * @return bool
 	 */
-	private function need_shipping(): bool {
+	private function shipping_for_context( string $context ): bool {
+		if ( $this->final_review_enabled ) {
+			return false;
+		}
+
+		// Block surfaces read needsShipping live from the React cart and combine it
+		// with this value themselves, so answering with the cart as it stood when the
+		// page was built would gate them twice, on a snapshot that goes stale the
+		// moment the buyer edits the cart.
+		if ( in_array( $context, array( 'cart-block', 'checkout-block' ), true ) ) {
+			return true;
+		}
+
+		if ( 'product' === $context ) {
+			$product = wc_get_product();
+
+			return $product instanceof WC_Product
+				&& ! $product->is_virtual()
+				&& ! $product->is_downloadable();
+		}
+
 		$cart = WC()->cart;
 
 		return $cart && $cart->needs_shipping();
+	}
+
+	/**
+	 * The countries a payment sheet may offer, for Google Pay's address allow-list.
+	 *
+	 * Sent whole whenever any context collects shipping, as the classic integration
+	 * did, so the buyer can never select an address the store would reject.
+	 *
+	 * @param array<string, bool> $shipping_contexts The per-context map.
+	 * @return array<int, string> ISO-2 country codes.
+	 */
+	private function shipping_countries( array $shipping_contexts ): array {
+		if ( ! in_array( true, $shipping_contexts, true ) ) {
+			return array();
+		}
+
+		$countries = WC()->countries;
+
+		return $countries ? array_keys( $countries->get_shipping_countries() ) : array();
 	}
 
 	/**
@@ -709,6 +781,7 @@ class SdkV6Manager {
 			if ( $order ) {
 				return number_format( (float) $order->get_total(), 2, '.', '' );
 			}
+
 			return '';
 		}
 

--- a/modules/ppcp-sdk-v6/src/Endpoint/WalletShippingEndpoint.php
+++ b/modules/ppcp-sdk-v6/src/Endpoint/WalletShippingEndpoint.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * Prices the cart for an address and rate chosen inside a wallet payment sheet.
+ *
+ * One request per selection, because WooCommerce re-picks the shipping method on
+ * every recalculation (see RecordedShippingRate): setting the destination and the rate in
+ * separate requests loses the choice, and answering from two responses can show a
+ * total and an option list that describe different carts. This endpoint sets both,
+ * recalculates, and answers from the one state it leaves behind.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Endpoint
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Endpoint;
+
+use Exception;
+use Psr\Log\LoggerInterface;
+use WC_Cart;
+use WC_Shipping_Rate;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\AbstractCartEndpoint;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedShippingRate;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedQuote;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedTaxBasis;
+
+class WalletShippingEndpoint extends AbstractCartEndpoint {
+
+	public const ENDPOINT = 'ppc-sdk-v6-wallet-shipping';
+
+	private AmountFactory $amount_factory;
+
+	private RecordedShippingRate $recorded_rate;
+
+	private RecordedTaxBasis $recorded_tax_basis;
+
+	private RecordedQuote $recorded_quote;
+
+	public function __construct(
+		RequestData $request_data,
+		AmountFactory $amount_factory,
+		RecordedShippingRate $recorded_rate,
+		RecordedTaxBasis $recorded_tax_basis,
+		RecordedQuote $recorded_quote,
+		LoggerInterface $logger
+	) {
+		$this->request_data       = $request_data;
+		$this->amount_factory     = $amount_factory;
+		$this->recorded_rate      = $recorded_rate;
+		$this->recorded_tax_basis = $recorded_tax_basis;
+		$this->recorded_quote     = $recorded_quote;
+		$this->logger             = $logger;
+
+		$this->logger_tag = 'wallet shipping';
+	}
+
+	/**
+	 * Prices the cart and responds with the quote the sheet displays.
+	 *
+	 * @throws Exception If the request is invalid or the cart is unavailable.
+	 */
+	protected function handle_data(): void {
+		$data = $this->request_data->read_request( $this->nonce() );
+
+		$cart = WC()->cart;
+		if ( ! $cart ) {
+			throw new Exception( 'The cart is not available.' );
+		}
+
+		if ( ! empty( $data['release'] ) ) {
+			$this->send_release();
+
+			return;
+		}
+
+		$this->send_quote( $cart, $data );
+	}
+
+	/**
+	 * Drops every record of this payment, so the page behind the sheet is the
+	 * shopper's own again.
+	 */
+	private function send_release(): void {
+		$this->recorded_rate->forget();
+		$this->recorded_tax_basis->forget();
+		$this->recorded_quote->forget();
+
+		wp_send_json_success( array( 'released' => true ) );
+	}
+
+	/**
+	 * Applies the sheet's selection to the cart and answers with the resulting quote.
+	 *
+	 * @param WC_Cart              $cart The shopper's cart.
+	 * @param array<string, mixed> $data The request data.
+	 */
+	private function send_quote( WC_Cart $cart, array $data ): void {
+		$rate_id        = $this->text_field( $data, 'rate_id' );
+		$shipping       = $this->address_from_request( $data, 'address' );
+		$billing        = $this->address_from_request( $data, 'billing_address' );
+		$expected_total = $this->text_field( $data, 'expected_total' );
+
+		$this->apply_shipping_address( $shipping );
+		$this->record_tax_basis( $shipping, $billing );
+
+		// Settles WooCommerce's rate-key baseline for the new destination, so the
+		// rate selected below is judged against the final rates.
+		$cart->calculate_shipping();
+		$cart->calculate_totals();
+
+		if ( $rate_id ) {
+			$this->apply_rate( $rate_id );
+		}
+
+		$quote = $this->quote();
+
+		if ( $expected_total && $this->exceeds( $quote['total'], $expected_total ) ) {
+			$this->send_refusal( $quote['total'], $expected_total, $billing );
+
+			return;
+		}
+
+		// Only the commit request states an expected total, and only its quote can
+		// reach an order.
+		if ( $expected_total ) {
+			$this->recorded_quote->set( $expected_total );
+		}
+
+		wp_send_json_success( $quote );
+	}
+
+	/**
+	 * Refuses a total higher than the sheet displayed, and tells the shopper why.
+	 *
+	 * Leads with the reassurance, because the sheet has just failed at the moment of
+	 * paying. Names the country and the new total, so the retry is not a second
+	 * surprise.
+	 *
+	 * @param string                $total    The reconciled total, as a decimal string.
+	 * @param string                $expected The total the sheet displayed.
+	 * @param array<string, string> $billing  The payer's billing address.
+	 */
+	private function send_refusal( string $total, string $expected, array $billing ): void {
+		$this->logger->info(
+			sprintf(
+				'Wallet payment refused: the sheet showed %1$s and the cart now totals %2$s.',
+				$expected,
+				$total
+			)
+		);
+
+		$message = sprintf(
+		/* translators: 1: country the tax was recalculated for, 2: the corrected total */
+			__(
+				'Nothing has been charged yet. Tax for %1$s differs from our estimate, so your total is now %2$s. Please try again.',
+				'woocommerce-paypal-payments'
+			),
+			$this->country_name( $billing['country'] ?? '' ),
+			html_entity_decode(
+				wp_strip_all_tags( wc_price( (float) $total, array( 'currency' => get_woocommerce_currency() ) ) ),
+				ENT_QUOTES,
+				'UTF-8'
+			)
+		);
+
+		wp_send_json_error( array( 'message' => $message ) );
+	}
+
+	/**
+	 * A country's name in the shopper's language, or its code when there is no name.
+	 *
+	 * @param string $code An ISO-2 country code.
+	 */
+	private function country_name( string $code ): string {
+		$countries = WC()->countries ? WC()->countries->get_countries() : array();
+
+		return (string) ( $countries[ $code ] ?? $code );
+	}
+
+	/**
+	 * Records which address this payment's tax is calculated from.
+	 *
+	 * Only where the store taxes on billing; elsewhere WooCommerce already prices the
+	 * destination the sheet collected. The destination stands in until the payer's
+	 * own address arrives with the final quote.
+	 *
+	 * @param array<string, string> $shipping The posted shipping address.
+	 * @param array<string, string> $billing  The payer's billing address, at commit.
+	 */
+	private function record_tax_basis( array $shipping, array $billing ): void {
+		if ( 'billing' !== get_option( 'woocommerce_tax_based_on' ) ) {
+			return;
+		}
+
+		if ( $billing ) {
+			$this->recorded_tax_basis->set( $billing );
+
+			return;
+		}
+
+		// An estimate never displaces the payer's own address.
+		if ( ! $this->recorded_tax_basis->get() ) {
+			$this->recorded_tax_basis->set( $shipping );
+		}
+	}
+
+	/**
+	 * Whether the total exceeds what the sheet displayed.
+	 *
+	 * In cents, not the shop's precision: both sides come from AmountFactory, which
+	 * always formats to two decimals, so scaling by a zero-decimal currency would
+	 * round a real increase away. No tolerance, since any tolerance is exactly the
+	 * amount that could be silently overcharged.
+	 *
+	 * @param string $total    The total this request produced.
+	 * @param string $expected The total the sheet displayed.
+	 */
+	private function exceeds( string $total, string $expected ): bool {
+		return (int) round( (float) $total * 100 ) > (int) round( (float) $expected * 100 );
+	}
+
+	/**
+	 * Reads a posted address, keeping only the fields WooCommerce prices from.
+	 *
+	 * Both sheets redact the street and the recipient until the shopper authorizes,
+	 * so before then those simply are not there.
+	 *
+	 * @param array<string, mixed> $data The request data.
+	 * @param string               $key  Which posted address to read.
+	 * @return array<string, string> WC address fields.
+	 */
+	private function address_from_request( array $data, string $key ): array {
+		$posted = isset( $data[ $key ] ) && is_array( $data[ $key ] )
+			? $data[ $key ]
+			: array();
+
+		$fields = array( 'country', 'state', 'postcode', 'city', 'address_1', 'address_2', 'first_name', 'last_name' );
+
+		$address = array();
+		foreach ( $fields as $field ) {
+			$value = $this->text_field( $posted, $field );
+
+			if ( '' !== $value ) {
+				$address[ $field ] = $value;
+			}
+		}
+
+		if ( isset( $address['country'] ) ) {
+			$address['country'] = strtoupper( $address['country'] );
+		}
+
+		return $address;
+	}
+
+	/**
+	 * Writes the sheet's destination onto the customer, leaving billing alone.
+	 *
+	 * The order is created from the customer record, so it must be priced from that
+	 * same record. An absent field means unchanged, never blanked. Billing is left to
+	 * RecordedTaxBasis.
+	 *
+	 * @param array<string, string> $address WC address fields.
+	 */
+	private function apply_shipping_address( array $address ): void {
+		$customer = WC()->customer;
+		if ( ! $customer || ! $address ) {
+			return;
+		}
+
+		foreach ( $address as $field => $value ) {
+			$setter = "set_shipping_{$field}";
+
+			if ( is_callable( array( $customer, $setter ) ) ) {
+				$customer->{$setter}( $value );
+			}
+		}
+
+		$customer->save();
+	}
+
+	/**
+	 * Selects a rate and makes the selection survive the recalculation.
+	 *
+	 * An unknown rate id is ignored: the response must never name a rate the order
+	 * will not be charged for.
+	 *
+	 * @param string $rate_id The WC rate id, e.g. flat_rate:3.
+	 */
+	private function apply_rate( string $rate_id ): void {
+		$session = WC()->session;
+		$cart    = WC()->cart;
+		if ( ! $session || ! $cart || ! isset( $this->available_rates()[ $rate_id ] ) ) {
+			return;
+		}
+
+		// Pinned before recalculating, so the pin's filter can restore the choice
+		// if this calculation, or the later one inside ppc-create-order, resets it.
+		$this->recorded_rate->set( $rate_id );
+
+		$session->set( 'chosen_shipping_methods', array( $rate_id ) );
+
+		$cart->calculate_shipping();
+		$cart->calculate_totals();
+	}
+
+	/**
+	 * The rates of the first shipping package.
+	 *
+	 * Only the first: neither sheet nor PayPal can express a per-package choice.
+	 *
+	 * @return array<string, WC_Shipping_Rate>
+	 */
+	private function available_rates(): array {
+		$packages = WC()->shipping() ? WC()->shipping()->get_packages() : array();
+		$package  = reset( $packages );
+
+		return is_array( $package ) && isset( $package['rates'] ) ? $package['rates'] : array();
+	}
+
+	/**
+	 * The rate WooCommerce will charge for the first package.
+	 *
+	 * @return string The rate id, or an empty string when none is chosen.
+	 */
+	private function chosen_rate_id(): string {
+		$session = WC()->session;
+		$chosen  = $session ? $session->get( 'chosen_shipping_methods' ) : array();
+
+		return is_array( $chosen ) && isset( $chosen[0] ) ? (string) $chosen[0] : '';
+	}
+
+	/**
+	 * The quote describing the cart as this request leaves it.
+	 *
+	 * Every figure comes from AmountFactory, the source the purchase unit is built
+	 * from, so the sheet displays the total PayPal is asked to charge. WC_Cart's own
+	 * total can differ by a cent, because AmountFactory sums its breakdown in integer
+	 * cents and PayPal rejects an amount that does not match that sum.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function quote(): array {
+		$cart      = WC()->cart;
+		$decimals  = wc_get_price_decimals();
+		$amount    = $this->amount_factory->from_wc_cart( $cart );
+		$breakdown = $amount->breakdown();
+
+		$options = array();
+		foreach ( $this->available_rates() as $rate ) {
+			$options[] = array(
+				'id'    => $rate->get_id(),
+				'label' => $rate->get_label(),
+				'cost'  => wc_format_decimal( $rate->get_cost(), $decimals ),
+			);
+		}
+
+		return array(
+			'total'            => $amount->value_str(),
+			'shipping_fee'     => $this->money_str( $breakdown ? $breakdown->shipping() : null ),
+			'subtotal'         => $this->money_str( $breakdown ? $breakdown->item_total() : null ),
+			'tax'              => $this->money_str( $breakdown ? $breakdown->tax_total() : null ),
+			'discount'         => $this->money_str( $breakdown ? $breakdown->discount() : null ),
+			'currency_code'    => get_woocommerce_currency(),
+			'needs_shipping'   => $cart->needs_shipping(),
+			'selected_rate_id' => $this->chosen_rate_id(),
+			'options'          => $options,
+		);
+	}
+
+	/**
+	 * A posted text field, sanitized. Anything but a scalar reads as absent.
+	 *
+	 * @param array<string, mixed> $data The data to read from.
+	 * @param string               $key  The field to read.
+	 */
+	private function text_field( array $data, string $key ): string {
+		$value = wp_unslash( $data[ $key ] ?? '' );
+
+		return is_scalar( $value ) ? sanitize_text_field( (string) $value ) : '';
+	}
+
+	/**
+	 * A breakdown figure as a decimal string, or zero where the breakdown omits it.
+	 *
+	 * @param Money|null $money The breakdown figure.
+	 */
+	private function money_str( ?Money $money ): string {
+		return $money ? $money->value_str() : wc_format_decimal( 0, wc_get_price_decimals() );
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Helper/RecordedQuote.php
+++ b/modules/ppcp-sdk-v6/src/Helper/RecordedQuote.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * The difference between the total a wallet sheet quoted and the one charged.
+ *
+ * A sheet quotes tax against the shipping address, and WalletShippingEndpoint
+ * re-prices against the card's real one and refuses an increase, so what can remain
+ * is a decrease. Charging less than the sheet showed is still a surprise, so the
+ * quote is noted on the order and explained to the shopper.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use WC_Order;
+
+class RecordedQuote extends WalletPaymentRecord {
+
+	protected const SESSION_KEY = 'ppcp_wallet_quoted_total';
+
+	public const ORDER_META_KEY = '_ppcp_wallet_quoted_total';
+
+	/**
+	 * Records what the sheet displayed, at the moment the shopper authorizes.
+	 *
+	 * @param string $quoted_total The total the sheet showed, as a decimal string.
+	 */
+	public function set( string $quoted_total ): void {
+		if ( '' !== $quoted_total ) {
+			$this->remember( $quoted_total );
+		}
+	}
+
+	/**
+	 * Moves the quote onto the order, recording it only when it differs.
+	 *
+	 * Consumed either way, or it would annotate the next order too.
+	 *
+	 * @param WC_Order $order The order just created for this payment.
+	 */
+	public function apply_to_order( WC_Order $order ): void {
+		$quoted = $this->get();
+		$this->forget();
+
+		$charged = (float) $order->get_total();
+
+		if ( '' === $quoted || $this->cents( (float) $quoted ) === $this->cents( $charged ) ) {
+			return;
+		}
+
+		$order->add_order_note(
+			sprintf(
+			/* translators: 1: total shown in the wallet payment sheet, 2: total of this order */
+				__(
+					'The wallet payment sheet showed %1$s and this order totals %2$s. The sheet estimated tax from the shipping address; the final amount uses the card\'s billing address.',
+					'woocommerce-paypal-payments'
+				),
+				$this->format( (float) $quoted, $order ),
+				$this->format( $charged, $order )
+			)
+		);
+
+		$order->update_meta_data( self::ORDER_META_KEY, $quoted );
+		$order->save();
+	}
+
+	/**
+	 * Explains a reduction on the order-received page.
+	 *
+	 * Only a reduction: an increase never reaches an order, because the endpoint
+	 * refuses the payment instead.
+	 *
+	 * @param string   $text  The message WooCommerce is about to show.
+	 * @param WC_Order $order The order being confirmed.
+	 * @return string
+	 */
+	public function thank_you_message( string $text, WC_Order $order ): string {
+		$quoted  = (float) $order->get_meta( self::ORDER_META_KEY );
+		$charged = (float) $order->get_total();
+		$savings = $this->cents( $quoted ) - $this->cents( $charged );
+
+		if ( $savings <= 0 ) {
+			return $text;
+		}
+
+		return trim(
+			$text . ' ' . sprintf(
+			/* translators: 1: amount the shopper saved, 2: total shown in the wallet payment sheet, 3: total charged */
+				__(
+					'You saved %1$s. We estimated %2$s at checkout, but the tax for your billing address is lower, so your actual charge is %3$s.',
+					'woocommerce-paypal-payments'
+				),
+				$this->format( $savings / 100, $order ),
+				$this->format( $quoted, $order ),
+				$this->format( $charged, $order )
+			)
+		);
+	}
+
+	/**
+	 * The recorded quote, or an empty string when none applies.
+	 */
+	private function get(): string {
+		$quoted = $this->remembered();
+
+		return is_string( $quoted ) ? $quoted : '';
+	}
+
+	/**
+	 * An amount as an integer number of cents, so two equal amounts compare equal.
+	 *
+	 * @param float $amount The amount to convert.
+	 */
+	private function cents( float $amount ): int {
+		return (int) round( $amount * 100 );
+	}
+
+	/**
+	 * An amount as the shopper reads it, stripped for the plain-text places it
+	 * appears in: an order note and the order-received message.
+	 *
+	 * @param float    $amount The amount to format.
+	 * @param WC_Order $order  The order whose currency applies.
+	 */
+	private function format( float $amount, WC_Order $order ): string {
+		return html_entity_decode(
+			wp_strip_all_tags( wc_price( $amount, array( 'currency' => $order->get_currency() ) ) ),
+			ENT_QUOTES,
+			'UTF-8'
+		);
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Helper/RecordedShippingRate.php
+++ b/modules/ppcp-sdk-v6/src/Helper/RecordedShippingRate.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * The shipping rate a wallet sheet chose, held against WooCommerce's re-picking.
+ *
+ * `wc_get_chosen_shipping_method_for_package()` falls back to the package default
+ * whenever the recomputed rate keys differ from the last calculation, which can drop
+ * a rate the sheet already showed and charged for.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+class RecordedShippingRate extends WalletPaymentRecord {
+
+	protected const SESSION_KEY = 'ppcp_wallet_chosen_rate';
+
+	/**
+	 * Records the rate for the rest of this payment.
+	 *
+	 * @param string $rate_id The WC rate id, e.g. flat_rate:3.
+	 */
+	public function set( string $rate_id ): void {
+		if ( '' !== $rate_id ) {
+			$this->remember( $rate_id );
+		}
+	}
+
+	/**
+	 * The recorded rate, or an empty string when none applies.
+	 */
+	public function get(): string {
+		$rate_id = $this->remembered();
+
+		return is_string( $rate_id ) ? $rate_id : '';
+	}
+
+	/**
+	 * Restores the recorded rate whenever WooCommerce is about to pick a default.
+	 *
+	 * A shopper picking a rate on the page still wins: that writes the session
+	 * directly, and no reset follows for this filter to act on.
+	 *
+	 * @param string                           $default The rate WooCommerce would choose.
+	 * @param array<string, \WC_Shipping_Rate> $rates   The package's rates.
+	 * @return string
+	 */
+	public function filter_chosen_method( $default, $rates = array() ): string {
+		$rate_id = $this->get();
+
+		if ( $rate_id && is_array( $rates ) && isset( $rates[ $rate_id ] ) ) {
+			return $rate_id;
+		}
+
+		return (string) $default;
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Helper/RecordedTaxBasis.php
+++ b/modules/ppcp-sdk-v6/src/Helper/RecordedTaxBasis.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * The address a wallet payment's tax is calculated from.
+ *
+ * No sheet learns the card's billing address before the shopper authorizes, so a
+ * store that taxes on billing can only quote against the destination and reconcile
+ * once the real address arrives. Applied through WooCommerce's taxable-address
+ * filter, so that a later recalculation prices this rather than the customer
+ * record.
+ *
+ * Never written onto WC()->customer: wallets report a partial billing address, and
+ * merging it into the one WooCommerce seeded from the shop base would tax against an
+ * address that exists nowhere.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use WC_Customer;
+
+class RecordedTaxBasis extends WalletPaymentRecord {
+
+	protected const SESSION_KEY = 'ppcp_wallet_tax_basis';
+
+	/**
+	 * Records the address this payment's tax is calculated from.
+	 *
+	 * @param array<string, string> $address WC address fields.
+	 */
+	public function set( array $address ): void {
+		if ( ! empty( $address['country'] ) ) {
+			$this->remember( $address );
+		}
+	}
+
+	/**
+	 * The recorded address, or an empty array when none applies.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get(): array {
+		$basis = $this->remembered();
+
+		return is_array( $basis ) && ! empty( $basis['country'] ) ? $basis : array();
+	}
+
+	/**
+	 * Substitutes the recorded address as the one tax is calculated from.
+	 *
+	 * Stands aside for local pickup, and for anything that already replaced the
+	 * address before this ran: a block-cart pickup location, or a tax plugin.
+	 *
+	 * @param array<int, string> $address The country, state, postcode and city.
+	 * @return array<int, string>
+	 */
+	public function filter_taxable_address( $address ): array {
+		if ( ! is_array( $address ) || $this->is_local_pickup() ) {
+			return (array) $address;
+		}
+
+		$basis = $this->get();
+		if ( ! $basis ) {
+			return $address;
+		}
+
+		$customer = WC()->customer;
+		if ( $customer && ! $this->matches_customer( $address, $customer ) ) {
+			return $address;
+		}
+
+		return array(
+			$basis['country'] ?? '',
+			$basis['state'] ?? '',
+			$basis['postcode'] ?? '',
+			$basis['city'] ?? '',
+		);
+	}
+
+	/**
+	 * Whether the shopper is collecting the order themselves.
+	 */
+	private function is_local_pickup(): bool {
+		$methods = apply_filters( 'woocommerce_local_pickup_methods', array( 'legacy_local_pickup', 'local_pickup' ) );
+
+		return (bool) array_intersect( wc_get_chosen_shipping_method_ids(), (array) $methods );
+	}
+
+	/**
+	 * Whether the address still is the one WooCommerce itself derived.
+	 *
+	 * A difference means something else already substituted one, which this must
+	 * not overrule.
+	 *
+	 * @param array<int, string> $address  The filtered address.
+	 * @param WC_Customer        $customer The customer it came from.
+	 */
+	private function matches_customer( array $address, WC_Customer $customer ): bool {
+		$expected = 'billing' === get_option( 'woocommerce_tax_based_on' )
+			? array( $customer->get_billing_country(), $customer->get_billing_state(), $customer->get_billing_postcode(), $customer->get_billing_city() )
+			: array( $customer->get_shipping_country(), $customer->get_shipping_state(), $customer->get_shipping_postcode(), $customer->get_shipping_city() );
+
+		return array_values( $address ) === $expected;
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Helper/WalletPaymentRecord.php
+++ b/modules/ppcp-sdk-v6/src/Helper/WalletPaymentRecord.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * One thing remembered for the duration of a wallet payment.
+ *
+ * The amount PayPal is charged is built from the cart in a later request, so a
+ * sheet's decisions have to outlive the request that made them. They must not
+ * outlive the payment: one an abandoned sheet left behind would price the next.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+abstract class WalletPaymentRecord {
+
+	protected const SESSION_KEY = '';
+
+	// The backstop for a shopper who walks away: outlasts a refused payment and its
+	// retry, but not the rest of their session.
+	private const TTL = 900;
+
+	/**
+	 * Drops the record, so the shopper's own choices apply again.
+	 */
+	public function forget(): void {
+		$session = WC()->session;
+		if ( $session ) {
+			$session->set( static::SESSION_KEY, null );
+		}
+	}
+
+	/**
+	 * Remembers a value for the rest of this payment.
+	 *
+	 * @param mixed $value The value to remember.
+	 */
+	protected function remember( $value ): void {
+		$session = WC()->session;
+		if ( ! $session ) {
+			return;
+		}
+
+		$session->set(
+			static::SESSION_KEY,
+			array(
+				'value'   => $value,
+				'expires' => time() + self::TTL,
+			)
+		);
+	}
+
+	/**
+	 * The remembered value, or null when there is none left to honour.
+	 *
+	 * @return mixed
+	 */
+	protected function remembered() {
+		$session = WC()->session;
+		$record  = $session ? $session->get( static::SESSION_KEY ) : null;
+
+		if ( ! is_array( $record ) || ! isset( $record['value'], $record['expires'] ) ) {
+			return null;
+		}
+
+		if ( $record['expires'] < time() ) {
+			$this->forget();
+
+			return null;
+		}
+
+		return $record['value'];
+	}
+}

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -10,12 +10,19 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\SdkV6;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\ApproveOrderEndpoint;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\ChangeCartEndpoint;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\AddPaymentMethodManager;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\WalletShippingEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedShippingRate;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedQuote;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedTaxBasis;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
@@ -67,6 +74,8 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 				$endpoint->handle_request();
 			}
 		);
+
+		$this->register_wallet_payment_records( $c );
 
 		add_action(
 			'wp_enqueue_scripts',
@@ -217,6 +226,109 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Wires the records that carry a wallet sheet's decisions through to its order.
+	 *
+	 * @param ContainerInterface $c The plugin container.
+	 */
+	private function register_wallet_payment_records( ContainerInterface $c ): void {
+		// Only where a payment is being priced. Elsewhere these would act on a record
+		// an abandoned sheet left behind, overriding a rate the shopper clicks or
+		// taxing them against the wallet's address.
+		if ( $this->prices_a_wallet_payment() ) {
+			add_filter(
+				'woocommerce_shipping_chosen_method',
+				static function ( $default, $rates = array() ) use ( $c ) {
+					$recorded_rate = $c->get( 'sdk-v6.recorded-shipping-rate' );
+					assert( $recorded_rate instanceof RecordedShippingRate );
+
+					return $recorded_rate->filter_chosen_method( $default, $rates );
+				},
+				20,
+				2
+			);
+
+			add_filter(
+				'woocommerce_customer_taxable_address',
+				static function ( $address ) use ( $c ) {
+					$recorded_tax_basis = $c->get( 'sdk-v6.recorded-tax-basis' );
+					assert( $recorded_tax_basis instanceof RecordedTaxBasis );
+
+					return $recorded_tax_basis->filter_taxable_address( $address );
+				},
+				20
+			);
+		}
+
+		$conclude_payment = static function ( $wc_order ) use ( $c ) {
+			$recorded_rate = $c->get( 'sdk-v6.recorded-shipping-rate' );
+			assert( $recorded_rate instanceof RecordedShippingRate );
+
+			$recorded_tax_basis = $c->get( 'sdk-v6.recorded-tax-basis' );
+			assert( $recorded_tax_basis instanceof RecordedTaxBasis );
+
+			$recorded_quote = $c->get( 'sdk-v6.recorded-quote' );
+			assert( $recorded_quote instanceof RecordedQuote );
+
+			$recorded_rate->forget();
+			$recorded_tax_basis->forget();
+
+			if ( $wc_order instanceof WC_Order ) {
+				$recorded_quote->apply_to_order( $wc_order );
+			} else {
+				$recorded_quote->forget();
+			}
+		};
+
+		// Both names, because which one fires depends on how the order was built:
+		// express payments go through WooCommerceOrderCreator, which announces itself
+		// as _from_cart, while the classic gateway and the pay-for-order page fire the
+		// plain name.
+		add_action( 'woocommerce_paypal_payments_woocommerce_order_created', $conclude_payment );
+		add_action( 'woocommerce_paypal_payments_woocommerce_order_created_from_cart', $conclude_payment );
+
+		// The order-received page's own success paragraph, so the message carries no
+		// markup and inherits that styling.
+		add_filter(
+			'woocommerce_thankyou_order_received_text',
+			static function ( $text, $wc_order ) use ( $c ) {
+				if ( ! is_string( $text ) || ! $wc_order instanceof WC_Order ) {
+					return $text;
+				}
+
+				$recorded_quote = $c->get( 'sdk-v6.recorded-quote' );
+				assert( $recorded_quote instanceof RecordedQuote );
+
+				return $recorded_quote->thank_you_message( $text, $wc_order );
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Whether this request is one that prices a wallet payment already in flight.
+	 *
+	 * Those four are every request whose cart calculation decides what the shopper is
+	 * shown or charged. Anything else, an ordinary page view included, must be left
+	 * to price the cart the shopper sees.
+	 */
+	private function prices_a_wallet_payment(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Reading which endpoint is being served, not acting on input; sanitize_key() drops any slashes along with everything outside [a-z0-9_-].
+		$action = is_string( $_GET['wc-ajax'] ?? null ) ? sanitize_key( $_GET['wc-ajax'] ) : '';
+
+		return in_array(
+			$action,
+			array(
+				WalletShippingEndpoint::ENDPOINT,
+				ChangeCartEndpoint::ENDPOINT,
+				CreateOrderEndpoint::ENDPOINT,
+				ApproveOrderEndpoint::ENDPOINT,
+			),
+			true
+		);
 	}
 
 	/**

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -404,7 +404,14 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 				'woocommerce_paypal_payments_pay_order_renderer_hook',
 				'woocommerce_pay_order_after_submit'
 			);
-			add_action( $hook, static fn() => $manager->render_wrapper(), 20 );
+			add_action(
+				$hook,
+				static function () use ( $manager ): void {
+					$manager->render_wrapper();
+					$manager->render_wallet_gateway_wrappers();
+				},
+				20
+			);
 		}
 
 		if ( $places['mini-cart'] ) {

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Assets\AddPaymentMethodManager;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\WalletShippingEndpoint;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
@@ -52,6 +53,16 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 			static function () use ( $c ) {
 				$endpoint = $c->get( 'sdk-v6.endpoint.simulate-cart' );
 				assert( $endpoint instanceof SimulateCartEndpoint );
+
+				$endpoint->handle_request();
+			}
+		);
+
+		add_action(
+			'wc_ajax_' . WalletShippingEndpoint::ENDPOINT,
+			static function () use ( $c ) {
+				$endpoint = $c->get( 'sdk-v6.endpoint.wallet-shipping' );
+				assert( $endpoint instanceof WalletShippingEndpoint );
 
 				$endpoint->handle_request();
 			}

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -63,36 +63,54 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
-     * A WC() stub carrying an empty cart/customer and a payment-gateways
-     * registry with no gateways available, matching the wallet defaults'
-     * "does not render" state used throughout this test.
+     * A WC() stub carrying an empty cart/customer, a payment-gateways registry
+     * with no gateways available (matching the wallet defaults' "does not
+     * render" state used throughout this test), and a countries service with
+     * an empty shipping-country list, so tests that reach shipping_countries()
+     * incidentally (without asserting on it) do not need their own setup.
      */
     private function create_wc_stub(): object
     {
         $payment_gateways = Mockery::mock();
         $payment_gateways->shouldReceive('get_available_payment_gateways')->andReturn([])->byDefault();
 
+        $countries = Mockery::mock();
+        $countries->shouldReceive('get_shipping_countries')->andReturn([])->byDefault();
+
         $wc = Mockery::mock();
         $wc->customer = null;
         $wc->cart = null;
+        $wc->countries = $countries;
         $wc->shouldReceive('payment_gateways')->andReturn($payment_gateways)->byDefault();
 
         return $wc;
     }
 
-    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = [], bool $card_vaulting_enabled = true, string $merchant_country = 'US'): SdkV6Manager
+    /**
+     * A WC_Product stub carrying the given virtual/downloadable flags, used to
+     * probe the product-page branch of the wallet shipping check.
+     */
+    private function create_product_stub(bool $is_virtual, bool $is_downloadable): object
+    {
+        $product = Mockery::mock(\WC_Product::class);
+        $product->shouldReceive('is_virtual')->andReturn($is_virtual);
+        $product->shouldReceive('is_downloadable')->andReturn($is_downloadable);
+
+        return $product;
+    }
+
+    private function createTestee(array $credit_card_icons = [], bool $card_vaulting_enabled = true, string $merchant_country = 'US', bool $final_review_enabled = false): SdkV6Manager
     {
         return new SdkV6Manager(
             $this->asset_getter,
             '1.0.0',
             $this->environment,
             $this->style_mapper,
-            $should_handle_shipping,
             $this->settings_status,
             $this->context,
             $this->session_handler,
             $this->cancel_view,
-            false,
+            $final_review_enabled,
             false,
             $this->card_payments_configuration,
 	        $card_vaulting_enabled,
@@ -233,7 +251,8 @@ class SdkV6ManagerTest extends TestCase
      * WHEN the SDK bootstrap data is generated
      * THEN the pay_now identifiers (order id and order key) are forwarded so the front end
      *      can create the PayPal order from the existing WC order
-     * AND shipping is not handled in PayPal for the pay-now page, matching checkout
+     * AND shipping is not collected on the pay-now page while the order's cart has nothing
+     *     to ship
      */
     public function testScriptDataIncludesPayNowIdentifiers(): void
     {
@@ -265,7 +284,7 @@ class SdkV6ManagerTest extends TestCase
         when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
-        $testee = $this->createTestee(true);
+        $testee = $this->createTestee();
         $data   = $testee->script_data();
 
         $this->assertSame(
@@ -273,7 +292,7 @@ class SdkV6ManagerTest extends TestCase
             $data['pay_now']
         );
         $this->assertSame('49.99', $data['amount']);
-        $this->assertFalse($data['shipping']['handle_in_paypal']);
+        $this->assertFalse($data['shipping']['in_context']['pay-now']);
     }
 
     /**
@@ -308,7 +327,7 @@ class SdkV6ManagerTest extends TestCase
         when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
-        $testee = $this->createTestee(false, [], true, 'FR');
+        $testee = $this->createTestee([], true, 'FR');
         $data   = $testee->script_data();
 
         $this->assertSame('FR', $data['merchant_country']);
@@ -358,7 +377,7 @@ class SdkV6ManagerTest extends TestCase
         when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
-        $testee = $this->createTestee(false, [], $card_vaulting_enabled);
+        $testee = $this->createTestee([], $card_vaulting_enabled);
         $data   = $testee->script_data();
 
         $this->assertSame($expected_enabled, $data['card_fields']['enabled']);
@@ -422,7 +441,7 @@ class SdkV6ManagerTest extends TestCase
         when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
-        $testee = $this->createTestee(false, $credit_card_icons);
+        $testee = $this->createTestee($credit_card_icons);
         $data   = $testee->script_data();
 
         $this->assertSame($expected_card_icons, $data['card_fields']['card_icons']);
@@ -440,5 +459,244 @@ class SdkV6ManagerTest extends TestCase
                 [],
             ],
         ];
+    }
+
+    /**
+     * GIVEN the merchant's final-review setting, the buyer's page context, and (on the
+     *       product page) the viewed product
+     * WHEN the SDK bootstrap data is generated
+     * THEN shipping.in_context reports, per context, whether that page should collect a
+     *      shipping address and offer shipping options for every surface that consumes it
+     *      (the PayPal popup, wallet sheets, and block express buttons): a final-review page
+     *      always disables it; the block cart/checkout contexts enable it unconditionally,
+     *      since the block components already gate on their own live cart state; the product
+     *      page is decided solely by the viewed product being physical and non-downloadable;
+     *      and every other context (cart, checkout, pay-now) falls back to whether the cart
+     *      needs shipping at all
+     * AND the mini-cart entry is always present alongside the current page's own entry,
+     *     since the mini-cart can render on any page independently of it
+     *
+     * @dataProvider shipping_in_context_provider
+     */
+    public function testScriptDataShippingInContextPerContext(
+        bool $final_review_enabled,
+        string $page_context,
+        bool $cart_needs_shipping,
+        string $product_state,
+        array $expected_in_context
+    ): void {
+        $this->context->shouldReceive('context')->andReturn($page_context);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        $wc = $this->create_wc_stub();
+        $cart = Mockery::mock();
+        $cart->shouldReceive('needs_shipping')->andReturn($cart_needs_shipping);
+        $cart->shouldReceive('is_empty')->andReturn(true);
+        $wc->cart = $cart;
+
+        $product = null;
+        if ('virtual' === $product_state) {
+            $product = $this->create_product_stub(true, false);
+        } elseif ('downloadable' === $product_state) {
+            $product = $this->create_product_stub(false, true);
+        } elseif ('physical' === $product_state) {
+            $product = $this->create_product_stub(false, false);
+        }
+
+        when('WC')->justReturn($wc);
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+        when('wc_get_product')->justReturn($product);
+
+        $testee = $this->createTestee([], true, 'US', $final_review_enabled);
+        $data   = $testee->script_data();
+
+        $this->assertSame($expected_in_context, $data['shipping']['in_context']);
+    }
+
+    public function shipping_in_context_provider(): array
+    {
+        return [
+            'a final review page disables shipping everywhere' => [
+                true, 'cart', true, 'none',
+                ['cart' => false, 'mini-cart' => false],
+            ],
+            'classic checkout collects shipping when the cart needs it' => [
+                false, 'checkout', true, 'none',
+                ['checkout' => true, 'mini-cart' => true],
+            ],
+            'pay-now falls out via the cart having nothing to ship, not a hardcoded exclusion' => [
+                false, 'pay-now', false, 'none',
+                ['pay-now' => false, 'mini-cart' => false],
+            ],
+            'cart page with a cart needing shipping enables shipping' => [
+                false, 'cart', true, 'none',
+                ['cart' => true, 'mini-cart' => true],
+            ],
+            'cart page with a cart that does not need shipping disables shipping' => [
+                false, 'cart', false, 'none',
+                ['cart' => false, 'mini-cart' => false],
+            ],
+            'product page with a physical product enables shipping even with an empty cart' => [
+                false, 'product', false, 'physical',
+                ['product' => true, 'mini-cart' => false],
+            ],
+            'product page with a physical product and a cart needing shipping enables shipping' => [
+                false, 'product', true, 'physical',
+                ['product' => true, 'mini-cart' => true],
+            ],
+            'product page with a virtual product disables shipping only for the product context' => [
+                false, 'product', true, 'virtual',
+                ['product' => false, 'mini-cart' => true],
+            ],
+            'product page with a downloadable product disables shipping only for the product context' => [
+                false, 'product', true, 'downloadable',
+                ['product' => false, 'mini-cart' => true],
+            ],
+            'product page with no resolvable product disables shipping only for the product context' => [
+                false, 'product', true, 'none',
+                ['product' => false, 'mini-cart' => true],
+            ],
+            'cart-block context enables shipping without consulting the cart' => [
+                false, 'cart-block', false, 'none',
+                ['cart-block' => true, 'mini-cart' => false],
+            ],
+            'checkout-block context enables shipping without consulting the cart' => [
+                false, 'checkout-block', false, 'none',
+                ['checkout-block' => true, 'mini-cart' => false],
+            ],
+            'a final review page disables the block contexts too' => [
+                true, 'checkout-block', true, 'none',
+                ['checkout-block' => false, 'mini-cart' => false],
+            ],
+        ];
+    }
+
+    /**
+     * GIVEN whether any context collects a shipping address, and whether WooCommerce's
+     *       countries service is available
+     * WHEN the SDK bootstrap data is generated
+     * THEN shipping.countries hands Google Pay the store's full shipping-country list
+     *      whenever at least one context needs shipping, matching the classic
+     *      integration, which always sent the whole list rather than trimming it to a
+     *      restricted subset
+     * AND it is empty when no context needs shipping, or when the countries service itself
+     *     is unavailable
+     *
+     * @dataProvider shipping_countries_provider
+     */
+    public function testScriptDataShippingCountries(
+        bool $final_review_enabled,
+        bool $cart_needs_shipping,
+        ?array $shipping_countries,
+        array $expected_countries
+    ): void {
+        $this->context->shouldReceive('context')->andReturn('cart');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        $wc = $this->create_wc_stub();
+        $cart = Mockery::mock();
+        $cart->shouldReceive('needs_shipping')->andReturn($cart_needs_shipping);
+        $cart->shouldReceive('is_empty')->andReturn(true);
+        $wc->cart = $cart;
+
+        if (null !== $shipping_countries) {
+            $wc->countries = Mockery::mock();
+            $wc->countries->shouldReceive('get_shipping_countries')->andReturn($shipping_countries);
+        } else {
+            $wc->countries = null;
+        }
+
+        when('WC')->justReturn($wc);
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee([], true, 'US', $final_review_enabled);
+        $data   = $testee->script_data();
+
+        $this->assertSame($expected_countries, $data['shipping']['countries']);
+    }
+
+    public function shipping_countries_provider(): array
+    {
+        return [
+            'no context needing shipping yields an empty country list' => [
+                true, true, ['US' => 'United States'], [],
+            ],
+            'a context needing shipping returns the store\'s full shipping country list' => [
+                false, true, ['US' => 'United States', 'CA' => 'Canada'], ['US', 'CA'],
+            ],
+            'no countries service available yields an empty list even though shipping is enabled' => [
+                false, true, null, [],
+            ],
+        ];
+    }
+
+    /**
+     * GIVEN the SDK bootstrap data is generated
+     * WHEN reading the labels payload
+     * THEN it carries the shipping-unserviceable message shown when a wallet sheet's address
+     *      cannot be served, and the itemization labels the Apple Pay sheet uses to break
+     *      down the total
+     */
+    public function testScriptDataIncludesShippingAndItemizationLabels(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout-block');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        when('WC')->justReturn($this->create_wc_stub());
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(
+            [
+                'generic_error'          => 'Something went wrong. Please try again or choose another payment source.',
+                'shipping_unserviceable' => 'Cannot ship to the selected address.',
+                'subtotal'               => 'Subtotal',
+                'shipping'               => 'Shipping',
+                'tax'                    => 'Tax',
+                'discount'               => 'Discount',
+            ],
+            $data['labels']
+        );
     }
 }

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -1657,8 +1657,10 @@ class SdkV6ManagerTest extends TestCase
      * WHEN the SDK bootstrap data is generated
      * THEN the card_button payload carries the payment method id, funding source,
      *      wrapper selector and button styling alongside its enabled flag
-     * AND the front-end labels include a card_declined message for the SDK to
-     *     show when a card is declined
+     * AND the front-end labels payload carries a card_declined key for the SDK to
+     *     show when a card is declined — only the key's presence is pinned, not
+     *     its wording, since the frontend renders whatever text arrives and this
+     *     project revises user-facing copy independently of this test
      */
     public function testScriptDataCardButtonShapeAndCardDeclinedLabel(): void
     {
@@ -1696,10 +1698,8 @@ class SdkV6ManagerTest extends TestCase
             ],
             $data['card_button']['styles']
         );
-        $this->assertSame(
-            'The card could not be charged. Please check the details or try a different card.',
-            $data['labels']['card_declined']
-        );
+        $this->assertArrayHasKey('card_declined', $data['labels']);
+        $this->assertNotSame('', $data['labels']['card_declined']);
     }
 
     /**
@@ -2023,9 +2023,13 @@ class SdkV6ManagerTest extends TestCase
     /**
      * GIVEN the SDK bootstrap data is generated
      * WHEN reading the labels payload
-     * THEN it carries the shipping-unserviceable message shown when a wallet sheet's address
-     *      cannot be served, and the itemization labels the Apple Pay sheet uses to break
-     *      down the total
+     * THEN it carries exactly the documented keys — the shipping-unserviceable key
+     *      shown when a wallet sheet's address cannot be served, and the itemization
+     *      keys the Apple Pay sheet uses to break down the total — since a missing
+     *      or renamed key is what would break those consumers, not the wording
+     * AND every label is a non-empty string, since the exact copy is not the
+     *     contract: the frontend renders whatever text arrives, and this project
+     *     revises user-facing copy independently of this test
      */
     public function testScriptDataIncludesShippingAndItemizationLabels(): void
     {
@@ -2052,10 +2056,14 @@ class SdkV6ManagerTest extends TestCase
         $testee = $this->createTestee();
         $data   = $testee->script_data();
 
-        $this->assertSame('Cannot ship to the selected address.', $data['labels']['shipping_unserviceable']);
-        $this->assertSame('Subtotal', $data['labels']['subtotal']);
-        $this->assertSame('Shipping', $data['labels']['shipping']);
-        $this->assertSame('Tax', $data['labels']['tax']);
-        $this->assertSame('Discount', $data['labels']['discount']);
+        $this->assertSame(
+            ['generic_error', 'card_declined', 'shipping_unserviceable', 'subtotal', 'shipping', 'tax', 'discount'],
+            array_keys($data['labels'])
+        );
+
+        foreach ($data['labels'] as $label) {
+            $this->assertIsString($label);
+            $this->assertNotSame('', $label);
+        }
     }
 }

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -468,11 +468,14 @@ class SdkV6ManagerTest extends TestCase
      * THEN shipping.in_context reports, per context, whether that page should collect a
      *      shipping address and offer shipping options for every surface that consumes it
      *      (the PayPal popup, wallet sheets, and block express buttons): a final-review page
-     *      always disables it; the block cart/checkout contexts enable it unconditionally,
-     *      since the block components already gate on their own live cart state; the product
-     *      page is decided solely by the viewed product being physical and non-downloadable;
-     *      and every other context (cart, checkout, pay-now) falls back to whether the cart
-     *      needs shipping at all
+     *      always disables it; classic checkout and the pay-for-order page always disable it
+     *      too, since checkout builds the WC order from its own posted address/shipping fields
+     *      and the pay-for-order page pays an order already priced from itself, so neither page
+     *      can let a wallet sheet collect a destination or total the order can't use; the block
+     *      cart/checkout contexts enable it unconditionally, since the block components already
+     *      gate on their own live cart state; the product page is decided solely by the viewed
+     *      product being physical and non-downloadable; and every remaining context (cart) falls
+     *      back to whether the cart needs shipping at all
      * AND the mini-cart entry is always present alongside the current page's own entry,
      *     since the mini-cart can render on any page independently of it
      *
@@ -533,11 +536,19 @@ class SdkV6ManagerTest extends TestCase
                 true, 'cart', true, 'none',
                 ['cart' => false, 'mini-cart' => false],
             ],
-            'classic checkout collects shipping when the cart needs it' => [
+            'classic checkout never collects shipping even when the cart needs it' => [
                 false, 'checkout', true, 'none',
-                ['checkout' => true, 'mini-cart' => true],
+                ['checkout' => false, 'mini-cart' => true],
             ],
-            'pay-now falls out via the cart having nothing to ship, not a hardcoded exclusion' => [
+            'classic checkout stays disabled when the cart needs no shipping either' => [
+                false, 'checkout', false, 'none',
+                ['checkout' => false, 'mini-cart' => false],
+            ],
+            'the pay-for-order page never collects shipping even when the cart needs it' => [
+                false, 'pay-now', true, 'none',
+                ['pay-now' => false, 'mini-cart' => true],
+            ],
+            'the pay-for-order page stays disabled when the cart needs no shipping either' => [
                 false, 'pay-now', false, 'none',
                 ['pay-now' => false, 'mini-cart' => false],
             ],

--- a/tests/PHPUnit/SdkV6/Endpoint/WalletShippingEndpointTest.php
+++ b/tests/PHPUnit/SdkV6/Endpoint/WalletShippingEndpointTest.php
@@ -1,0 +1,481 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Endpoint;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Psr\Log\LoggerInterface;
+use WC_Cart;
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedShippingRate;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\StubsWcSession;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedQuote;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedTaxBasis;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+use function Brain\Monkey\Functions\expect;
+
+class WalletShippingEndpointTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+	use StubsWcSession;
+
+	/**
+	 * @var RequestData&Mockery\MockInterface
+	 */
+	private $request_data;
+
+	/**
+	 * @var AmountFactory&Mockery\MockInterface
+	 */
+	private $amount_factory;
+
+	private RecordedShippingRate $recorded_rate;
+
+	private RecordedTaxBasis $recorded_tax_basis;
+
+	private RecordedQuote $recorded_quote;
+
+	private WalletShippingEndpoint $sut;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	private array $session_state = array();
+
+	/**
+	 * What the amount_factory stub reports for from_wc_cart(), so one expectation
+	 * covers every stub_cart() call instead of stacking a losing one per call.
+	 *
+	 * @var Amount&Mockery\MockInterface
+	 */
+	private $current_amount;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->request_data     = Mockery::mock( RequestData::class );
+		$this->amount_factory   = Mockery::mock( AmountFactory::class );
+		$this->recorded_rate         = new RecordedShippingRate();
+		$this->recorded_tax_basis        = new RecordedTaxBasis();
+		$this->recorded_quote = new RecordedQuote();
+		$logger                 = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+
+		$this->amount_factory->allows( 'from_wc_cart' )->andReturnUsing(
+			function () {
+				return $this->current_amount;
+			}
+		);
+
+		$this->sut = new WalletShippingEndpoint(
+			$this->request_data,
+			$this->amount_factory,
+			$this->recorded_rate,
+			$this->recorded_tax_basis,
+			$this->recorded_quote,
+			$logger
+		);
+
+		when( 'wc_get_price_decimals' )->justReturn( 2 );
+		when( 'wc_format_decimal' )->justReturn( '0.00' );
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		// A plain, deterministic stand-in for wc_price(): keeps the two decimals the
+		// comparison logic already normalized to, without formatting concerns.
+		when( 'wc_price' )->alias(
+			static fn( $amount, $args = array() ) => number_format( (float) $amount, 2, '.', '' )
+		);
+		when( 'wp_strip_all_tags' )->returnArg();
+
+		$this->stub_wc();
+	}
+
+	/**
+	 * Wires up the WC() global. The real RecordedShippingRate and RecordedTaxBasis run
+	 * against it, so the session has to persist what they write.
+	 *
+	 * @param array<string, string>|null $countries Country code => name pairs, as
+	 *                                               WC()->countries->get_countries() returns them.
+	 */
+	private function stub_wc( ?WC_Cart $cart = null, ?array $countries = null ): void {
+		$session = $this->session_with( $this->session_state );
+
+		$shipping = Mockery::mock( 'WC_Shipping' );
+		$shipping->allows( 'get_packages' )->andReturn( array() );
+
+		$countries_provider = Mockery::mock( 'WC_Countries' );
+		$countries_provider->allows( 'get_countries' )->andReturn( $countries ?? array() );
+
+		$wc            = Mockery::mock( 'WooCommerce' );
+		$wc->allows( 'shipping' )->andReturn( $shipping );
+		$wc->session   = $session;
+		$wc->cart      = $cart ?? $this->stub_cart( '0.00' );
+		$wc->customer  = null;
+		$wc->countries = $countries_provider;
+
+		when( 'WC' )->justReturn( $wc );
+	}
+
+	/**
+	 * A cart stub whose recomputed total, as reported by AmountFactory, is fixed
+	 * to the given amount.
+	 */
+	private function stub_cart( string $total ): WC_Cart {
+		$cart = Mockery::mock( 'WC_Cart' );
+		$cart->allows( 'calculate_shipping' );
+		$cart->allows( 'calculate_totals' );
+		$cart->allows( 'needs_shipping' )->andReturn( false );
+
+		$amount = Mockery::mock( Amount::class );
+		$amount->allows( 'value_str' )->andReturn( $total );
+		$amount->allows( 'breakdown' )->andReturn( null );
+
+		$this->current_amount = $amount;
+
+		return $cart;
+	}
+
+	private function stub_request( array $data ): void {
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( WalletShippingEndpoint::nonce() )
+			->andReturn( $data );
+	}
+
+	/**
+	 * GIVEN a store's tax-basis configuration and any address already recorded
+	 * from an earlier request in this payment
+	 * WHEN a wallet shipping request carries the given addresses
+	 * THEN the recorded tax basis afterwards is the expected address
+	 *
+	 * @dataProvider tax_basis_provider
+	 */
+	public function test_tax_basis_after_request( ?array $initial_basis, string $tax_based_on, array $request, array $expected ): void {
+		when( 'get_option' )->justReturn( $tax_based_on );
+		when( 'wp_send_json_success' )->justReturn( null );
+
+		if ( $initial_basis ) {
+			$this->recorded_tax_basis->set( $initial_basis );
+		}
+
+		$this->stub_request( $request );
+
+		$this->sut->handle_request();
+
+		$this->assertSame( $expected, $this->recorded_tax_basis->get() );
+	}
+
+	public function tax_basis_provider(): array {
+		return array(
+			'billing address recorded once it arrives at commit'               => array(
+				null,
+				'billing',
+				array(
+					'address'         => array(
+						'country'  => 'FR',
+						'postcode' => '75000',
+					),
+					'billing_address' => array(
+						'country'  => 'DE',
+						'postcode' => '10115',
+					),
+				),
+				array(
+					'country'  => 'DE',
+					'postcode' => '10115',
+				),
+			),
+			'destination stands in for the payer\'s address before authorization' => array(
+				null,
+				'billing',
+				array(
+					'address' => array(
+						'country'  => 'FR',
+						'postcode' => '75000',
+					),
+				),
+				array(
+					'country'  => 'FR',
+					'postcode' => '75000',
+				),
+			),
+			'a retry estimate never displaces the payer\'s already recorded address' => array(
+				array(
+					'country'  => 'DE',
+					'postcode' => '10115',
+				),
+				'billing',
+				array(
+					'address' => array(
+						'country'  => 'FR',
+						'postcode' => '75000',
+					),
+				),
+				array(
+					'country'  => 'DE',
+					'postcode' => '10115',
+				),
+			),
+			'nothing is recorded when the store does not tax on the billing address' => array(
+				null,
+				'shipping',
+				array(
+					'address' => array(
+						'country'  => 'FR',
+						'postcode' => '75000',
+					),
+				),
+				array(),
+			),
+		);
+	}
+
+	/**
+	 * GIVEN a wallet request that quoted a price to the shopper
+	 * WHEN the recomputed cart total is compared against the total the sheet
+	 * displayed
+	 * THEN the quote is answered unless the recomputed total is higher, and the
+	 * comparison is made in integer cents regardless of the shop's own display
+	 * precision
+	 *
+	 * @dataProvider price_guard_provider
+	 */
+	public function test_price_guard( string $expected_total, string $recomputed_total, int $price_decimals, bool $should_be_refused ): void {
+		when( 'get_option' )->justReturn( 'shipping' );
+		when( 'wc_get_price_decimals' )->justReturn( $price_decimals );
+
+		$this->stub_wc( $this->stub_cart( $recomputed_total ) );
+		$this->stub_request( array( 'expected_total' => $expected_total ) );
+
+		if ( $should_be_refused ) {
+			expect( 'wp_send_json_error' )
+				->once()
+				->with(
+					Mockery::on(
+						static function ( $payload ) {
+							return isset( $payload['message'] ) && '' !== $payload['message'];
+						}
+					)
+				);
+			expect( 'wp_send_json_success' )->never();
+		} else {
+			expect( 'wp_send_json_success' )
+				->once()
+				->with(
+					Mockery::on(
+						static function ( $payload ) use ( $recomputed_total ) {
+							return isset( $payload['total'] ) && $recomputed_total === $payload['total'];
+						}
+					)
+				);
+			expect( 'wp_send_json_error' )->never();
+		}
+
+		$this->sut->handle_request();
+	}
+
+	public function price_guard_provider(): array {
+		return array(
+			'total exactly equal to the sheet\'s displayed total proceeds'            => array( '10.00', '10.00', 2, false ),
+			'total one cent higher than the sheet\'s displayed total is refused'      => array( '10.00', '10.01', 2, true ),
+			'total lower than the sheet\'s displayed total proceeds'                  => array( '10.00', '9.99', 2, false ),
+			'a one-cent overcharge is still caught on a zero-decimal shop, because AmountFactory always formats two decimals' => array( '100.00', '100.01', 0, true ),
+		);
+	}
+
+	/**
+	 * GIVEN a shopper chose a shipping rate, a tax basis was recorded for the open
+	 * payment sheet, and an authorized quote was recorded for it
+	 * WHEN the sheet is dismissed and sends a release request
+	 * THEN neither the chosen rate, the tax basis, nor the price adjustment carries
+	 * over to a later, ordinary checkout
+	 */
+	public function test_release_clears_every_record_of_the_payment(): void {
+		$this->recorded_rate->set( 'flat_rate:1' );
+		$this->recorded_tax_basis->set(
+			array(
+				'country'  => 'DE',
+				'postcode' => '10115',
+			)
+		);
+		$this->recorded_quote->set( '10.00' );
+
+		$this->stub_request( array( 'release' => true ) );
+
+		when( 'wp_send_json_success' )->justReturn( null );
+
+		$this->sut->handle_request();
+
+		$this->assertSame( '', $this->recorded_rate->get() );
+		$this->assertSame( array(), $this->recorded_tax_basis->get() );
+
+		$meta = array();
+		$this->recorded_quote->apply_to_order( $this->order_with( '5.00', $meta ) );
+		$this->assertSame( array(), $meta );
+	}
+
+	// ---------------------------------------------------------------------
+	// price adjustment recording
+	// ---------------------------------------------------------------------
+
+	/**
+	 * GIVEN a wallet request whose recomputed total matches the total the sheet
+	 * posted as authorized
+	 * WHEN the request is handled
+	 * THEN the quote is recorded, so applying it afterward to the order created for
+	 * this payment annotates the order with the difference from its actual total
+	 */
+	public function test_authorized_quote_is_recorded_when_expected_total_is_posted(): void {
+		when( 'get_option' )->justReturn( 'shipping' );
+		when( 'wp_send_json_success' )->justReturn( null );
+
+		$this->stub_wc( $this->stub_cart( '10.00' ) );
+		$this->stub_request( array( 'expected_total' => '10.00' ) );
+
+		$this->sut->handle_request();
+
+		$meta  = array();
+		$notes = array();
+		$this->recorded_quote->apply_to_order( $this->order_with( '9.00', $meta, $notes ) );
+
+		$this->assertSame( '10.00', $meta[ RecordedQuote::ORDER_META_KEY ] );
+		$this->assertCount( 1, $notes );
+	}
+
+	/**
+	 * GIVEN a wallet request that posts no authorized total, e.g. an in-sheet
+	 * recalculation before the shopper authorizes
+	 * WHEN the request is handled
+	 * THEN nothing is recorded, so applying the adjustment to the order created for
+	 * this payment leaves it unannotated
+	 */
+	public function test_no_quote_is_recorded_when_expected_total_is_absent(): void {
+		when( 'get_option' )->justReturn( 'shipping' );
+		when( 'wp_send_json_success' )->justReturn( null );
+
+		$this->stub_wc( $this->stub_cart( '10.00' ) );
+		$this->stub_request( array() );
+
+		$this->sut->handle_request();
+
+		$meta  = array();
+		$notes = array();
+		$this->recorded_quote->apply_to_order( $this->order_with( '9.00', $meta, $notes ) );
+
+		$this->assertSame( array(), $meta );
+		$this->assertSame( array(), $notes );
+	}
+
+	// ---------------------------------------------------------------------
+	// refusal message
+	// ---------------------------------------------------------------------
+
+	/**
+	 * GIVEN a billing address whose country WooCommerce has a translated name for,
+	 * and a recomputed total that exceeds the total the sheet quoted
+	 * WHEN the request is handled
+	 * THEN the shopper is refused, and the message names the country and the
+	 * corrected total
+	 */
+	public function test_refusal_message_names_a_country_known_to_woocommerce(): void {
+		when( 'get_option' )->justReturn( 'shipping' );
+
+		$this->stub_wc( $this->stub_cart( '10.01' ), array( 'DE' => 'Germany' ) );
+		$this->stub_request(
+			array(
+				'expected_total'  => '10.00',
+				'billing_address' => array( 'country' => 'DE' ),
+			)
+		);
+
+		$captured_message = '';
+		expect( 'wp_send_json_error' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $payload ) use ( &$captured_message ) {
+						$captured_message = $payload['message'] ?? '';
+
+						return true;
+					}
+				)
+			);
+
+		$this->sut->handle_request();
+
+		$this->assertStringContainsString( 'Germany', $captured_message );
+		$this->assertStringContainsString( '10.01', $captured_message );
+	}
+
+	/**
+	 * GIVEN a billing address whose country code WooCommerce has no translated name
+	 * for, and a recomputed total that exceeds the total the sheet quoted
+	 * WHEN the request is handled
+	 * THEN the shopper is refused, and the message falls back to the raw country
+	 * code
+	 */
+	public function test_refusal_message_falls_back_to_the_raw_country_code_when_unknown(): void {
+		when( 'get_option' )->justReturn( 'shipping' );
+
+		$this->stub_wc( $this->stub_cart( '10.01' ), array( 'DE' => 'Germany' ) );
+		$this->stub_request(
+			array(
+				'expected_total'  => '10.00',
+				'billing_address' => array( 'country' => 'ZZ' ),
+			)
+		);
+
+		$captured_message = '';
+		expect( 'wp_send_json_error' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $payload ) use ( &$captured_message ) {
+						$captured_message = $payload['message'] ?? '';
+
+						return true;
+					}
+				)
+			);
+
+		$this->sut->handle_request();
+
+		$this->assertStringContainsString( 'ZZ', $captured_message );
+		$this->assertStringContainsString( '10.01', $captured_message );
+	}
+
+	/**
+	 * An order whose total, meta and notes are all backed by plain arrays, so what
+	 * the price adjustment writes is visible to assertions the same way a real
+	 * WC_Order persists it.
+	 */
+	private function order_with( string $total, array &$meta = array(), array &$notes = array() ): WC_Order {
+		$order = Mockery::mock( WC_Order::class );
+
+		$order->allows( 'get_total' )->andReturn( $total );
+		$order->allows( 'get_currency' )->andReturn( 'USD' );
+
+		$order->allows( 'get_meta' )->andReturnUsing(
+			static fn( string $key ) => $meta[ $key ] ?? ''
+		);
+
+		$order->allows( 'update_meta_data' )->andReturnUsing(
+			static function ( string $key, $value ) use ( &$meta ): void {
+				$meta[ $key ] = $value;
+			}
+		);
+
+		$order->allows( 'add_order_note' )->andReturnUsing(
+			static function ( string $note ) use ( &$notes ): void {
+				$notes[] = $note;
+			}
+		);
+
+		$order->allows( 'save' );
+
+		return $order;
+	}
+}

--- a/tests/PHPUnit/SdkV6/Helper/RecordedQuoteTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/RecordedQuoteTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WC_Order;
+use WC_Session;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class RecordedQuoteTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+	use StubsWcSession;
+
+	private RecordedQuote $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// A plain, deterministic stand-in for wc_price(): keeps the two decimals the
+		// comparison logic already normalized to, without formatting concerns.
+		when( 'wc_price' )->alias(
+			static fn( $amount, $args = array() ) => number_format( (float) $amount, 2, '.', '' )
+		);
+		when( 'wp_strip_all_tags' )->returnArg();
+
+		$this->sut = new RecordedQuote();
+	}
+
+	private function stub_wc( ?WC_Session $session ): void {
+		when( 'WC' )->justReturn( (object) array( 'session' => $session ) );
+	}
+
+	/**
+	 * An order whose total, meta and notes are all backed by plain arrays, so what
+	 * the SUT writes is visible to assertions the same way a real WC_Order persists it.
+	 */
+	private function order_with( string $total, array &$meta = array(), array &$notes = array() ): WC_Order {
+		$order = Mockery::mock( WC_Order::class );
+
+		$order->allows( 'get_total' )->andReturn( $total );
+		$order->allows( 'get_currency' )->andReturn( 'USD' );
+
+		$order->allows( 'get_meta' )->andReturnUsing(
+			static fn( string $key ) => $meta[ $key ] ?? ''
+		);
+
+		$order->allows( 'update_meta_data' )->andReturnUsing(
+			static function ( string $key, $value ) use ( &$meta ): void {
+				$meta[ $key ] = $value;
+			}
+		);
+
+		$order->allows( 'add_order_note' )->andReturnUsing(
+			static function ( string $note ) use ( &$notes ): void {
+				$notes[] = $note;
+			}
+		);
+
+		$order->allows( 'save' );
+
+		return $order;
+	}
+
+	// ---------------------------------------------------------------------
+	// record() / apply_to_order()
+	// ---------------------------------------------------------------------
+
+	/**
+	 * GIVEN the sheet quoted a higher total than the order ends up totaling
+	 * WHEN the quote is recorded at authorization and later applied to the order
+	 * THEN the order is annotated with a private note describing both totals
+	 * AND the quoted total is stored as order meta
+	 */
+	public function test_recorded_quote_is_applied_to_the_order_when_totals_differ(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$this->sut->set( '12.00' );
+
+		$meta  = array();
+		$notes = array();
+		$order = $this->order_with( '10.00', $meta, $notes );
+
+		$this->sut->apply_to_order( $order );
+
+		$this->assertSame( '12.00', $meta[ RecordedQuote::ORDER_META_KEY ] );
+		$this->assertCount( 1, $notes );
+		$this->assertStringContainsString( '12.00', $notes[0] );
+		$this->assertStringContainsString( '10.00', $notes[0] );
+	}
+
+	/**
+	 * GIVEN a quote already applied to one order
+	 * WHEN a second order is later created for a different payment
+	 * THEN applying the adjustment to that second order leaves it untouched, because
+	 * the quote describes one payment and was consumed by the first order
+	 */
+	public function test_quote_is_consumed_so_a_second_order_does_not_inherit_it(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$this->sut->set( '12.00' );
+
+		$first_meta  = array();
+		$first_notes = array();
+		$this->sut->apply_to_order( $this->order_with( '10.00', $first_meta, $first_notes ) );
+
+		$second_meta  = array();
+		$second_notes = array();
+		$this->sut->apply_to_order( $this->order_with( '5.00', $second_meta, $second_notes ) );
+
+		$this->assertArrayNotHasKey( RecordedQuote::ORDER_META_KEY, $second_meta );
+		$this->assertSame( array(), $second_notes );
+	}
+
+	/**
+	 * GIVEN a quoted total and an order total that differ only by float noise
+	 * WHEN the quote is applied to the order
+	 * THEN nothing is recorded, because the two amounts are equal once compared in
+	 * integer cents
+	 */
+	public function test_apply_to_order_records_nothing_when_totals_are_equal_in_cents(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$this->sut->set( '19.99' );
+
+		$meta  = array();
+		$notes = array();
+		$order = $this->order_with( '19.990000004', $meta, $notes );
+
+		$this->sut->apply_to_order( $order );
+
+		$this->assertSame( array(), $meta );
+		$this->assertSame( array(), $notes );
+	}
+
+	// ---------------------------------------------------------------------
+	// thank_you_message()
+	// ---------------------------------------------------------------------
+
+	/**
+	 * GIVEN an order for which no reduction was ever recorded, or one whose total is
+	 * not below the total the sheet quoted
+	 * WHEN the order-received message is filtered
+	 * THEN the message is returned unchanged
+	 *
+	 * @dataProvider unchanged_message_provider
+	 */
+	public function test_thank_you_message_is_unchanged( array $meta, string $total ): void {
+		$order = $this->order_with( $total, $meta );
+
+		$this->assertSame( 'Thank you.', $this->sut->thank_you_message( 'Thank you.', $order ) );
+	}
+
+	public function unchanged_message_provider(): array {
+		return array(
+			'no adjustment was ever recorded for this order' => array( array(), '10.00' ),
+			'the order total equals the quoted total'        => array(
+				array( RecordedQuote::ORDER_META_KEY => '10.00' ),
+				'10.00',
+			),
+			'the order total is higher than the quoted total' => array(
+				array( RecordedQuote::ORDER_META_KEY => '10.00' ),
+				'12.00',
+			),
+		);
+	}
+
+	/**
+	 * GIVEN an order whose recorded quote is higher than what was actually charged
+	 * WHEN the order-received message is filtered
+	 * THEN the original text is kept and a sentence explaining the reduction is
+	 * appended, naming both totals and the difference between them
+	 */
+	public function test_thank_you_message_appends_a_reduction_notice_when_the_shopper_paid_less(): void {
+		$meta  = array( RecordedQuote::ORDER_META_KEY => '12.00' );
+		$order = $this->order_with( '10.00', $meta );
+
+		$result = $this->sut->thank_you_message( 'Thank you.', $order );
+
+		$this->assertStringStartsWith( 'Thank you.', $result );
+		$this->assertStringContainsString( '12.00', $result );
+		$this->assertStringContainsString( '10.00', $result );
+
+		// Derived from the other two, so a wrong subtraction would contradict them.
+		$this->assertStringContainsString( '2.00', $result );
+	}
+}

--- a/tests/PHPUnit/SdkV6/Helper/RecordedTaxBasisTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/RecordedTaxBasisTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WC_Customer;
+use WC_Session;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class RecordedTaxBasisTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+	use StubsWcSession;
+
+	private RecordedTaxBasis $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// A shopper who has not chosen local pickup and a store that taxes on the
+		// shipping address, unless a test says otherwise.
+		when( 'apply_filters' )->justReturn( array( 'legacy_local_pickup', 'local_pickup' ) );
+		when( 'wc_get_chosen_shipping_method_ids' )->justReturn( array( 'flat_rate' ) );
+		when( 'get_option' )->justReturn( '' );
+
+		$this->sut = new RecordedTaxBasis();
+	}
+
+	private function stub_wc( ?WC_Session $session, ?WC_Customer $customer = null ): void {
+		when( 'WC' )->justReturn(
+			(object) array(
+				'session'  => $session,
+				'customer' => $customer,
+			)
+		);
+	}
+
+	private function customer( array $billing, array $shipping ): WC_Customer {
+		$customer = Mockery::mock( WC_Customer::class );
+		$customer->allows( 'get_billing_country' )->andReturn( $billing['country'] ?? '' );
+		$customer->allows( 'get_billing_state' )->andReturn( $billing['state'] ?? '' );
+		$customer->allows( 'get_billing_postcode' )->andReturn( $billing['postcode'] ?? '' );
+		$customer->allows( 'get_billing_city' )->andReturn( $billing['city'] ?? '' );
+		$customer->allows( 'get_shipping_country' )->andReturn( $shipping['country'] ?? '' );
+		$customer->allows( 'get_shipping_state' )->andReturn( $shipping['state'] ?? '' );
+		$customer->allows( 'get_shipping_postcode' )->andReturn( $shipping['postcode'] ?? '' );
+		$customer->allows( 'get_shipping_city' )->andReturn( $shipping['city'] ?? '' );
+
+		return $customer;
+	}
+
+	private function basis_address(): array {
+		return array(
+			'country'  => 'US',
+			'state'    => 'CA',
+			'postcode' => '90210',
+			'city'     => 'Beverly Hills',
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// set() / get()
+	// ---------------------------------------------------------------------
+
+	/**
+	 * GIVEN a wallet-reported address that carries a country
+	 * WHEN it is recorded and then read back
+	 * THEN the same address is returned
+	 */
+	public function test_get_returns_the_address_that_was_set(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$this->sut->set( $this->basis_address() );
+
+		$this->assertSame( $this->basis_address(), $this->sut->get() );
+	}
+
+	/**
+	 * GIVEN a wallet-reported address with no country
+	 * WHEN it is recorded
+	 * THEN nothing is stored, because an address without a country is not a basis for tax
+	 */
+	public function test_set_ignores_an_address_without_a_country(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$this->sut->set(
+			array(
+				'state'    => 'CA',
+				'postcode' => '90210',
+			)
+		);
+
+		$this->assertSame( array(), $this->sut->get() );
+	}
+
+	/**
+	 * GIVEN nothing was ever recorded
+	 * WHEN the basis is read
+	 * THEN an empty array is returned
+	 */
+	public function test_get_returns_empty_array_when_nothing_is_stored(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$this->assertSame( array(), $this->sut->get() );
+	}
+
+	// ---------------------------------------------------------------------
+	// filter_taxable_address()
+	// ---------------------------------------------------------------------
+
+	/**
+	 * GIVEN a recorded wallet address
+	 * AND the store taxes on the shipping address, which the incoming address matches
+	 * WHEN the taxable address filter runs
+	 * THEN the recorded address is substituted as a positional [country, state, postcode, city] tuple
+	 */
+	public function test_filter_substitutes_the_recorded_address_when_shipping_based(): void {
+		$store    = array();
+		$customer = $this->customer(
+			array(),
+			array(
+				'country'  => 'FR',
+				'state'    => 'IDF',
+				'postcode' => '75001',
+				'city'     => 'Paris',
+			)
+		);
+		$this->stub_wc( $this->session_with( $store ), $customer );
+		when( 'time' )->justReturn( 1000 );
+		when( 'get_option' )->justReturn( 'shipping' );
+
+		$this->sut->set( $this->basis_address() );
+
+		$result = $this->sut->filter_taxable_address( array( 'FR', 'IDF', '75001', 'Paris' ) );
+
+		$this->assertSame( array( 'US', 'CA', '90210', 'Beverly Hills' ), $result );
+	}
+
+	/**
+	 * GIVEN a recorded wallet address
+	 * AND the store taxes on the billing address, which the incoming address matches
+	 * WHEN the taxable address filter runs
+	 * THEN the recorded address is substituted as a positional tuple
+	 */
+	public function test_filter_substitutes_the_recorded_address_when_billing_based(): void {
+		$store    = array();
+		$customer = $this->customer(
+			array(
+				'country'  => 'FR',
+				'state'    => 'IDF',
+				'postcode' => '75001',
+				'city'     => 'Paris',
+			),
+			array()
+		);
+		$this->stub_wc( $this->session_with( $store ), $customer );
+		when( 'time' )->justReturn( 1000 );
+		when( 'get_option' )->justReturn( 'billing' );
+
+		$this->sut->set( $this->basis_address() );
+
+		$result = $this->sut->filter_taxable_address( array( 'FR', 'IDF', '75001', 'Paris' ) );
+
+		$this->assertSame( array( 'US', 'CA', '90210', 'Beverly Hills' ), $result );
+	}
+
+	/**
+	 * GIVEN nothing was recorded for this payment
+	 * WHEN the taxable address filter runs
+	 * THEN the incoming address is returned unchanged
+	 */
+	public function test_filter_passes_through_when_nothing_is_recorded(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+
+		$address = array( 'FR', 'IDF', '75001', 'Paris' );
+
+		$this->assertSame( $address, $this->sut->filter_taxable_address( $address ) );
+	}
+
+	/**
+	 * GIVEN a recorded wallet address
+	 * AND the shopper has chosen a local pickup shipping method
+	 * WHEN the taxable address filter runs
+	 * THEN the incoming address is returned unchanged, because WooCommerce already applies the
+	 * shop's own base address for pickup and the wallet's address must not override it
+	 */
+	public function test_filter_passes_through_for_local_pickup(): void {
+		$store = array();
+		$this->stub_wc( $this->session_with( $store ) );
+		when( 'time' )->justReturn( 1000 );
+		when( 'wc_get_chosen_shipping_method_ids' )->justReturn( array( 'local_pickup' ) );
+
+		$this->sut->set( $this->basis_address() );
+
+		$address = array( 'FR', 'IDF', '75001', 'Paris' );
+
+		$this->assertSame( $address, $this->sut->filter_taxable_address( $address ) );
+	}
+
+	/**
+	 * GIVEN a recorded wallet address
+	 * AND the incoming address no longer matches the customer's own address for whichever
+	 * field the store taxes on, meaning something else already substituted one (a block-cart
+	 * pickup location, or a merchant's own tax plugin)
+	 * WHEN the taxable address filter runs
+	 * THEN the incoming address is returned unchanged, deferring to whatever substituted it
+	 *
+	 * @dataProvider already_substituted_address_provider
+	 */
+	public function test_filter_passes_through_when_address_already_substituted( string $tax_based_on, array $billing, array $shipping ): void {
+		$store    = array();
+		$customer = $this->customer( $billing, $shipping );
+		$this->stub_wc( $this->session_with( $store ), $customer );
+		when( 'time' )->justReturn( 1000 );
+		when( 'get_option' )->justReturn( $tax_based_on );
+
+		$this->sut->set( $this->basis_address() );
+
+		$address = array( 'DE', 'BE', '10115', 'Berlin' );
+
+		$this->assertSame( $address, $this->sut->filter_taxable_address( $address ) );
+	}
+
+	public function already_substituted_address_provider(): array {
+		return array(
+			'billing-based tax, address does not match the customer billing address'   => array(
+				'billing',
+				array(
+					'country'  => 'FR',
+					'state'    => 'IDF',
+					'postcode' => '75001',
+					'city'     => 'Paris',
+				),
+				array(),
+			),
+			'shipping-based tax, address does not match the customer shipping address' => array(
+				'shipping',
+				array(),
+				array(
+					'country'  => 'FR',
+					'state'    => 'IDF',
+					'postcode' => '75001',
+					'city'     => 'Paris',
+				),
+			),
+		);
+	}
+}

--- a/tests/PHPUnit/SdkV6/Helper/StubsWcSession.php
+++ b/tests/PHPUnit/SdkV6/Helper/StubsWcSession.php
@@ -1,0 +1,37 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery;
+use WC_Session;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * A WC()->session backed by a plain array, so what one call stores is visible to
+ * the next, the way the real session persists across a request.
+ */
+trait StubsWcSession {
+
+	/**
+	 * @param array<string, mixed> $store The backing store.
+	 */
+	private function session_with( array &$store ): WC_Session {
+		$session = Mockery::mock( WC_Session::class );
+
+		$session->shouldReceive( 'get' )->andReturnUsing(
+			static function ( string $key ) use ( &$store ) {
+				return $store[ $key ] ?? null;
+			}
+		);
+
+		$session->shouldReceive( 'set' )->andReturnUsing(
+			static function ( string $key, $value ) use ( &$store ): void {
+				$store[ $key ] = $value;
+			}
+		);
+
+		return $session;
+	}
+}

--- a/tests/PHPUnit/SdkV6/Helper/TestRecord.php
+++ b/tests/PHPUnit/SdkV6/Helper/TestRecord.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+/**
+ * Exposes WalletPaymentRecord's protected storage API, so the shared behaviour can
+ * be exercised without standing in for any one of the real records.
+ */
+class TestRecord extends WalletPaymentRecord {
+
+	public const KEY = 'ppcp_test_record';
+
+	protected const SESSION_KEY = self::KEY;
+
+	/**
+	 * @param mixed $value The value to remember.
+	 */
+	public function write( $value ): void {
+		$this->remember( $value );
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function read() {
+		return $this->remembered();
+	}
+}

--- a/tests/PHPUnit/SdkV6/Helper/WalletPaymentRecordTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/WalletPaymentRecordTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * The storage and expiry every wallet payment record shares. Its subclasses are
+ * tested only for what they add on top.
+ *
+ * Expiry is exercised by seeding the session directly, because time() cannot be
+ * redefined in this suite.
+ */
+class WalletPaymentRecordTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+	use StubsWcSession;
+
+	private TestRecord $sut;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	private array $store = array();
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->store = array();
+		$this->sut   = new TestRecord();
+
+		$this->stub_wc( $this->session_with( $this->store ) );
+	}
+
+	/**
+	 * @param mixed $session The session WC() should report.
+	 */
+	private function stub_wc( $session ): void {
+		when( 'WC' )->justReturn( (object) array( 'session' => $session ) );
+	}
+
+	/**
+	 * @param mixed $value   The stored value.
+	 * @param int   $expires Its expiry, relative to now.
+	 */
+	private function seed( $value, int $expires ): void {
+		$this->store[ TestRecord::KEY ] = array(
+			'value'   => $value,
+			'expires' => time() + $expires,
+		);
+	}
+
+	/**
+	 * GIVEN a value remembered for this payment
+	 * WHEN it is read back
+	 * THEN the same value is returned, because the record has not expired yet
+	 */
+	public function test_returns_the_value_it_remembered(): void {
+		$this->sut->write( 'kept' );
+
+		$this->assertSame( 'kept', $this->sut->read() );
+	}
+
+	/**
+	 * GIVEN a value remembered for this payment
+	 * WHEN the stored record is inspected
+	 * THEN it carries an expiry, so nothing can be stored that never expires
+	 */
+	public function test_stores_an_expiry_in_the_future(): void {
+		$this->sut->write( 'kept' );
+
+		$this->assertGreaterThan( time(), $this->store[ TestRecord::KEY ]['expires'] );
+	}
+
+	/**
+	 * GIVEN nothing was ever remembered
+	 * WHEN the record is read
+	 * THEN null is returned
+	 */
+	public function test_returns_null_when_nothing_was_remembered(): void {
+		$this->assertNull( $this->sut->read() );
+	}
+
+	/**
+	 * GIVEN a record that expires this very second
+	 * WHEN it is read
+	 * THEN it still applies, because the payment it belongs to may still be open
+	 */
+	public function test_survives_up_to_its_expiry(): void {
+		$this->seed( 'kept', 0 );
+
+		$this->assertSame( 'kept', $this->sut->read() );
+	}
+
+	/**
+	 * GIVEN a record whose expiry has passed
+	 * WHEN it is read
+	 * THEN null is returned
+	 * AND the stale record is cleared, so it cannot linger past its TTL
+	 */
+	public function test_clears_and_returns_null_once_expired(): void {
+		$this->seed( 'stale', -1 );
+
+		$this->assertNull( $this->sut->read() );
+		$this->assertNull( $this->store[ TestRecord::KEY ] );
+	}
+
+	/**
+	 * GIVEN a record stored without an expiry
+	 * WHEN it is read
+	 * THEN null is returned, rather than a record that would never expire
+	 */
+	public function test_ignores_a_record_with_no_expiry(): void {
+		$this->store[ TestRecord::KEY ] = array( 'value' => 'forever' );
+
+		$this->assertNull( $this->sut->read() );
+	}
+
+	/**
+	 * GIVEN a remembered value
+	 * WHEN it is forgotten
+	 * THEN reading it afterward returns null
+	 */
+	public function test_forget_clears_the_record(): void {
+		$this->sut->write( 'gone' );
+		$this->sut->forget();
+
+		$this->assertNull( $this->sut->read() );
+	}
+
+	/**
+	 * GIVEN WooCommerce has no session available, e.g. outside of a request
+	 * WHEN the record is written, forgotten and read
+	 * THEN none of them error, and nothing is reported
+	 */
+	public function test_tolerates_a_missing_session(): void {
+		$this->stub_wc( null );
+
+		$this->sut->write( 'nowhere' );
+		$this->sut->forget();
+
+		$this->assertNull( $this->sut->read() );
+	}
+}


### PR DESCRIPTION
*Changelog:* (none - part of v6 SDK feature)

# Description

## 🎯 The goal

An express wallet button pays without a checkout form, so the sheet has to collect the shipping address and offer the store's shipping options. Two decisions shape the whole change, both written up in `modules/ppcp-sdk-v6/docs/wallet-shipping-and-tax.md`: only one surface may own the shipping address, and the buyer is never charged more than the sheet showed.

## 🔍 What to review

- **The tax basis, the chosen rate and the quoted total live in the WooCommerce session**, because WooCommerce recalculates totals server-side and drops a browser-held choice. They expire after 15 minutes and the filters reading them are gated to the plugin's own wallet AJAX requests. That gating is what keeps an abandoned sheet from altering a later checkout, and it is the part worth a second pair of eyes.
- **The pinned rate can only fill a selection WooCommerce itself just cleared**, never override the buyer's own choice. That rests on `woocommerce_shipping_chosen_method` running only in the reset branch of `wc_get_default_shipping_method_for_package()`.
- **Apple's synchronous session rule is not covered by tests.** Safari builds the `ApplePaySession` inside the click handler with nothing awaited first, so cart population starts at click time and is awaited later. Verified by hand on the product page, where an empty cart used to reject every address.
- **The savings sentence on a reduced total reaches classic checkout only**, since it hangs off `woocommerce_thankyou_order_received_text`. Blocks buyers get the reduced charge without the explanation.

## 🧪 How to verify

1. Start an Apple Pay or Google Pay payment from a shippable product page, the cart, the mini cart, and the block express area. The sheet lists shipping options and the total follows the selection.
2. On classic checkout and pay for order, confirm the sheet asks for no shipping and charges the total the page shows.
3. Tax the billing country lower than the shipping country and pay with a card billed there. The payment completes, the order-received page explains the reduction, and the order carries a private note.
4. Reverse those rates. The first attempt is refused with no capture; paying again immediately succeeds at the corrected total.
