### PR TITLE
fix: stop polling merchant-integrations on every cron run

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -87,6 +87,16 @@ class PartnersEndpoint {
 	public const SELLER_STATUS_CACHE_TTL = 600; // 10 minutes.
 
 	/**
+	 * How long to stop retrying after a failed seller status request, in seconds.
+	 *
+	 * Deliberately longer than the success cache: while WP-Cron runs on a period
+	 * of its own (15 minutes by default), a back-off shorter than that interval
+	 * lets every single cron run through to the merchant-integrations endpoint,
+	 * so a persistently failing account is polled indefinitely.
+	 */
+	public const SELLER_STATUS_FAILURE_BACKOFF = 3600; // 1 hour.
+
+	/**
 	 * Cache key for the seller status response.
 	 */
 	public const SELLER_STATUS_CACHE_KEY = 'seller_status';
@@ -146,11 +156,10 @@ class PartnersEndpoint {
 		/*
 		 * Back off if a recent failure was registered, to avoid hammering the
 		 * merchant-integrations endpoint on persistent errors (e.g. a 403). The
-		 * window matches the success cache TTL, and is anchored to the last real
-		 * API failure since add_failure() is only written in
-		 * fetch_seller_status_from_api() on a non-200 response.
+		 * window is anchored to the last real API failure registered in
+		 * fetch_seller_status_from_api().
 		 */
-		if ( $this->failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, self::SELLER_STATUS_CACHE_TTL ) ) {
+		if ( $this->failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, self::SELLER_STATUS_FAILURE_BACKOFF ) ) {
 			return $this->handle_seller_status_failure(
 				new RuntimeException( 'Seller status recently failed; backing off the merchant-integrations endpoint.' )
 			);
@@ -235,6 +244,11 @@ class PartnersEndpoint {
 					'response' => $response,
 				)
 			);
+
+			// A transport error (DNS, timeout, TLS) is as worth backing off from
+			// as a rejected response, and is retried on every request otherwise.
+			$this->failure_registry->add_failure( FailureRegistry::SELLER_STATUS_KEY );
+
 			throw $error;
 		}
 

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -174,7 +174,7 @@ abstract class ProductStatus {
 	protected function get_seller_status_object(): SellerStatus {
 		if ( null === self::$seller_status ) {
 			// Check API failure registry to prevent multiple failed API requests.
-			if ( $this->api_failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL ) ) {
+			if ( $this->api_failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF ) ) {
 				throw new RuntimeException( 'Timeout for re-check not reached yet' );
 			}
 

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -64,7 +64,9 @@ return array(
 			$container->get( 'applepay.apple-product-status' ),
 			$container->get( 'wcgateway.is-wc-gateways-list-page' ),
 			$container->get( 'wcgateway.is-plugin-settings-page' ),
-			$container->get( 'applepay.available' ) || ( ! $container->get( 'applepay.is_referral' ) ),
+			// Deferred: resolving this performs a merchant-integrations API call,
+			// so it must not run while merely constructing the notice.
+			static fn(): bool => $container->get( 'applepay.available' ) || ( ! $container->get( 'applepay.is_referral' ) ),
 			$container->get( 'applepay.server_supported' ),
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'applepay.button' )

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -60,6 +60,16 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 		add_action(
 			'init',
 			static function () use ( $c, $module ) {
+				/*
+				 * Everything below renders notices, assets and buttons, none of
+				 * which a cron request can use, while resolving availability costs
+				 * a merchant-integrations API call. The payment gateway itself is
+				 * registered elsewhere, so skipping this leaves order processing
+				 * during cron untouched.
+				 */
+				if ( wp_doing_cron() ) {
+					return;
+				}
 
 				// Check if the module is applicable, correct country, currency, ... etc.
 				if ( ! $c->get( 'applepay.eligible' ) ) {

--- a/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
@@ -36,9 +36,16 @@ class AvailabilityNotice {
 	private bool $is_ppcp_settings_page;
 
 	/**
-	 * Indicates if ApplePay is available to be enabled.
+	 * Resolves whether ApplePay is available to be enabled.
+	 *
+	 * A callable rather than a bool because resolving it performs a
+	 * merchant-integrations API call: as a constructor value it ran for every
+	 * request that built this object, outrunning the settings-page gate in
+	 * should_display() that is meant to govern it.
+	 *
+	 * @var callable():bool
 	 */
-	private bool $is_available;
+	private $is_available;
 
 	/**
 	 * Indicates if this server is supported for ApplePay.
@@ -61,7 +68,7 @@ class AvailabilityNotice {
 	 * @param AppleProductStatus $product_status The product status handler.
 	 * @param bool               $is_wc_gateways_list_page Indicates if we're on the WooCommerce gateways list page.
 	 * @param bool               $is_ppcp_settings_page Indicates if we're on a PPCP Settings page.
-	 * @param bool               $is_available Indicates if ApplePay is available to be enabled.
+	 * @param callable           $is_available Resolves if ApplePay is available to be enabled.
 	 * @param bool               $is_server_supported Indicates if this server is supported for ApplePay.
 	 * @param SettingsProvider   $settings Used to inspect the domain verification status.
 	 * @param ApplePayButton     $button The button.
@@ -70,7 +77,7 @@ class AvailabilityNotice {
 		AppleProductStatus $product_status,
 		bool $is_wc_gateways_list_page,
 		bool $is_ppcp_settings_page,
-		bool $is_available,
+		callable $is_available,
 		bool $is_server_supported,
 		SettingsProvider $settings,
 		ApplePayButton $button
@@ -103,7 +110,7 @@ class AvailabilityNotice {
 			$this->add_not_available_notice();
 		}
 
-		if ( ! $this->is_available ) {
+		if ( ! ( $this->is_available )() ) {
 			return;
 		}
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -58,6 +58,16 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 		add_action(
 			'init',
 			static function () use ( $c ) {
+				/*
+				 * Everything below renders notices, assets and buttons, none of
+				 * which a cron request can use, while resolving availability costs
+				 * a merchant-integrations API call. The payment gateway itself is
+				 * registered elsewhere, so skipping this leaves order processing
+				 * during cron untouched.
+				 */
+				if ( wp_doing_cron() ) {
+					return;
+				}
 
 				// Check if the module is applicable, correct country, currency, ... etc.
 				if ( ! $c->get( 'googlepay.eligible' ) ) {

--- a/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\SellerStatusFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
@@ -167,7 +168,7 @@ class PartnersEndpointTest extends TestCase
 		$this->failure_registry
 			->shouldReceive('has_failure_in_timeframe')
 			->once()
-			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF)
 			->andReturn(false);
 
 		$this->seller_status_factory
@@ -212,7 +213,7 @@ class PartnersEndpointTest extends TestCase
 		$this->failure_registry
 			->shouldReceive('has_failure_in_timeframe')
 			->once()
-			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF)
 			->andReturn(false);
 
 		$this->failure_registry
@@ -223,6 +224,51 @@ class PartnersEndpointTest extends TestCase
 		$this->stub_failed_http_round_trip($raw_response, 500);
 
 		$this->expectException(PayPalApiException::class);
+
+		$this->make_endpoint()->seller_status();
+	}
+
+	/**
+	 * GIVEN the transient cache is empty
+	 * AND the PayPal API request fails at the transport level (e.g. timeout, DNS)
+	 * WHEN seller_status() is called
+	 * THEN the failure is registered in the failure registry
+	 * AND the result is NOT stored in the cache
+	 * AND a RuntimeException is thrown
+	 */
+	public function testSellerStatusOnTransportErrorRegistersFailureAndThrows(): void
+	{
+		$wp_error = Mockery::mock(\WP_Error::class);
+		$wp_error->shouldReceive('get_error_messages')->andReturn(['Connection timeout']);
+
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn(false);
+
+		$this->cache
+			->shouldReceive('set')
+			->never();
+
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF)
+			->andReturn(false);
+
+		$this->failure_registry
+			->shouldReceive('add_failure')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY);
+
+		when('apply_filters')->alias(function (string $hook, ...$args) {
+			return $args[0] ?? null;
+		});
+		when('wp_remote_get')->justReturn($wp_error);
+		when('is_wp_error')->justReturn(true);
+
+		$this->expectException(RuntimeException::class);
 
 		$this->make_endpoint()->seller_status();
 	}
@@ -262,7 +308,7 @@ class PartnersEndpointTest extends TestCase
 		$this->failure_registry
 			->shouldReceive('has_failure_in_timeframe')
 			->once()
-			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF)
 			->andReturn(false);
 
 		$this->failure_registry
@@ -312,7 +358,7 @@ class PartnersEndpointTest extends TestCase
 		$this->failure_registry
 			->shouldReceive('has_failure_in_timeframe')
 			->once()
-			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF)
 			->andReturn(true);
 
 		$this->failure_registry
