### PR TITLE
fix: complete the checkout after returning from PayPal on mobile

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -52,6 +52,11 @@ class CheckoutActionHandler {
 	configuration() {
 		const spinner = this.spinner;
 		const createOrder = ( data, actions ) => {
+			// Lets onApprove tell an approval in this same document apart from one
+			// that comes back into a rebuilt document (AppSwitch or redirect),
+			// where everything the buyer typed has been discarded.
+			ResumeFlowHelper.markOrderCreated();
+
 			const payer = payerData();
 			const bnCode =
 				typeof this.config.bn_codes[ this.config.context ] !==

--- a/modules/ppcp-button/resources/js/modules/Helper/ResumeFlowHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ResumeFlowHelper.js
@@ -41,6 +41,88 @@ class ResumeFlowHelper {
 		}
 	}
 
+	/**
+	 * Whether the PayPal order was created by this document.
+	 *
+	 * Reset on every page load by virtue of being module state.
+	 */
+	static orderCreatedInDocument = false;
+
+	/**
+	 * Records that this document created the PayPal order.
+	 */
+	static markOrderCreated() {
+		ResumeFlowHelper.orderCreatedInDocument = true;
+	}
+
+	static AUTO_SUBMIT_KEY = 'ppcpSubmitAfterReturn';
+
+	/**
+	 * Remembers, across the reload that follows a return from PayPal, that the
+	 * buyer already asked to pay and the restored checkout should submit itself.
+	 *
+	 * sessionStorage rather than a URL param so the SDK cannot mistake it for one
+	 * of its own, and it dies with the tab. Guarded because private browsing can
+	 * refuse storage outright, in which case the buyer simply confirms by hand.
+	 */
+	static markSubmitAfterReturn() {
+		try {
+			window.sessionStorage.setItem(
+				ResumeFlowHelper.AUTO_SUBMIT_KEY,
+				'1'
+			);
+		} catch ( error ) {
+			// Storage unavailable; fall back to a manual confirmation.
+		}
+	}
+
+	/**
+	 * Whether approval is happening in a different document than the one that
+	 * created the order — AppSwitch and redirect flows both replace it.
+	 *
+	 * Deliberately not derived from the URL: the SDK strips its own token and
+	 * PayerID params before invoking onApprove, so by then location.search is
+	 * empty and any check against it reports a false negative. Whether the
+	 * document was replaced is the condition that actually matters, since that
+	 * is what discards everything the buyer typed.
+	 *
+	 * @return {boolean} True when the buyer is coming back from PayPal.
+	 */
+	static isReturnFromPayPal() {
+		return ! ResumeFlowHelper.orderCreatedInDocument;
+	}
+
+	/**
+	 * The current URL with every PayPal param stripped from both the query
+	 * string and the hash.
+	 *
+	 * Reloading with the params still present would let the SDK treat the fresh
+	 * page as another return and approve again, in a loop.
+	 *
+	 * @return {string} The cleaned URL.
+	 */
+	static urlWithoutPayPalParams() {
+		const url = new URL( window.location.href );
+
+		this.PAYPAL_PARAMS.forEach( ( param ) =>
+			url.searchParams.delete( param )
+		);
+
+		if ( url.hash ) {
+			const kept = url.hash
+				.substring( 1 )
+				.split( '&' )
+				.filter(
+					( param ) =>
+						! this.PAYPAL_PARAMS.includes( param.split( '=' )[ 0 ] )
+				);
+
+			url.hash = kept.length ? kept.join( '&' ) : '';
+		}
+
+		return url.toString();
+	}
+
 	static isResumeFlow() {
 		if ( ! window.location.hash ) {
 			return false;

--- a/modules/ppcp-button/resources/js/modules/Helper/ResumeFlowHelper.test.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ResumeFlowHelper.test.js
@@ -1,0 +1,118 @@
+/* global describe, test, expect, beforeEach */
+import resumeFlowHelper from "./ResumeFlowHelper";
+
+// history.replaceState() updates document._URL directly in jsdom, unlike
+// setting window.location.search/hash, which routes through jsdom's
+// unimplemented navigation stub and never actually changes the URL. It is
+// also how the module itself relocates the page (see cleanHashParams()), so
+// it is the realistic way to set up a "current URL" for these tests.
+const setUrl = (pathAndQueryAndHash) => {
+    window.history.replaceState(null, "", pathAndQueryAndHash);
+};
+
+describe("ResumeFlowHelper", () => {
+    beforeEach(() => {
+        setUrl("/checkout/");
+        // orderCreatedInDocument is module state, not derived from anything
+        // reset by setUrl(); without this, markOrderCreated() from one test
+        // would silently leak into the next.
+        resumeFlowHelper.orderCreatedInDocument = false;
+        window.sessionStorage.clear();
+    });
+
+    describe("isReturnFromPayPal()", () => {
+        test("is true when nothing has created an order in this document yet", () => {
+            expect(resumeFlowHelper.isReturnFromPayPal()).toBe(true);
+        });
+
+        test("is false once markOrderCreated() has run in this document", () => {
+            resumeFlowHelper.markOrderCreated();
+
+            expect(resumeFlowHelper.isReturnFromPayPal()).toBe(false);
+        });
+
+        test("stays true with token and PayerID in the query string, because the SDK strips them before onApprove runs and reading the URL would report a false negative", () => {
+            setUrl("/checkout/?token=8HY42288U3810663S&PayerID=2Q7KYG2RLJT2S");
+
+            expect(resumeFlowHelper.isReturnFromPayPal()).toBe(true);
+        });
+
+        test("stays false after markOrderCreated() even with a completely clean URL", () => {
+            resumeFlowHelper.markOrderCreated();
+            setUrl("/checkout/");
+
+            expect(resumeFlowHelper.isReturnFromPayPal()).toBe(false);
+        });
+    });
+
+    describe("markSubmitAfterReturn()", () => {
+        test("writes '1' under AUTO_SUBMIT_KEY in sessionStorage", () => {
+            resumeFlowHelper.markSubmitAfterReturn();
+
+            // AUTO_SUBMIT_KEY's value is duplicated in
+            // ButtonModule::SUBMIT_AFTER_RETURN_KEY on the PHP side, which is
+            // now the sole reader of this key; a rename that breaks the pair
+            // would only show up there, so it is asserted here too.
+            expect(window.sessionStorage.getItem(resumeFlowHelper.AUTO_SUBMIT_KEY)).toBe("1");
+        });
+
+        test("does not throw when sessionStorage is unavailable, as in private browsing", () => {
+            // jsdom's Storage is a Proxy with a named-property setter, so
+            // assigning window.sessionStorage.setItem directly creates a new
+            // storage entry rather than replacing the method. The real
+            // method lives on the prototype, so that is what has to be
+            // stubbed.
+            jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+                throw new Error("SecurityError");
+            });
+
+            expect(() => resumeFlowHelper.markSubmitAfterReturn()).not.toThrow();
+
+            jest.restoreAllMocks();
+        });
+    });
+
+    describe("urlWithoutPayPalParams()", () => {
+        test("strips PayPal params from the query string while preserving unrelated params", () => {
+            setUrl("/checkout/?token=ABC&PayerID=XYZ&order-received=1");
+
+            expect(resumeFlowHelper.urlWithoutPayPalParams()).toBe(
+                "http://localhost/checkout/?order-received=1",
+            );
+        });
+
+        test("strips PayPal params from the hash while preserving unrelated params", () => {
+            setUrl("/checkout/#switch_initiated_time=123&scrollTo=payment");
+
+            expect(resumeFlowHelper.urlWithoutPayPalParams()).toBe(
+                "http://localhost/checkout/#scrollTo=payment",
+            );
+        });
+
+        test("strips PayPal params from both the query string and the hash at once", () => {
+            setUrl(
+                "/checkout/?token=ABC&PayerID=XYZ&order-received=1#switch_initiated_time=123&scrollTo=payment",
+            );
+
+            expect(resumeFlowHelper.urlWithoutPayPalParams()).toBe(
+                "http://localhost/checkout/?order-received=1#scrollTo=payment",
+            );
+        });
+
+        test("drops an empty hash entirely once its only params are removed", () => {
+            setUrl("/checkout/?order-received=1#switch_initiated_time=123");
+
+            expect(resumeFlowHelper.urlWithoutPayPalParams()).toBe(
+                "http://localhost/checkout/?order-received=1",
+            );
+        });
+
+        test("returns the URL unchanged when there are no PayPal params to strip", () => {
+            setUrl("/checkout/?order-received=1");
+
+            expect(resumeFlowHelper.urlWithoutPayPalParams()).toBe(
+                "http://localhost/checkout/?order-received=1",
+            );
+        });
+    });
+});

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -11,6 +11,11 @@ const onApprove = ( context, errorHandler ) => {
 		const spinner = Spinner.fullPage();
 		spinner.block();
 		errorHandler.clear();
+		// Both captured before the params are stripped below, since that is what
+		// they read.
+		const isReturnFromPayPal = resumeFlowHelper.isReturnFromPayPal();
+		const cleanUrl = resumeFlowHelper.urlWithoutPayPalParams();
+
 		// Pay Now submits via form (not AJAX), so we can't detect payment errors.
 		// Preemptively remove hash params to prevent reload issues.
 		if ( resumeFlowHelper.isResumeFlow() ) {
@@ -54,6 +59,30 @@ const onApprove = ( context, errorHandler ) => {
 					jQuery(
 						`input[name="payment_method"][value="${ PaymentMethods.PAYPAL }"]`
 					).prop( 'checked', true );
+				}
+
+				/*
+				 * Returning from PayPal — by AppSwitch or by redirect — lands on a
+				 * freshly loaded page, rendered before the approved order reached
+				 * the session. The checkout fields WooCommerce cannot restore for a
+				 * guest, name, email and phone, are therefore empty, and the terms
+				 * box is unticked, so submitting now fails validation with the
+				 * payment already approved.
+				 *
+				 * Loading the page again, with the order in the session, lets
+				 * CheckoutPayPalAddressPreset fill those fields from the payer and
+				 * puts the checkout in continuation mode for the buyer to confirm.
+				 * Terms acceptance is deliberately left to them.
+				 *
+				 * The PayPal params are dropped on the way, or the SDK would treat
+				 * the new page as another return and approve again in a loop.
+				 */
+				if ( isReturnFromPayPal ) {
+					// The buyer already asked to pay before leaving, so carry that
+					// across the reload and let the restored checkout submit itself.
+					resumeFlowHelper.markSubmitAfterReturn();
+					window.location.replace( cleanUrl );
+					return;
 				}
 
 				document.querySelector( '#place_order' ).click();

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.test.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.test.js
@@ -1,0 +1,196 @@
+/* global describe, test, expect, beforeEach, afterEach, jest */
+jest.mock("../Helper/CheckoutMethodState", () => ({
+    getCurrentPaymentMethod: jest.fn(),
+    PaymentMethods: { PAYPAL: "ppcp-gateway" },
+}));
+
+jest.mock("../Helper/ResumeFlowHelper", () => ({
+    __esModule: true,
+    default: {
+        isResumeFlow: jest.fn(),
+        cleanHashParams: jest.fn(),
+        isReturnFromPayPal: jest.fn(),
+        urlWithoutPayPalParams: jest.fn(),
+        markSubmitAfterReturn: jest.fn(),
+    },
+}));
+
+jest.mock("../Helper/Spinner", () => ({
+    __esModule: true,
+    default: {
+        fullPage: jest.fn(() => ({
+            block: jest.fn(),
+            unblock: jest.fn(),
+        })),
+    },
+}));
+
+import onApproveForPayNow from "./onApproveForPayNow";
+import { getCurrentPaymentMethod, PaymentMethods } from "../Helper/CheckoutMethodState";
+import resumeFlowHelper from "../Helper/ResumeFlowHelper";
+
+// jsdom has no real navigation: window.location.replace() falls through to
+// its "not implemented: navigation" stub whenever the target URL differs
+// from the current one, and the test environment forwards that to
+// console.error. That makes it an observable, unmockable signal that
+// replace() was actually invoked (see jsdom's navigation.js and
+// @jest/environment-jsdom-abstract's `jsdomError` forwarding). `replace`,
+// like `reload`, is a non-configurable unforgeable on window.location in
+// jsdom 26, so it cannot be spied on directly, and the string it was called
+// with cannot be recovered from the emitted error either - the assertions
+// below confirm the navigation happened and that it was driven by
+// urlWithoutPayPalParams()'s return value, rather than inspecting the call
+// argument.
+describe("onApproveForPayNow", () => {
+    let context;
+    let errorHandler;
+    let checkedProp;
+    let placeOrderClickSpy;
+
+    const CLEAN_URL = "http://localhost/checkout/";
+
+    const successResponse = () => ({
+        ok: true,
+        json: async () => ({ success: true }),
+    });
+
+    const failureResponse = (code, message = "Something went wrong") => ({
+        ok: true,
+        json: async () => ({ success: false, data: { code, message } }),
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        document.body.innerHTML = '<button id="place_order"></button>';
+        placeOrderClickSpy = jest.spyOn(document.querySelector("#place_order"), "click");
+
+        context = {
+            config: {
+                ajax: {
+                    approve_order: {
+                        endpoint: "/approve-order",
+                        nonce: "nonce-value",
+                    },
+                },
+            },
+        };
+
+        errorHandler = {
+            clear: jest.fn(),
+            message: jest.fn(),
+            genericError: jest.fn(),
+        };
+
+        checkedProp = jest.fn();
+        global.jQuery = jest.fn(() => ({
+            prop: checkedProp,
+            block: jest.fn(),
+            unblock: jest.fn(),
+        }));
+
+        global.fetch = jest.fn();
+
+        getCurrentPaymentMethod.mockReturnValue("ppcp-gateway");
+        resumeFlowHelper.isResumeFlow.mockReturnValue(false);
+        resumeFlowHelper.isReturnFromPayPal.mockReturnValue(false);
+        resumeFlowHelper.urlWithoutPayPalParams.mockReturnValue(CLEAN_URL);
+    });
+
+    afterEach(() => {
+        delete global.jQuery;
+        delete global.fetch;
+    });
+
+    test("submits the checkout form when the page load is not a return from PayPal", async () => {
+        resumeFlowHelper.isResumeFlow.mockReturnValue(false);
+        resumeFlowHelper.isReturnFromPayPal.mockReturnValue(false);
+        fetch.mockResolvedValueOnce(successResponse());
+
+        await onApproveForPayNow(context, errorHandler)({ orderID: "1" }, {});
+
+        expect(placeOrderClickSpy).toHaveBeenCalled();
+        expect(resumeFlowHelper.markSubmitAfterReturn).not.toHaveBeenCalled();
+    });
+
+    test("navigates to the cleaned URL instead of submitting when returning from PayPal via AppSwitch", async () => {
+        resumeFlowHelper.isResumeFlow.mockReturnValue(true);
+        resumeFlowHelper.isReturnFromPayPal.mockReturnValue(true);
+        fetch.mockResolvedValueOnce(successResponse());
+
+        await onApproveForPayNow(context, errorHandler)({ orderID: "1" }, {});
+
+        expect(console).toHaveErrored();
+        expect(resumeFlowHelper.urlWithoutPayPalParams).toHaveBeenCalled();
+        expect(resumeFlowHelper.markSubmitAfterReturn).toHaveBeenCalled();
+        expect(placeOrderClickSpy).not.toHaveBeenCalled();
+    });
+
+    test("navigates to the cleaned URL instead of submitting when returning from PayPal without a resume-flow hash", async () => {
+        // isReturnFromPayPal() no longer derives from the URL, so a plain
+        // redirect return (no switch_initiated_time hash, isResumeFlow false)
+        // still triggers navigation on its own.
+        resumeFlowHelper.isResumeFlow.mockReturnValue(false);
+        resumeFlowHelper.isReturnFromPayPal.mockReturnValue(true);
+        fetch.mockResolvedValueOnce(successResponse());
+
+        await onApproveForPayNow(context, errorHandler)({ orderID: "1" }, {});
+
+        expect(console).toHaveErrored();
+        expect(resumeFlowHelper.urlWithoutPayPalParams).toHaveBeenCalled();
+        expect(resumeFlowHelper.cleanHashParams).not.toHaveBeenCalled();
+        expect(resumeFlowHelper.markSubmitAfterReturn).toHaveBeenCalled();
+        expect(placeOrderClickSpy).not.toHaveBeenCalled();
+    });
+
+    describe("when the approval request fails", () => {
+        // With no actions.restart() available (classic checkout has none), the
+        // handler re-throws after reporting the error so the outer .catch() in
+        // the SDK bootstrap can surface it too.
+        test("shows the returned message for a code 100 failure", async () => {
+            fetch.mockResolvedValueOnce(failureResponse(100, "Card declined"));
+
+            await expect(
+                onApproveForPayNow(context, errorHandler)({ orderID: "1" }, {}),
+            ).rejects.toThrow("Card declined");
+
+            expect(errorHandler.message).toHaveBeenCalledWith("Card declined");
+            expect(errorHandler.genericError).not.toHaveBeenCalled();
+            expect(placeOrderClickSpy).not.toHaveBeenCalled();
+        });
+
+        test("shows a generic error for a non-100 failure code", async () => {
+            fetch.mockResolvedValueOnce(failureResponse(500, "Server error"));
+
+            await expect(
+                onApproveForPayNow(context, errorHandler)({ orderID: "1" }, {}),
+            ).rejects.toThrow("Server error");
+
+            expect(errorHandler.genericError).toHaveBeenCalled();
+            expect(errorHandler.message).not.toHaveBeenCalled();
+        });
+
+        test("restarts the PayPal action instead of throwing when restart() is available", async () => {
+            fetch.mockResolvedValueOnce(failureResponse(100, "Card declined"));
+            const restart = jest.fn().mockResolvedValue();
+
+            await expect(
+                onApproveForPayNow(context, errorHandler)({ orderID: "1" }, { restart }),
+            ).resolves.toBeUndefined();
+
+            expect(restart).toHaveBeenCalled();
+        });
+    });
+
+    test("checks the PayPal radio when a different payment method ended up selected", async () => {
+        getCurrentPaymentMethod.mockReturnValue("other-gateway");
+        fetch.mockResolvedValueOnce(successResponse());
+
+        await onApproveForPayNow(context, errorHandler)({ orderID: "1" }, {});
+
+        expect(jQuery).toHaveBeenCalledWith(
+            `input[name="payment_method"][value="${PaymentMethods.PAYPAL}"]`,
+        );
+        expect(checkedProp).toHaveBeenCalledWith("checked", true);
+    });
+});

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\GetOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\SaveCheckoutFormEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ValidateCheckoutEndpoint;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\OrderEndpoints\Helper\EarlyOrderHandler;
 use WooCommerce\PayPalCommerce\OrderEndpoints\Helper\WooCommerceOrderCreator;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataTransientStorage;
@@ -35,6 +36,12 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
  */
 class ButtonModule implements ServiceModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
+
+	/**
+	 * Storage key carrying the buyer's pending submit across the reload that a
+	 * return from PayPal triggers. Must match ResumeFlowHelper.AUTO_SUBMIT_KEY.
+	 */
+	private const SUBMIT_AFTER_RETURN_KEY = 'ppcpSubmitAfterReturn';
 
 	/**
 	 * {@inheritDoc}
@@ -74,6 +81,60 @@ class ButtonModule implements ServiceModule, ExecutableModule {
 					$smart_button->enqueue();
 				}
 			}
+		);
+
+		add_action(
+			'wp_enqueue_scripts',
+			static function () use ( $c ) {
+				$context = $c->get( 'button.helper.context' );
+				assert( $context instanceof Context );
+
+				if ( ! $context->is_checkout() ) {
+					return;
+				}
+
+				/*
+				 * Replays the buyer's submit after a return from PayPal.
+				 *
+				 * onApproveForPayNow reloads the checkout on a return so the billing
+				 * fields can be restored from the payer, which costs the buyer the tap
+				 * they already made. The smart button script does not load once an
+				 * approved order is in the session, so the replay is printed here
+				 * instead, attached to WooCommerce's own checkout script: that runs
+				 * before its ready handler fires the first update, so the listener is
+				 * bound in time.
+				 *
+				 * Printed on every checkout rather than only where an approved order is
+				 * detected: the stored flag is the real gate, it is only ever written on
+				 * the return path, and keying on a second condition would silently do
+				 * nothing wherever that condition disagreed.
+				 *
+				 * The flag is written by ResumeFlowHelper.markSubmitAfterReturn() and is
+				 * cleared before use, so this can fire at most once per return. If the
+				 * checkout does not validate — most likely an unticked terms box, which
+				 * is not ours to tick — the buyer simply confirms by hand.
+				 */
+				wp_add_inline_script(
+					'wc-checkout',
+					sprintf(
+						'( function () {
+	var key = %s;
+	try {
+		if ( window.sessionStorage.getItem( key ) !== "1" ) { return; }
+		window.sessionStorage.removeItem( key );
+	} catch ( e ) { return; }
+	jQuery( document.body ).one( "updated_checkout", function () {
+		var button = document.querySelector( "#place_order" );
+		if ( button ) { button.click(); }
+	} );
+} )();',
+						wp_json_encode( self::SUBMIT_AFTER_RETURN_KEY )
+					)
+				);
+			},
+			// After WooCommerce has registered wc-checkout, or the inline script
+			// would attach to nothing and silently never run.
+			20
 		);
 
 		add_filter(


### PR DESCRIPTION
### Description

On mobile, approving a PayPal payment left the buyer stranded on the classic checkout with validation errors for first name, last name and terms, no PayPal button, and the payment already approved at PayPal.

**Cause.** Returning from PayPal is a *fresh page load* — the document that created the order is gone, and with it everything the buyer typed. WooCommerce's `update_order_review` only persists six address fields to a guest session, never name, email or phone, so those render empty. The handler then clicked `#place_order` immediately, into a form that could not validate.

**Fix.** On a return, load the page again instead of submitting. The approved order is in the session by then, so `CheckoutPayPalAddressPreset` fills the fields from the payer and the checkout is completable. The buyer's submit is then replayed once, so the flow stays one-tap: approve → order received.

Two implementation notes, both the result of failed attempts worth not repeating:

- **Detection is not URL-based.** The SDK strips its own `token`/`PayerID` params before invoking `onApprove`, so `location.search` is already empty there. Instead we track whether *this document* created the order — the condition that actually matters, and one that covers AppSwitch and redirect returns alike.
- **The submit replay is an inline script from PHP, not the button bundle.** That bundle is not enqueued once an approved order sits in the session, which is exactly the state a return lands in, so a JS-side implementation was unreachable. It attaches to WooCommerce's own `wc-checkout` script so the listener binds before the first `updated_checkout`.

### Steps to Test

Requires a real mobile device and a publicly reachable site (App Switch needs `server_side_shipping_callback`, which needs working webhooks). Verified on a device via an ngrok tunnel.

1. Pay Now Experience **on**; a virtual product; browse as a **guest** (a logged-in customer repopulates from their account and will not reproduce).
2. On the phone, add the product, go to classic checkout, fill in billing, accept terms.
3. Tap the PayPal button and approve.
4. **Expected:** a brief reload, then the order received page — no tap needed. The URL loses `?token=…&PayerID=…`.
5. **Before this change:** validation errors for first name, last name and terms, and no PayPal button.

Regression checks:

6. Desktop popup flow — approve goes straight to order received, no intermediate reload. `createOrder` and `onApprove` run in the same document, so nothing changes.
7. Repeat step 3 and cancel in PayPal instead — the checkout is untouched.

### Known gaps

- On a store that **requires the terms checkbox**, the replayed submit fails validation and the buyer confirms by hand. Terms acceptance cannot be restored and is deliberately not ticked on their behalf. Still a completable checkout rather than a dead end.
- The inline script and its `updated_checkout` click have **no automated coverage** — testing them would mean standing up jQuery's event system and the checkout DOM for one assertion. They are covered by the manual test above.

### Follow-up

`ppc-save-checkout-form` already persists the buyer's own input, terms included, via `WC_Checkout::update_session()` — but only the webhook handler consumes it. Restoring it on return would give back *their* data rather than PayPal's, and would likely close the terms gap on every store. Worth its own ticket.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix - Complete the order after returning from PayPal on mobile, instead of failing checkout validation with the payment already approved.