### PR TITLE
enable SDK v6 feature flag for new store setups (6828)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -105,6 +105,7 @@ return static function ( string $root_dir ): iterable {
 	if ( apply_filters(
 		'woocommerce.feature-flags.woocommerce_paypal_payments.sdk_v6_enabled',
 		getenv( 'PCP_SDK_V6_ENABLED' ) === '1'
+			|| 'yes' === get_option( 'woocommerce-ppcp-sdk-v6-eligible' )
 	) ) {
 		$modules[] = ( require "$modules_dir/ppcp-sdk-v6/module.php" )();
 	}

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -30,6 +30,7 @@ return array(
 			'woocommerce_' . PayUponInvoiceGateway::ID . '_settings',
 			'woocommerce_' . CardButtonGateway::ID . '_settings',
 			'woocommerce-ppcp-version',
+			'woocommerce-ppcp-sdk-v6-eligible',
 			WebhookSimulation::OPTION_ID,
 			WebhookRegistrar::KEY,
 			'ppcp_payment_tokens_migration_initialized',

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -161,6 +161,15 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 					if ( $installed_plugin_version !== $current_plugin_version ) {
 						update_option( 'woocommerce-ppcp-version', $current_plugin_version );
 
+						// Set once: fresh installs opt into the SDK v6 default, existing
+						// stores stay on v5. Guarded so it is never recomputed later.
+						if ( false === get_option( 'woocommerce-ppcp-sdk-v6-eligible', false ) ) {
+							update_option(
+								'woocommerce-ppcp-sdk-v6-eligible',
+								$installed_plugin_version ? 'no' : 'yes'
+							);
+						}
+
 						/**
 						 * The hook fired when the plugin is installed or updated.
 						 */


### PR DESCRIPTION
SDK v6 was gated by a code/env flag defaulting off, so there was no way to give it to new stores while leaving existing stores (including on reconnect) on v5.                    
                                                                                                                                                                                             
This PR records a one-time `woocommerce-ppcp-sdk-v6-eligible` option at install/update, `yes` for fresh installs, `no` for updates and have `modules.php` load the v6 module when it's `yes` (env/filter overrides still apply). Since it's set once and never recomputed, disconnect/reconnect keeps existing stores on v5; the option is also cleaned up on uninstall.     