### PR TITLE
Pin nested GitHub Action dependencies to full SHAs

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build-and-distribute:
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-playwright-matrix.outputs.matrix) }}
-    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     with:
       PLAYWRIGHT_SCRIPT: ${{ matrix.script }}
       PLAYWRIGHT_ARTIFACT_NAME: ${{ matrix.artifact_name }}

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -27,7 +27,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@a9af34f34e95cbe18703198c7e972e97ebcd7473
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     with:
       PHP_VERSION: 7.4
       NODE_VERSION: 22

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   coding-standards-analysis-php:
-    uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     with:
       PHP_VERSION: '8.0'
       PHPCS_ARGS: '--report-full --runtime-set ignore_warnings_on_exit 1'
   static-code-analysis-php:
-    uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     with:
       PHP_VERSION: '8.0'
       PHPSTAN_ARGS: '--no-progress --memory-limit=2G'
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     with:
       PHPUNIT_ARGS: ''
       PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/weekly-builds.yml
+++ b/.github/workflows/weekly-builds.yml
@@ -69,7 +69,7 @@ jobs:
     if: github.repository_owner == 'woocommerce'
     name: Build package
     needs: create-tag
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Tracking: PAYPAL-178

- Updates the affected parent actions or reusable workflows to immutable commits whose own remote action dependencies are pinned to full-length SHAs.
- Keeps human-readable version comments beside the SHAs.
- Pins Inpsyde reusable workflows to the immutable head commit of inpsyde/reusable-workflows#278.

This is part of the WooCommerce organization audit for transitive GitHub Action pinning.

### Detailed test instructions

1. Inspect the changed `uses:` references and confirm every remote action ref is a 40-character commit SHA.
2. Confirm the adjacent comments identify the intended version or upstream pinning PR.
3. Let the affected workflows run through this PR's hosted checks.

Validation already completed:

- Parsed every GitHub workflow and composite action in this repository as YAML.
- Ran `git diff --check`.
- Verified the replacement parent commits resolve through their canonical GitHub repositories.
- Verified their nested remote action dependencies are pinned to full-length SHAs.

### Documentation

- [x] No documentation changes are required.

### Changelog entry

> Dev - Pin GitHub Actions and their nested dependencies to immutable commit SHAs.

**left by Biff (AI agent) on behalf of Darren*

