### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,6 +56,7 @@ jobs:
   resolve-playwright-matrix:
     name: Resolve Playwright matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,7 @@ on: workflow_dispatch
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         php-versions: ['7.4']

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -25,6 +25,7 @@ jobs:
   UnitTests:
     name: JavaScript Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   check_version:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       PACKAGE_VERSION: ${{ github.event.inputs.packageVersion }}
     outputs:

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   fetch_build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.repository == 'woocommerce/woocommerce-paypal-payments'
     permissions:
       actions: read
@@ -143,6 +144,7 @@ jobs:
   playground_demo:
     name: Comment on PR with Playground details
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: fetch_build
     if: needs.fetch_build.outputs.has_build == 'true'
     permissions:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   typos:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Check for typos
     steps:
       - name: Checkout

--- a/.github/workflows/weekly-builds.yml
+++ b/.github/workflows/weekly-builds.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository_owner == 'woocommerce'
     name: Create weekly tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     outputs:
@@ -83,6 +84,7 @@ jobs:
     if: github.repository_owner == 'woocommerce'
     name: Upload weekly build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [create-tag, build]
     steps:
       - name: Download artifact
@@ -110,6 +112,7 @@ jobs:
     if: github.repository_owner == 'woocommerce'
     name: Trigger E2E tests (all:parallel)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [ create-tag, build, deploy ]
     continue-on-error: true
     permissions:
@@ -134,6 +137,7 @@ jobs:
     if: always() && github.repository_owner == 'woocommerce'
     name: Send Slack notification
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [ create-tag, build, deploy ]
     steps:
       - name: Send success message to Slack


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `e2e-tests.yml` / `resolve-playwright-matrix` | 0.05 min | 0.08 min | 5 |
| `integration.yml` / `build` | no run in 30d (last success 4.52 min) | — | 10 |
| `js-tests.yml` / `UnitTests` | 2.37 min | 3.25 min | 10 |
| `package-new.yml` / `check_version` | no run in 30d (historic 0.07–0.10 min) | — | 5 |
| `pr-playground-demo.yml` / `fetch_build` | 2.63 min | 5.48 min | 10 |
| `pr-playground-demo.yml` / `playground_demo` | 0.10 min | 0.35 min | 5 |
| `spell-check.yml` / `typos` | 0.13 min | 0.20 min | 5 |
| `weekly-builds.yml` / `create-tag` | 0.07 min | 0.12 min | 5 |
| `weekly-builds.yml` / `deploy` | 0.10 min | 0.13 min | 5 |
| `weekly-builds.yml` / `trigger-e2e` | 0.07 min | 0.10 min | 5 |
| `weekly-builds.yml` / `notify-slack` | 0.06 min | 0.10 min | 5 |

The other 8 jobs call reusable workflows in `inpsyde/reusable-workflows` with `uses:`, where `timeout-minutes` is not valid.

Part of TESTOPS-272