@@ -360,7 +406,7 @@ class PartnersEndpointTest extends TestCase
 		$this->failure_registry
 			->shouldReceive('has_failure_in_timeframe')
 			->once()
-			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF)
 			->andReturn(true);
 
 		$this->failure_registry
@@ -379,6 +425,28 @@ class PartnersEndpointTest extends TestCase
 		$result = $this->make_endpoint()->seller_status();
 
 		$this->assertSame($fallback, $result);
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests: back-off/cache TTL relationship
+	// -----------------------------------------------------------------------
+
+	/**
+	 * GIVEN the success cache TTL and the failure back-off window
+	 * WHEN comparing the two constants
+	 * THEN the back-off window is strictly longer than the cache TTL
+	 *
+	 * A back-off equal to or shorter than the WP-Cron period (which defaults
+	 * to roughly the cache TTL) would lapse before the next cron run, so a
+	 * persistently failing merchant account would be polled on every run
+	 * instead of being throttled.
+	 */
+	public function testFailureBackoffIsLongerThanSuccessCacheTtl(): void
+	{
+		$this->assertGreaterThan(
+			PartnersEndpoint::SELLER_STATUS_CACHE_TTL,
+			PartnersEndpoint::SELLER_STATUS_FAILURE_BACKOFF
+		);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
### Description

An idle store hit `GET /v1/customer/partners/{partner_id}/merchant-integrations/{merchant_id}` roughly every 15 minutes — about 96 calls a day doing nothing.

**The mechanism.** `wp-cron.php` defines `DOING_CRON` but never `WP_ADMIN`, so `is_admin()` is false and `init` fires normally. The Apple Pay and Google Pay modules hook `init` guarded only by country/currency eligibility — the plugin has no cron guards anywhere — and reaching their availability gate resolves `applepay.available` / `googlepay.available`, which calls `AppleProductStatus`/`GoogleProductStatus::is_active()` → `PartnersEndpoint::seller_status()`. On an idle store, cron is the only traffic, so the cadence is simply the cron period.

It repeats forever because `ProductStatus::is_active()` persists nothing when the call fails, so the never-expiring result cache stays empty and the next request retries. The only throttle is `FailureRegistry`, whose window was `SELLER_STATUS_CACHE_TTL` (600s) — shorter than WP-Cron's ~900s period, so the back-off had always lapsed. Transport errors weren't throttled at all, since `add_failure()` was only called on a non-200.

Note this is *not* the layer the ticket's DeepWiki analysis pointed at: `ProductStatusResultCache` never expires by default and no subclass overrides `get_cache_lifespan()`, so a successful product-status resolution cannot produce a 15-minute cadence.

**Four fixes:**

1. **Cron guards** on both `init` callbacks. Those callbacks only render notices, enqueue assets and wire buttons — useless in a cron request. The payment gateway is registered on `woocommerce_payment_gateways`, outside them, so order processing during cron is untouched.
2. **Apple Pay availability resolved lazily.** `AvailabilityNotice` took availability as a constructor value, so the API call ran whenever the object was built and outran the settings-page gate in `should_display()` meant to govern it — that gate could never prevent the request. Google Pay's factory does not have this defect.
3. **A dedicated, longer failure back-off** (`SELLER_STATUS_FAILURE_BACKOFF`), leaving the 600s success cache TTL unchanged. This is the arithmetic that caused the bug.
4. **Transport errors register a failure**, so DNS/timeout/TLS errors are throttled like rejected responses.

Deliberately *not* done: caching a negative result. Writing `STATE_IS_DISABLED` into a cache that never expires for Apple/Google would persist a wrong answer from a transient blip, and would swap the accurate "could not determine your seller status" notice for a misleading "not available on your account".

### Steps to Test

Cron path (the reported symptom):

1. Connect a merchant account and enable logging.
2. Trigger cron directly: `wp cron event run --due-now`, or request `/wp-cron.php?doing_wp_cron` .
3. **Expected:** no `merchant-integrations` request in the log. Repeat a few times over 30+ minutes to confirm the cadence is gone.

No regressions:

4. Load the PayPal Payments settings page and the WooCommerce → Payments list. Apple Pay and Google Pay availability notices must still appear exactly as before when the account lacks the capability.
5. Place an order with Apple Pay and with Google Pay — buttons render and checkout completes.
6. With a subscription, let a renewal run through cron (or `wp cron event run` the scheduled payment) and confirm it still processes. This is the case the cron guards had to not break.

Back-off:

7. Force failure by pointing the account at bad credentials, load the settings page once, then trigger cron repeatedly. Expected: one API attempt, then silence for the back-off window rather than one attempt per cron run.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix - Stop requesting the PayPal merchant-integrations endpoint on every WP-Cron run, and back off properly when the seller status request fails.