### PR TITLE
Exclude connection details from Blueprint exports by default (6792)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Compat;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
+use WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\ConnectionDataSanitizer;
 use WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalBlueprintBootstrap;
 use WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalSettingsExporter;
 use WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalSettingsImporter;
@@ -132,8 +133,20 @@ return array(
 	'compat.blueprint.is_available'                        => function (): bool {
 		return interface_exists( 'Automattic\WooCommerce\Blueprint\Exporters\StepExporter' );
 	},
+	'compat.blueprint.connection_data_sanitizer'           => static function (): ConnectionDataSanitizer {
+		return new ConnectionDataSanitizer();
+	},
 	'compat.blueprint.paypal_settings_exporter'            => static function ( ContainerInterface $container ): PayPalSettingsExporter {
-		return new PayPalSettingsExporter();
+		return new PayPalSettingsExporter(
+			$container->get( 'compat.blueprint.connection_data_sanitizer' ),
+			false
+		);
+	},
+	'compat.blueprint.paypal_settings_exporter_with_connection' => static function ( ContainerInterface $container ): PayPalSettingsExporter {
+		return new PayPalSettingsExporter(
+			$container->get( 'compat.blueprint.connection_data_sanitizer' ),
+			true
+		);
 	},
 	'compat.blueprint.paypal_settings_importer'            => static function ( ContainerInterface $container ): PayPalSettingsImporter {
 		return new PayPalSettingsImporter(
@@ -143,6 +156,7 @@ return array(
 	'compat.blueprint.bootstrap'                           => static function ( ContainerInterface $container ): PayPalBlueprintBootstrap {
 		return new PayPalBlueprintBootstrap(
 			$container->get( 'compat.blueprint.paypal_settings_exporter' ),
+			$container->get( 'compat.blueprint.paypal_settings_exporter_with_connection' ),
 			$container->get( 'compat.blueprint.paypal_settings_importer' )
 		);
 	},

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/ConnectionDataSanitizer.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/ConnectionDataSanitizer.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Removes PayPal connection data from a Blueprint export payload.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+/**
+ * Single source of truth for what counts as "connection data" in a Blueprint export.
+ */
+class ConnectionDataSanitizer {
+
+	/**
+	 * Option holding the merchant connection details.
+	 */
+	public const OPTION_COMMON = 'woocommerce-ppcp-data-common';
+
+	/**
+	 * Option holding the onboarding progress flags.
+	 */
+	public const OPTION_ONBOARDING = 'woocommerce-ppcp-data-onboarding';
+
+	/**
+	 * Connection keys of the common option, mapped to their neutral value.
+	 *
+	 * Mirrors GeneralSettings::get_defaults(), which is protected; the two are kept
+	 * in sync by ConnectionDataSanitizerTest.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public const CONNECTION_DEFAULTS = array(
+		'client_id'             => '',
+		'client_secret'         => '',
+		'merchant_id'           => '',
+		'merchant_email'        => '',
+
+		// Not reliably recomputed on connect, so a stale value would persist.
+		'merchant_country'      => '',
+		'wc_installation_path'  => '',
+
+		'seller_type'           => 'unknown',
+		'sandbox_merchant'      => false,
+		'merchant_connected'    => false,
+		'use_sandbox'           => false,
+		'use_manual_connection' => false,
+	);
+
+	/**
+	 * Onboarding flags reset alongside the connection data.
+	 *
+	 * `setup_done` is deliberately NOT reset: it guards
+	 * SettingsDataManager::set_defaults_for_new_merchant(), which would overwrite
+	 * the styling settings this export exists to carry.
+	 *
+	 * @var array<string, mixed>
+	 */
+	public const ONBOARDING_DEFAULTS = array(
+		'completed'          => false,
+		'step'               => 0,
+		'gateways_synced'    => false,
+		'gateways_refreshed' => false,
+	);
+
+	/**
+	 * Returns a copy of the export payload with all connection data neutralised.
+	 *
+	 * @param array<string, mixed> $options Option name => option value.
+	 * @return array<string, mixed>
+	 */
+	public function sanitize( array $options ): array {
+		if ( isset( $options[ self::OPTION_COMMON ] ) && is_array( $options[ self::OPTION_COMMON ] ) ) {
+			$options[ self::OPTION_COMMON ] = $this->reset_present_keys(
+				$options[ self::OPTION_COMMON ],
+				self::CONNECTION_DEFAULTS
+			);
+		}
+
+		if ( isset( $options[ self::OPTION_ONBOARDING ] ) && is_array( $options[ self::OPTION_ONBOARDING ] ) ) {
+			$options[ self::OPTION_ONBOARDING ] = $this->reset_present_keys(
+				$options[ self::OPTION_ONBOARDING ],
+				self::ONBOARDING_DEFAULTS
+			);
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Overwrites the given keys with their neutral values, skipping keys the
+	 * payload does not contain.
+	 *
+	 * @param array<string, mixed> $data     Stored option value.
+	 * @param array<string, mixed> $defaults Key => neutral value.
+	 * @return array<string, mixed>
+	 */
+	private function reset_present_keys( array $data, array $defaults ): array {
+		foreach ( $defaults as $key => $neutral_value ) {
+			if ( array_key_exists( $key, $data ) ) {
+				$data[ $key ] = $neutral_value;
+			}
+		}
+
+		return $data;
+	}
+}

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintBootstrap.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintBootstrap.php
@@ -15,11 +15,18 @@ namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
 class PayPalBlueprintBootstrap {
 
 	/**
-	 * PayPal Settings Exporter instance.
+	 * PayPal Settings Exporter instance, without connection details.
 	 *
 	 * @var PayPalSettingsExporter
 	 */
 	private PayPalSettingsExporter $exporter;
+
+	/**
+	 * PayPal Settings Exporter instance, including connection details.
+	 *
+	 * @var PayPalSettingsExporter
+	 */
+	private PayPalSettingsExporter $exporter_with_connection;
 
 	/**
 	 * PayPal Settings Importer instance.
@@ -31,15 +38,18 @@ class PayPalBlueprintBootstrap {
 	/**
 	 * Constructor.
 	 *
-	 * @param PayPalSettingsExporter $exporter PayPal settings exporter.
-	 * @param PayPalSettingsImporter $importer PayPal settings importer.
+	 * @param PayPalSettingsExporter $exporter                 Default exporter, without connection details.
+	 * @param PayPalSettingsExporter $exporter_with_connection Opt-in exporter, including connection details.
+	 * @param PayPalSettingsImporter $importer                 PayPal settings importer.
 	 */
 	public function __construct(
 		PayPalSettingsExporter $exporter,
+		PayPalSettingsExporter $exporter_with_connection,
 		PayPalSettingsImporter $importer
 	) {
-		$this->exporter = $exporter;
-		$this->importer = $importer;
+		$this->exporter                 = $exporter;
+		$this->exporter_with_connection = $exporter_with_connection;
+		$this->importer                 = $importer;
 	}
 
 	/**
@@ -69,6 +79,7 @@ class PayPalBlueprintBootstrap {
 	 */
 	public function register_exporters( array $exporters ): array {
 		$exporters[] = $this->exporter;
+		$exporters[] = $this->exporter_with_connection;
 		return $exporters;
 	}
 

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintOptions.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintOptions.php
@@ -28,8 +28,11 @@ class PayPalBlueprintOptions {
 		'woocommerce-ppcp-data-styling',
 		'woocommerce-ppcp-data-fastlane',
 		'woocommerce-ppcp-data-paylater-messaging',
-		// Merchant state flags.
-		'woocommerce-ppcp-is-new-merchant',
+
+		/*
+		 * 'woocommerce-ppcp-is-new-merchant' is deliberately excluded: importing it
+		 * as truthy makes MigrationManager permanently skip the legacy migrations.
+		 */
 		// Individual payment method settings (gateway titles/descriptions).
 		'woocommerce_venmo_settings',
 		'woocommerce_pay-later_settings',

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
@@ -15,6 +15,11 @@ use Automattic\WooCommerce\Blueprint\Steps\Step;
 
 /**
  * PayPal Settings Exporter for WooCommerce Blueprint.
+ *
+ * Registered twice, as the default connection-free export and as the opt-in one.
+ * Two instances rather than one configurable export because Blueprint gives
+ * exporters no per-request context: choosing an alias is the only lever a caller
+ * has, whether that is the settings UI, WP-CLI or a direct REST request.
  */
 class PayPalSettingsExporter implements StepExporter, HasAlias {
 
@@ -22,6 +27,52 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	 * Sentinel value to detect if option doesn't exist.
 	 */
 	private const OPTION_NOT_FOUND = '__PAYPAL_OPTION_NOT_FOUND__';
+
+	/**
+	 * Alias of the default export, which carries no connection details.
+	 */
+	public const ALIAS = 'paypalSettings';
+
+	/**
+	 * Alias of the opt-in export, which carries the connection details.
+	 */
+	public const ALIAS_WITH_CONNECTION = 'paypalSettingsWithConnection';
+
+	/**
+	 * Selection id of the opt-in export.
+	 *
+	 * Deliberately different from the step name emitted into the file, so that
+	 * asking for 'setPayPalSettings' can only ever select the safe export.
+	 */
+	public const STEP_NAME_WITH_CONNECTION = 'setPayPalSettingsWithConnection';
+
+	/**
+	 * Strips connection data from the exported options.
+	 *
+	 * @var ConnectionDataSanitizer
+	 */
+	private ConnectionDataSanitizer $sanitizer;
+
+	/**
+	 * Whether this instance exports the merchant's connection details.
+	 *
+	 * @var bool
+	 */
+	private bool $include_connection;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ConnectionDataSanitizer $sanitizer          Connection data sanitizer.
+	 * @param bool                    $include_connection Whether to export connection details.
+	 */
+	public function __construct(
+		ConnectionDataSanitizer $sanitizer,
+		bool $include_connection = false
+	) {
+		$this->sanitizer          = $sanitizer;
+		$this->include_connection = $include_connection;
+	}
 
 	/**
 	 * Export PayPal settings.
@@ -38,6 +89,10 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 			}
 		}
 
+		if ( ! $this->include_connection ) {
+			$paypal_options = $this->sanitizer->sanitize( $paypal_options );
+		}
+
 		return new SetPayPalSettings( $paypal_options );
 	}
 
@@ -47,7 +102,9 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	 * @return string
 	 */
 	public function get_step_name(): string {
-		return SetPayPalSettings::get_step_name();
+		return $this->include_connection
+			? self::STEP_NAME_WITH_CONNECTION
+			: SetPayPalSettings::get_step_name();
 	}
 
 	/**
@@ -56,7 +113,9 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	 * @return string
 	 */
 	public function get_alias(): string {
-		return 'paypalSettings';
+		return $this->include_connection
+			? self::ALIAS_WITH_CONNECTION
+			: self::ALIAS;
 	}
 
 	/**
@@ -65,7 +124,9 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	 * @return string
 	 */
 	public function get_label(): string {
-		return __( 'PayPal Settings', 'woocommerce-paypal-payments' );
+		return $this->include_connection
+			? __( 'PayPal Settings (including connection details)', 'woocommerce-paypal-payments' )
+			: __( 'PayPal Settings', 'woocommerce-paypal-payments' );
 	}
 
 	/**
@@ -74,7 +135,9 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	 * @return string
 	 */
 	public function get_description(): string {
-		return __( 'Exports PayPal Payments settings and configuration options.', 'woocommerce-paypal-payments' );
+		return $this->include_connection
+			? __( 'Exports PayPal Payments settings together with the connection credentials of the connected account.', 'woocommerce-paypal-payments' )
+			: __( 'Exports PayPal Payments settings and configuration options, without any connection credentials.', 'woocommerce-paypal-payments' );
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
@@ -132,11 +132,15 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	/**
 	 * Return the description used in the frontend.
 	 *
+	 * Blueprint surfaces outside this plugin render only the label and this
+	 * description, so the opt-in variant states the risk here rather than relying
+	 * on the plugin's own confirmation dialog.
+	 *
 	 * @return string
 	 */
 	public function get_description(): string {
 		return $this->include_connection
-			? __( 'Exports PayPal Payments settings together with the connection credentials of the connected account.', 'woocommerce-paypal-payments' )
+			? __( 'Exports PayPal Payments settings together with the connection credentials of the connected account. The file will contain your client ID and client secret in plain text, so store it securely and do not share it.', 'woocommerce-paypal-payments' )
 			: __( 'Exports PayPal Payments settings and configuration options, without any connection credentials.', 'woocommerce-paypal-payments' );
 	}
 

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
@@ -59,8 +59,9 @@ class PayPalSettingsImporter implements StepProcessor {
 			return $result;
 		}
 
-		$options        = (array) $schema->options;
-		$imported_count = 0;
+		$options            = (array) $schema->options;
+		$carries_connection = $this->carries_connection( $options );
+		$imported_count     = 0;
 
 		foreach ( $options as $option_name => $option_value ) {
 			// Validate option name first (before using it in any operations).
@@ -82,7 +83,7 @@ class PayPalSettingsImporter implements StepProcessor {
 			}
 
 			// Attempt to update the option with proper error handling.
-			if ( $this->update_option_safely( $option_name, $option_value ) ) {
+			if ( $this->update_option_safely( $option_name, $option_value, $carries_connection ) ) {
 				++$imported_count;
 			} else {
 				$sanitized_name = sanitize_text_field( $option_name );
@@ -166,13 +167,18 @@ class PayPalSettingsImporter implements StepProcessor {
 	/**
 	 * Safely update an option with proper comparison for existing values.
 	 *
-	 * @param string $option_name  Option name.
-	 * @param mixed  $option_value Option value.
+	 * @param string $option_name        Option name.
+	 * @param mixed  $option_value       Option value.
+	 * @param bool   $carries_connection Whether the payload brings its own connection.
 	 * @return bool
 	 */
-	private function update_option_safely( string $option_name, $option_value ): bool {
+	private function update_option_safely( string $option_name, $option_value, bool $carries_connection = true ): bool {
 		// Convert stdClass objects from JSON decode to arrays.
 		$option_value = $this->convert_objects_to_arrays( $option_value );
+
+		if ( ! $carries_connection ) {
+			$option_value = $this->keep_local_connection( $option_name, $option_value );
+		}
 
 		// Hydrate DTO-based options so typed objects are preserved in the database.
 		$option_value = $this->hydrate_dtos( $option_name, $option_value );
@@ -186,6 +192,57 @@ class PayPalSettingsImporter implements StepProcessor {
 		}
 
 		return update_option( $option_name, $option_value );
+	}
+
+	/**
+	 * Whether the payload brings a PayPal connection of its own.
+	 *
+	 * @param array<string, mixed> $options Options from the imported step.
+	 * @return bool
+	 */
+	private function carries_connection( array $options ): bool {
+		$common = $this->convert_objects_to_arrays(
+			$options[ ConnectionDataSanitizer::OPTION_COMMON ] ?? null
+		);
+
+		return is_array( $common ) && ! empty( $common['client_id'] );
+	}
+
+	/**
+	 * Keeps the target store's own connection when the payload does not bring one.
+	 *
+	 * A settings-only export carries the connection keys as empty values, and
+	 * options are written whole rather than merged, so without this an import
+	 * would disconnect a store that was already connected.
+	 *
+	 * @param string $option_name  Option name.
+	 * @param mixed  $option_value Option value.
+	 * @return mixed
+	 */
+	private function keep_local_connection( string $option_name, $option_value ) {
+		if ( ConnectionDataSanitizer::OPTION_COMMON === $option_name ) {
+			$keys = array_keys( ConnectionDataSanitizer::CONNECTION_DEFAULTS );
+		} elseif ( ConnectionDataSanitizer::OPTION_ONBOARDING === $option_name ) {
+			$keys = array_keys( ConnectionDataSanitizer::ONBOARDING_DEFAULTS );
+		} else {
+			return $option_value;
+		}
+
+		$current = get_option( $option_name );
+
+		if ( ! is_array( $option_value ) || ! is_array( $current ) ) {
+			return $option_value;
+		}
+
+		foreach ( $keys as $key ) {
+			if ( array_key_exists( $key, $current ) ) {
+				$option_value[ $key ] = $current[ $key ];
+			} else {
+				unset( $option_value[ $key ] );
+			}
+		}
+
+		return $option_value;
 	}
 
 	/**

--- a/modules/ppcp-settings/resources/css/_mixins.scss
+++ b/modules/ppcp-settings/resources/css/_mixins.scss
@@ -44,6 +44,39 @@
 	gap: $gap;
 }
 
+// Expects a single `> .ppcp--content` child; open state is `.ppcp--is-open`.
+@mixin grid-reveal($open-margin: 0) {
+	display: grid;
+	grid-template-rows: 0fr;
+	opacity: 0;
+	margin: 0;
+	transition: grid-template-rows 0.2s ease-out, opacity 0.2s ease-out, margin 0.2s ease-out;
+
+	> .ppcp--content {
+		overflow: hidden;
+	}
+
+	&.ppcp--is-open {
+		grid-template-rows: 1fr;
+		opacity: 1;
+		margin: $open-margin;
+		transition: grid-template-rows 0.3s ease-in, opacity 0.3s ease-in, margin 0.3s ease-in;
+
+		> .ppcp--content {
+			// Focus outlines can extend beyond the content box.
+			overflow: visible;
+		}
+
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		&,
+		&.ppcp--is-open {
+			transition: none;
+		}
+	}
+}
+
 @mixin disabled-state($control-type) {
 	.components-#{$control-type}-control.ppcp--is-disabled {
 		.components-#{$control-type}-control__input,

--- a/modules/ppcp-settings/resources/css/_variables.scss
+++ b/modules/ppcp-settings/resources/css/_variables.scss
@@ -18,6 +18,11 @@ $color-border: #AEAEAE;
 $color-divider: #F0F0F0;
 $color-error-red: #cc1818;
 $color-warning: #e2a030;
+// SCSS variables so modals, which portal outside #ppcp-settings-container, can use them.
+$color-failure-background: #faeded;
+$color-failure-text: #5c0000;
+$color-warning-background: #fdf4e7;
+$color-warning-text: #5c3d00;
 
 $shadow-card: 0 3px 6px 0 rgba(0, 0, 0, 0.15);
 $color-gradient-dark: #001435;
@@ -57,8 +62,10 @@ $card-vertical-gap: 48px;
 	--color-gradient-dark: #{$color-gradient-dark};
 	--color-success-background: #DAFFE0;
 	--color-success-text: #144722;
-	--color-failure-background: #faeded;
-	--color-failure-text: #5c0000;
+	--color-failure-background: #{$color-failure-background};
+	--color-failure-text: #{$color-failure-text};
+	--color-warning-background: #{$color-warning-background};
+	--color-warning-text: #{$color-warning-text};
 
 	--color-preview-background: #FAF8F5;
 	--color-separators: #{$color-gray-200};

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_accordion-section.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_accordion-section.scss
@@ -22,26 +22,6 @@
 	}
 
 	.ppcp--accordion-content {
-		display: grid;
-		grid-template-rows: 0fr;
-		transition: grid-template-rows 0.2s ease-out, opacity 0.2s ease-out, margin 0.2s ease-out;
-		opacity: 0;
-		margin: 0;
-
-		> .ppcp--content {
-			overflow: hidden;
-		}
-
-		&.ppcp--is-open {
-			grid-template-rows: 1fr;
-			opacity: 1;
-			margin: 24px 0 0;
-			transition: grid-template-rows 0.3s ease-in, opacity 0.3s ease-in, margin 0.3s ease-in;
-
-			> .ppcp--content {
-				// Show the overflow, since the focus-outline can extend outside the content div.
-				overflow: visible;
-			}
-		}
+		@include grid-reveal(24px 0 0);
 	}
 }

--- a/modules/ppcp-settings/resources/css/components/screens/_modals.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_modals.scss
@@ -1,10 +1,13 @@
 /**
- * Modal for disconnecting the merchant from the current PayPal account.
+ * Shared styling for the confirmation modals.
  */
-.ppcp--modal-disconnect {
+.ppcp--modal-disconnect,
+.ppcp--modal-blueprint-export {
+	// Modals portal outside #ppcp-settings-container, so its custom properties are
+	// out of scope here. Use the SCSS variables directly.
 	.ppcp--toggle-danger .components-form-toggle {
 		&.is-checked {
-			--wp-components-color-accent: #cc1818;
+			--wp-components-color-accent: #{$color-error-red};
 		}
 	}
 
@@ -15,6 +18,31 @@
 		.components-button {
 			transition: background 0.3s;
 		}
+	}
+}
+
+/**
+ * Modal confirming a Blueprint export that may include connection credentials.
+ */
+.ppcp--modal-blueprint-export {
+	// Padding lives on .ppcp--warning-body: on the collapsed grid row it would
+	// still paint a visible strip.
+	.ppcp--credentials-warning {
+		@include grid-reveal(16px 0 0);
+	}
+
+	// Warning palette, not failure: exporting is risky, not destructive.
+	.ppcp--toggle-warning .components-form-toggle.is-checked {
+		--wp-components-color-accent: #{$color-warning};
+	}
+
+	.ppcp--warning-body {
+		display: block;
+		padding: 10px;
+		line-height: 1.5714285714;
+		font-size: 0.8125rem;
+		background: $color-warning-background;
+		color: $color-warning-text;
 	}
 }
 

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/ConfirmationModal.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/ConfirmationModal.js
@@ -1,0 +1,65 @@
+import { __ } from '@wordpress/i18n';
+import { Button, Modal, ToggleControl } from '@wordpress/components';
+
+import { HStack } from '@ppcp-settings/Components/ReusableComponents/Stack';
+
+/**
+ * Dialog confirming a consequential action, optionally with a toggle that changes
+ * the scope of that action.
+ *
+ * @param {Object}   props                 Component props.
+ * @param {string}   props.className       Modal class, used to scope its styling.
+ * @param {string}   props.title           Dialog title.
+ * @param {string}   props.description     Sentence explaining the action.
+ * @param {?Object}  [props.toggle]        {label, help, checked, onChange, className}.
+ * @param {*}        [props.children]      Extra content rendered below the toggle.
+ * @param {string}   props.confirmLabel    Label of the confirm button.
+ * @param {boolean}  [props.isDestructive] Style the confirm button as destructive.
+ * @param {Function} props.onConfirm       Called when the merchant confirms.
+ * @param {Function} props.onCancel        Called when the dialog is dismissed.
+ */
+const ConfirmationModal = ( {
+	className,
+	title,
+	description,
+	toggle = null,
+	children = null,
+	confirmLabel,
+	isDestructive = false,
+	onConfirm,
+	onCancel,
+} ) => (
+	<Modal
+		className={ className }
+		size="small"
+		title={ title }
+		onRequestClose={ onCancel }
+	>
+		<p>{ description }</p>
+		{ toggle && (
+			<ToggleControl
+				__nextHasNoMarginBottom
+				className={ toggle.className }
+				checked={ toggle.checked }
+				onChange={ toggle.onChange }
+				label={ toggle.label }
+				help={ toggle.help }
+			/>
+		) }
+		{ children }
+		<HStack className="ppcp--action-buttons">
+			<Button variant="tertiary" onClick={ onCancel }>
+				{ __( 'Cancel', 'woocommerce-paypal-payments' ) }
+			</Button>
+			<Button
+				variant="primary"
+				isDestructive={ isDestructive }
+				onClick={ onConfirm }
+			>
+				{ confirmLabel }
+			</Button>
+		</HStack>
+	</Modal>
+);
+
+export default ConfirmationModal;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/FeatureSettingsBlock.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/FeatureSettingsBlock.js
@@ -71,6 +71,7 @@ const FeatureSettingsBlock = ( { title, description, ...props } ) => {
 							text,
 							onClick,
 							target,
+							disabled,
 						} = buttonData;
 
 						const buttonUrl = getButtonUrl( buttonData );
@@ -84,6 +85,7 @@ const FeatureSettingsBlock = ( { title, description, ...props } ) => {
 								className={ className }
 								variant={ type }
 								isBusy={ actionProps.isBusy }
+								disabled={ disabled }
 								href={ buttonUrl }
 								target={ buttonTarget }
 								onClick={ ! buttonUrl ? onClick : undefined }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.js
@@ -12,9 +12,16 @@ const BlueprintExportImport = () => {
 	const { blueprint } = data();
 	const { exportBlueprint, isExporting } = useBlueprintExport();
 	const { isConnected } = CommonHooks.useMerchant();
-	const { isOpen, setIsOpen } = useToggleState( 'blueprint-export' );
+	const { isReady } = CommonHooks.useStore();
+	// No id: opening the dialog from the URL would skip the isConnected branch.
+	const { isOpen, setIsOpen } = useToggleState();
 
 	const handleExportClick = useCallback( () => {
+		// isConnected defaults to false until the merchant resolves.
+		if ( ! isReady ) {
+			return;
+		}
+
 		// Nothing to opt in to while disconnected.
 		if ( ! isConnected ) {
 			exportBlueprint();
@@ -22,7 +29,7 @@ const BlueprintExportImport = () => {
 		}
 
 		setIsOpen( true );
-	}, [ isConnected, exportBlueprint, setIsOpen ] );
+	}, [ isReady, isConnected, exportBlueprint, setIsOpen ] );
 
 	const handleCancel = useCallback( () => {
 		setIsOpen( false );
@@ -52,7 +59,7 @@ const BlueprintExportImport = () => {
 					'woocommerce-paypal-payments'
 				) }
 				actionProps={ {
-					isBusy: isExporting,
+					isBusy: isExporting || ! isReady,
 					buttons: [
 						{
 							text: __( 'Export', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.js
@@ -1,45 +1,82 @@
 import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
+
+import { CommonHooks } from '@ppcp-settings/data';
 import FeatureSettingsBlock from '../../../../../ReusableComponents/SettingsBlocks/FeatureSettingsBlock';
 import data from '../../../../../../utils/data';
 import { useBlueprintExport } from '../../../../../../hooks/useBlueprintExport';
+import { useToggleState } from '../../../../../../hooks/useToggleState';
+import BlueprintExportModal from '../Parts/BlueprintExportModal';
 
 const BlueprintExportImport = () => {
 	const { blueprint } = data();
 	const { exportBlueprint, isExporting } = useBlueprintExport();
+	const { isConnected } = CommonHooks.useMerchant();
+	const { isOpen, setIsOpen } = useToggleState( 'blueprint-export' );
+
+	const handleExportClick = useCallback( () => {
+		// Nothing to opt in to while disconnected.
+		if ( ! isConnected ) {
+			exportBlueprint();
+			return;
+		}
+
+		setIsOpen( true );
+	}, [ isConnected, exportBlueprint, setIsOpen ] );
+
+	const handleCancel = useCallback( () => {
+		setIsOpen( false );
+	}, [ setIsOpen ] );
+
+	const handleExport = useCallback(
+		( options ) => {
+			setIsOpen( false );
+			exportBlueprint( options );
+		},
+		[ setIsOpen, exportBlueprint ]
+	);
 
 	if ( ! blueprint?.isActive ) {
 		return null;
 	}
 
 	return (
-		<FeatureSettingsBlock
-			title={ __(
-				'WooCommerce Blueprint Export & Import',
-				'woocommerce-paypal-payments'
+		<>
+			<FeatureSettingsBlock
+				title={ __(
+					'WooCommerce Blueprint Export & Import',
+					'woocommerce-paypal-payments'
+				) }
+				description={ __(
+					'Export or import your current PayPal Payments settings across WooCommerce sites. Connection credentials are excluded from the export unless you choose to include them.',
+					'woocommerce-paypal-payments'
+				) }
+				actionProps={ {
+					isBusy: isExporting,
+					buttons: [
+						{
+							text: __( 'Export', 'woocommerce-paypal-payments' ),
+							type: 'secondary',
+							class: 'small-button',
+							onClick: handleExportClick,
+						},
+						{
+							text: __( 'Import', 'woocommerce-paypal-payments' ),
+							type: 'tertiary',
+							class: 'small-button',
+							url: blueprint.importUrl,
+							target: false,
+						},
+					],
+				} }
+			/>
+			{ isOpen && (
+				<BlueprintExportModal
+					onExport={ handleExport }
+					onCancel={ handleCancel }
+				/>
 			) }
-			description={ __(
-				'Export or import your current PayPal Payments settings across WooCommerce sites.',
-				'woocommerce-paypal-payments'
-			) }
-			actionProps={ {
-				isBusy: isExporting,
-				buttons: [
-					{
-						text: __( 'Export', 'woocommerce-paypal-payments' ),
-						type: 'secondary',
-						class: 'small-button',
-						onClick: exportBlueprint,
-					},
-					{
-						text: __( 'Import', 'woocommerce-paypal-payments' ),
-						type: 'tertiary',
-						class: 'small-button',
-						url: blueprint.importUrl,
-						target: false,
-					},
-				],
-			} }
-		/>
+		</>
 	);
 };
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.js
@@ -66,6 +66,7 @@ const BlueprintExportImport = () => {
 							type: 'secondary',
 							class: 'small-button',
 							onClick: handleExportClick,
+							disabled: ! isReady,
 						},
 						{
 							text: __( 'Import', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.test.js
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import BlueprintExportImport from './BlueprintExportImport';
+
+const mockExportBlueprint = jest.fn();
+const mockUseMerchant = jest.fn();
+const mockData = jest.fn();
+
+jest.mock( '@ppcp-settings/data', () => ( {
+	CommonHooks: {
+		useMerchant: () => mockUseMerchant(),
+	},
+} ) );
+
+jest.mock( '../../../../../../utils/data', () => ( {
+	__esModule: true,
+	default: () => mockData(),
+} ) );
+
+jest.mock( '../../../../../../hooks/useBlueprintExport', () => ( {
+	useBlueprintExport: () => ( {
+		exportBlueprint: mockExportBlueprint,
+		isExporting: false,
+	} ),
+} ) );
+
+// Render the action buttons flat so the Export button is clickable.
+jest.mock(
+	'../../../../../ReusableComponents/SettingsBlocks/FeatureSettingsBlock',
+	() => ( {
+		__esModule: true,
+		default: ( { actionProps } ) => (
+			<div>
+				{ actionProps.buttons.map( ( button ) => (
+					<button key={ button.text } onClick={ button.onClick }>
+						{ button.text }
+					</button>
+				) ) }
+			</div>
+		),
+	} )
+);
+
+jest.mock( '../Parts/BlueprintExportModal', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="export-modal" />,
+} ) );
+
+const clickExport = () =>
+	fireEvent.click( screen.getByRole( 'button', { name: 'Export' } ) );
+
+describe( 'BlueprintExportImport', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockData.mockReturnValue( {
+			blueprint: { isActive: true, importUrl: 'http://example.test' },
+		} );
+		mockUseMerchant.mockReturnValue( { isConnected: true } );
+	} );
+
+	it( 'asks for confirmation before exporting while connected', () => {
+		render( <BlueprintExportImport /> );
+
+		clickExport();
+
+		expect( screen.getByTestId( 'export-modal' ) ).toBeInTheDocument();
+		expect( mockExportBlueprint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'exports straight away while disconnected, with no credentials to opt into', () => {
+		mockUseMerchant.mockReturnValue( { isConnected: false } );
+
+		render( <BlueprintExportImport /> );
+
+		clickExport();
+
+		expect( screen.queryByTestId( 'export-modal' ) ).not.toBeInTheDocument();
+		expect( mockExportBlueprint ).toHaveBeenCalledWith();
+	} );
+
+	it( 'renders nothing when the Blueprint feature is disabled', () => {
+		mockData.mockReturnValue( { blueprint: { isActive: false } } );
+
+		const { container } = render( <BlueprintExportImport /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/BlueprintExportImport.test.js
@@ -5,11 +5,13 @@ import BlueprintExportImport from './BlueprintExportImport';
 
 const mockExportBlueprint = jest.fn();
 const mockUseMerchant = jest.fn();
+const mockUseStore = jest.fn();
 const mockData = jest.fn();
 
 jest.mock( '@ppcp-settings/data', () => ( {
 	CommonHooks: {
 		useMerchant: () => mockUseMerchant(),
+		useStore: () => mockUseStore(),
 	},
 } ) );
 
@@ -32,6 +34,9 @@ jest.mock(
 		__esModule: true,
 		default: ( { actionProps } ) => (
 			<div>
+				<span data-testid="is-busy">
+					{ String( actionProps.isBusy ) }
+				</span>
 				{ actionProps.buttons.map( ( button ) => (
 					<button key={ button.text } onClick={ button.onClick }>
 						{ button.text }
@@ -57,6 +62,7 @@ describe( 'BlueprintExportImport', () => {
 			blueprint: { isActive: true, importUrl: 'http://example.test' },
 		} );
 		mockUseMerchant.mockReturnValue( { isConnected: true } );
+		mockUseStore.mockReturnValue( { isReady: true } );
 	} );
 
 	it( 'asks for confirmation before exporting while connected', () => {
@@ -75,8 +81,34 @@ describe( 'BlueprintExportImport', () => {
 
 		clickExport();
 
-		expect( screen.queryByTestId( 'export-modal' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'export-modal' )
+		).not.toBeInTheDocument();
 		expect( mockExportBlueprint ).toHaveBeenCalledWith();
+	} );
+
+	it( 'does not export while the merchant is still resolving', () => {
+		// isConnected is false until the store resolves, which would otherwise
+		// take the disconnected branch and export with no prompt.
+		mockUseStore.mockReturnValue( { isReady: false } );
+		mockUseMerchant.mockReturnValue( { isConnected: false } );
+
+		render( <BlueprintExportImport /> );
+
+		clickExport();
+
+		expect( mockExportBlueprint ).not.toHaveBeenCalled();
+		expect(
+			screen.queryByTestId( 'export-modal' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'disables the actions until the merchant has resolved', () => {
+		mockUseStore.mockReturnValue( { isReady: false } );
+
+		render( <BlueprintExportImport /> );
+
+		expect( screen.getByTestId( 'is-busy' ) ).toHaveTextContent( 'true' );
 	} );
 
 	it( 'renders nothing when the Blueprint feature is disabled', () => {

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.js
@@ -1,0 +1,104 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from '@wordpress/element';
+
+import { CommonHooks } from '@ppcp-settings/data';
+import ConfirmationModal from '@ppcp-settings/Components/ReusableComponents/ConfirmationModal';
+
+/**
+ * Toggle help text: states the outcome for the importing store, not the risk.
+ *
+ * @param {boolean} includeConnection Whether credentials are included.
+ * @param {boolean} isSandbox         Whether the connected account is a sandbox account.
+ * @return {string} Help text shown under the toggle.
+ */
+const outcomeDescription = ( includeConnection, isSandbox ) => {
+	if ( ! includeConnection ) {
+		return __(
+			'Export settings only. The store that imports this file will need to connect its own PayPal account.',
+			'woocommerce-paypal-payments'
+		);
+	}
+
+	return isSandbox
+		? __(
+				'The store that imports this file will connect as your sandbox PayPal account.',
+				'woocommerce-paypal-payments'
+		  )
+		: __(
+				'The store that imports this file will connect as your live PayPal account.',
+				'woocommerce-paypal-payments'
+		  );
+};
+
+/**
+ * States the risk of holding the exported file.
+ *
+ * Deliberately identical for sandbox and live: a stale environment flag would
+ * otherwise show the reassuring copy to someone exporting live credentials.
+ *
+ * @return {string} Warning shown when credentials are included.
+ */
+const credentialsWarning = () =>
+	__(
+		'Warning: The exported file will contain your client ID, client secret and merchant details in plain text. Anyone who has the file can act on your PayPal account, so store it securely and do not share it.',
+		'woocommerce-paypal-payments'
+	);
+
+/**
+ * Confirmation dialog shown before a Blueprint export.
+ *
+ * The credentials choice is asked per export and never stored: a persisted setting
+ * would carry credentials into every later export without asking again.
+ *
+ * @param {Object}   props          Component props.
+ * @param {Function} props.onExport Called with { includeConnection } to run the export.
+ * @param {Function} props.onCancel Called when the dialog is dismissed.
+ */
+const BlueprintExportModal = ( { onExport, onCancel } ) => {
+	const [ includeConnection, setIncludeConnection ] = useState( false );
+	const { isSandbox } = CommonHooks.useMerchant();
+
+	const handleConfirm = useCallback( () => {
+		onExport( { includeConnection } );
+	}, [ onExport, includeConnection ] );
+
+	return (
+		<ConfirmationModal
+			className="ppcp--modal-blueprint-export"
+			title={ __( 'Export settings', 'woocommerce-paypal-payments' ) }
+			description={ __(
+				'Exports your PayPal Payments settings so they can be imported into another WooCommerce store.',
+				'woocommerce-paypal-payments'
+			) }
+			toggle={ {
+				className: 'ppcp--toggle-warning',
+				checked: includeConnection,
+				onChange: setIncludeConnection,
+				label: __(
+					'Include connection credentials',
+					'woocommerce-paypal-payments'
+				),
+				help: outcomeDescription( includeConnection, isSandbox ),
+			} }
+			confirmLabel={ __( 'Export', 'woocommerce-paypal-payments' ) }
+			onConfirm={ handleConfirm }
+			onCancel={ onCancel }
+		>
+			{ /* Kept mounted and revealed via CSS so the modal grows smoothly. */ }
+			<div
+				className={ `ppcp--credentials-warning${
+					includeConnection ? ' ppcp--is-open' : ''
+				}` }
+				aria-hidden={ ! includeConnection }
+			>
+				<div className="ppcp--content">
+					<span className="ppcp--warning-body">
+						{ credentialsWarning() }
+					</span>
+				</div>
+			</div>
+		</ConfirmationModal>
+	);
+};
+
+export default BlueprintExportModal;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.js
@@ -92,7 +92,9 @@ const BlueprintExportModal = ( { onExport, onCancel } ) => {
 				aria-hidden={ ! includeConnection }
 			>
 				<div className="ppcp--content">
-					<span className="ppcp--warning-body">
+					{ /* Announced on reveal; the toggle's help text states the
+					     outcome, not the risk. */ }
+					<span className="ppcp--warning-body" role="alert">
 						{ credentialsWarning() }
 					</span>
 				</div>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.test.js
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import BlueprintExportModal from './BlueprintExportModal';
+
+// @wordpress/components cannot load here: the repo mocks @wordpress/i18n without
+// isRTL, which that package needs at import time.
+jest.mock( '@wordpress/components', () => ( {
+	Modal: ( { title, children } ) => (
+		<div role="dialog" aria-label={ title }>
+			{ children }
+		</div>
+	),
+	Button: ( { children, onClick } ) => (
+		<button onClick={ onClick }>{ children }</button>
+	),
+	ToggleControl: ( { label, help, checked, onChange } ) => (
+		<>
+			<label htmlFor="toggle">{ label }</label>
+			<input
+				id="toggle"
+				type="checkbox"
+				checked={ checked }
+				onChange={ ( event ) => onChange( event.target.checked ) }
+			/>
+			<span>{ help }</span>
+		</>
+	),
+} ) );
+
+const mockUseMerchant = jest.fn();
+
+jest.mock( '@ppcp-settings/data', () => ( {
+	CommonHooks: {
+		useMerchant: () => mockUseMerchant(),
+	},
+} ) );
+
+jest.mock( '@ppcp-settings/Components/ReusableComponents/Stack', () => ( {
+	HStack: ( { children, ...props } ) => <div { ...props }>{ children }</div>,
+} ) );
+
+const toggle = () =>
+	screen.getByLabelText( 'Include connection credentials', {
+		exact: false,
+	} );
+
+const exportButton = () => screen.getByRole( 'button', { name: 'Export' } );
+
+// Matched by class, not text: the text is in the DOM in both states.
+const warning = () =>
+	document.querySelector( '.ppcp--credentials-warning' );
+
+describe( 'BlueprintExportModal', () => {
+	let onExport;
+	let onCancel;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseMerchant.mockReturnValue( {
+			isConnected: true,
+			isSandbox: false,
+		} );
+		onExport = jest.fn();
+		onCancel = jest.fn();
+	} );
+
+	const renderModal = () =>
+		render(
+			<BlueprintExportModal onExport={ onExport } onCancel={ onCancel } />
+		);
+
+	it( 'leaves the credentials opt-in off when opened', () => {
+		renderModal();
+
+		expect( toggle() ).not.toBeChecked();
+	} );
+
+	it( 'keeps the credentials warning collapsed and hidden from assistive technology until the opt-in is enabled', () => {
+		// Stays mounted for the CSS reveal, so "not shown" means collapsed.
+		renderModal();
+
+		expect( warning() ).not.toHaveClass( 'ppcp--is-open' );
+		expect( warning() ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	it( 'reveals the credentials warning when the opt-in is enabled', () => {
+		renderModal();
+
+		fireEvent.click( toggle() );
+
+		expect( warning() ).toHaveClass( 'ppcp--is-open' );
+		expect( warning() ).toHaveAttribute( 'aria-hidden', 'false' );
+	} );
+
+	it( 'exports without credentials when confirmed untouched', () => {
+		renderModal();
+
+		fireEvent.click( exportButton() );
+
+		expect( onExport ).toHaveBeenCalledWith( {
+			includeConnection: false,
+		} );
+	} );
+
+	it( 'exports with credentials once the opt-in is enabled', () => {
+		renderModal();
+
+		fireEvent.click( toggle() );
+		fireEvent.click( exportButton() );
+
+		expect( onExport ).toHaveBeenCalledWith( { includeConnection: true } );
+	} );
+
+	it( 'describes the outcome for the importing store when credentials are excluded', () => {
+		renderModal();
+
+		expect(
+			screen.getByText( /need to connect its own PayPal account/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'names the live environment in the enabled help text', () => {
+		renderModal();
+
+		fireEvent.click( toggle() );
+
+		expect(
+			screen.getByText( /connect as your live PayPal account/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'names the sandbox environment in the enabled help text', () => {
+		mockUseMerchant.mockReturnValue( {
+			isConnected: true,
+			isSandbox: true,
+		} );
+
+		renderModal();
+
+		fireEvent.click( toggle() );
+
+		expect(
+			screen.getByText( /connect as your sandbox PayPal account/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'warns that anyone holding the file can act on the account', () => {
+		renderModal();
+
+		fireEvent.click( toggle() );
+
+		expect(
+			screen.getByText( /can act on your PayPal account/i )
+		).toBeInTheDocument();
+		expect( screen.getByText( /do not share it/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'warns identically for sandbox and live accounts', () => {
+		// Must not soften for sandbox: a stale environment flag would then show
+		// the reassuring copy to someone exporting live credentials.
+		const warningFor = ( isSandbox ) => {
+			mockUseMerchant.mockReturnValue( { isConnected: true, isSandbox } );
+			const { unmount } = renderModal();
+			fireEvent.click( toggle() );
+			const text = screen.getByText( /client secret/i ).textContent;
+			unmount();
+			return text;
+		};
+
+		expect( warningFor( true ) ).toBe( warningFor( false ) );
+	} );
+
+	it( 'cancels without exporting', () => {
+		renderModal();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onCancel ).toHaveBeenCalled();
+		expect( onExport ).not.toHaveBeenCalled();
+	} );
+} );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/BlueprintExportModal.test.js
@@ -48,8 +48,7 @@ const toggle = () =>
 const exportButton = () => screen.getByRole( 'button', { name: 'Export' } );
 
 // Matched by class, not text: the text is in the DOM in both states.
-const warning = () =>
-	document.querySelector( '.ppcp--credentials-warning' );
+const warning = () => document.querySelector( '.ppcp--credentials-warning' );
 
 describe( 'BlueprintExportModal', () => {
 	let onExport;
@@ -112,14 +111,6 @@ describe( 'BlueprintExportModal', () => {
 		expect( onExport ).toHaveBeenCalledWith( { includeConnection: true } );
 	} );
 
-	it( 'describes the outcome for the importing store when credentials are excluded', () => {
-		renderModal();
-
-		expect(
-			screen.getByText( /need to connect its own PayPal account/i )
-		).toBeInTheDocument();
-	} );
-
 	it( 'names the live environment in the enabled help text', () => {
 		renderModal();
 
@@ -143,17 +134,6 @@ describe( 'BlueprintExportModal', () => {
 		expect(
 			screen.getByText( /connect as your sandbox PayPal account/i )
 		).toBeInTheDocument();
-	} );
-
-	it( 'warns that anyone holding the file can act on the account', () => {
-		renderModal();
-
-		fireEvent.click( toggle() );
-
-		expect(
-			screen.getByText( /can act on your PayPal account/i )
-		).toBeInTheDocument();
-		expect( screen.getByText( /do not share it/i ) ).toBeInTheDocument();
 	} );
 
 	it( 'warns identically for sandbox and live accounts', () => {

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/DisconnectButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/DisconnectButton.js
@@ -1,10 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import { Button, Modal, ToggleControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 
 import { CommonHooks } from '@ppcp-settings/data';
 import { useToggleState } from '@ppcp-settings/hooks/useToggleState';
-import { HStack } from '@ppcp-settings/Components/ReusableComponents/Stack';
+import ConfirmationModal from '@ppcp-settings/Components/ReusableComponents/ConfirmationModal';
 import { useNavigation } from '@ppcp-settings/hooks/useNavigation';
 
 const DisconnectButton = () => {
@@ -42,55 +42,39 @@ const DisconnectButton = () => {
 			</Button>
 
 			{ isOpen && (
-				<Modal
+				<ConfirmationModal
 					className="ppcp--modal-disconnect"
-					size="small"
 					title={ confirmationTitle }
-					onRequestClose={ handleCancel }
-				>
-					<p>
-						{ __(
-							'Disconnecting your account will restart the connection wizard. Are you sure you want to disconnect from your PayPal account?',
-							'woocommerce-paypal-payments'
-						) }
-					</p>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						className="ppcp--toggle-danger"
-						checked={ resetFlag }
-						onChange={ setResetFlag }
-						label={ __(
+					description={ __(
+						'Disconnecting your account will restart the connection wizard. Are you sure you want to disconnect from your PayPal account?',
+						'woocommerce-paypal-payments'
+					) }
+					toggle={ {
+						className: 'ppcp--toggle-danger',
+						checked: resetFlag,
+						onChange: setResetFlag,
+						label: __(
 							'Start over',
 							'woocommerce-paypal-payments'
-						) }
-						help={
-							resetFlag
-								? __(
-										'Attention: The plugin is reset to its initial state!',
-										'woocommerce-paypal-payments'
-								  )
-								: __(
-										'Disconnect, but preserve all settings',
-										'woocommerce-paypal-payments'
-								  )
-						}
-					/>
-					<HStack className="ppcp--action-buttons">
-						<Button variant="tertiary" onClick={ handleCancel }>
-							{ __( 'Cancel', 'woocommerce-paypal-payments' ) }
-						</Button>
-						<Button
-							variant="primary"
-							isDestructive={ resetFlag }
-							onClick={ handleConfirm }
-						>
-							{ __(
-								'Disconnect',
-								'woocommerce-paypal-payments'
-							) }
-						</Button>
-					</HStack>
-				</Modal>
+						),
+						help: resetFlag
+							? __(
+									'Attention: The plugin is reset to its initial state!',
+									'woocommerce-paypal-payments'
+							  )
+							: __(
+									'Disconnect, but preserve all settings',
+									'woocommerce-paypal-payments'
+							  ),
+					} }
+					confirmLabel={ __(
+						'Disconnect',
+						'woocommerce-paypal-payments'
+					) }
+					isDestructive={ resetFlag }
+					onConfirm={ handleConfirm }
+					onCancel={ handleCancel }
+				/>
 			) }
 		</>
 	);

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/DisconnectButton.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/DisconnectButton.test.js
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import DisconnectButton from './DisconnectButton';
+
+// @wordpress/components cannot load here: the repo mocks @wordpress/i18n without
+// isRTL, which that package needs at import time.
+
+jest.mock( '@wordpress/components', () => ( {
+	Modal: ( { title, children } ) => (
+		<div role="dialog" aria-label={ title }>
+			{ children }
+		</div>
+	),
+	Button: ( { children, onClick } ) => (
+		<button onClick={ onClick }>{ children }</button>
+	),
+	ToggleControl: ( { label, help, checked, onChange } ) => (
+		<>
+			<label htmlFor="toggle">{ label }</label>
+			<input
+				id="toggle"
+				type="checkbox"
+				checked={ checked }
+				onChange={ ( event ) => onChange( event.target.checked ) }
+			/>
+			<span>{ help }</span>
+		</>
+	),
+} ) );
+
+const mockDisconnectMerchant = jest.fn();
+const mockGoToPluginSettings = jest.fn();
+
+jest.mock( '@ppcp-settings/data', () => ( {
+	CommonHooks: {
+		useDisconnectMerchant: () => ( {
+			disconnectMerchant: ( ...args ) =>
+				mockDisconnectMerchant( ...args ),
+		} ),
+	},
+} ) );
+
+jest.mock( '@ppcp-settings/hooks/useNavigation', () => ( {
+	useNavigation: () => ( {
+		goToPluginSettings: () => mockGoToPluginSettings(),
+	} ),
+} ) );
+
+jest.mock( '@ppcp-settings/Components/ReusableComponents/Stack', () => ( {
+	HStack: ( { children, ...props } ) => <div { ...props }>{ children }</div>,
+} ) );
+
+const openDialog = () =>
+	fireEvent.click( screen.getByRole( 'button', { name: 'Disconnect' } ) );
+
+const dialog = () => screen.queryByRole( 'dialog' );
+
+const startOverToggle = () =>
+	screen.getByLabelText( 'Start over', { exact: false } );
+
+const confirmButton = () =>
+	screen.getAllByRole( 'button', { name: 'Disconnect' } ).pop();
+
+describe( 'DisconnectButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockDisconnectMerchant.mockResolvedValue( undefined );
+		window.location.hash = '';
+	} );
+
+	it( 'shows no dialog until the button is clicked', () => {
+		render( <DisconnectButton /> );
+
+		expect( dialog() ).not.toBeInTheDocument();
+	} );
+
+	it( 'opens the confirmation dialog on click', () => {
+		render( <DisconnectButton /> );
+
+		openDialog();
+
+		expect( dialog() ).toBeInTheDocument();
+		expect(
+			screen.getByText( /restart the connection wizard/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'leaves the start-over toggle off by default', () => {
+		render( <DisconnectButton /> );
+
+		openDialog();
+
+		expect( startOverToggle() ).not.toBeChecked();
+		expect(
+			screen.getByText( /preserve all settings/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'disconnects without resetting when confirmed untouched', async () => {
+		render( <DisconnectButton /> );
+
+		openDialog();
+		fireEvent.click( confirmButton() );
+
+		await waitFor( () =>
+			expect( mockDisconnectMerchant ).toHaveBeenCalledWith( false )
+		);
+		expect( mockGoToPluginSettings ).toHaveBeenCalled();
+	} );
+
+	it( 'disconnects with a full reset once start-over is enabled', async () => {
+		render( <DisconnectButton /> );
+
+		openDialog();
+		fireEvent.click( startOverToggle() );
+
+		expect(
+			screen.getByText( /reset to its initial state/i )
+		).toBeInTheDocument();
+
+		fireEvent.click( confirmButton() );
+
+		await waitFor( () =>
+			expect( mockDisconnectMerchant ).toHaveBeenCalledWith( true )
+		);
+	} );
+
+	it( 'closes without disconnecting when cancelled', () => {
+		render( <DisconnectButton /> );
+
+		openDialog();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( dialog() ).not.toBeInTheDocument();
+		expect( mockDisconnectMerchant ).not.toHaveBeenCalled();
+	} );
+} );

--- a/modules/ppcp-settings/resources/js/hooks/useBlueprintExport.js
+++ b/modules/ppcp-settings/resources/js/hooks/useBlueprintExport.js
@@ -6,6 +6,25 @@ import apiFetch from '@wordpress/api-fetch';
 import { downloadBlob } from '@wordpress/blob';
 
 /**
+ * Exporter alias producing a Blueprint without any connection credentials.
+ *
+ * Mirrors PayPalSettingsExporter::ALIAS.
+ *
+ * @type {string}
+ */
+export const EXPORTER_ALIAS = 'paypalSettings';
+
+/**
+ * Exporter alias producing a Blueprint that includes the connection credentials.
+ *
+ * Mirrors PayPalSettingsExporter::ALIAS_WITH_CONNECTION. A separate exporter
+ * because Blueprint lets the client choose aliases, not exporter behaviour.
+ *
+ * @type {string}
+ */
+export const EXPORTER_ALIAS_WITH_CONNECTION = 'paypalSettingsWithConnection';
+
+/**
  * Generates a timestamp string for filenames.
  *
  * @return {string} Formatted timestamp (YYYY-MM-DDTHH-MM-SS)
@@ -26,8 +45,13 @@ export const useBlueprintExport = () => {
 
 	/**
 	 * Exports PayPal settings as a WooCommerce Blueprint file.
+	 *
+	 * Credentials are excluded unless explicitly requested.
+	 *
+	 * @param {Object}  [options]                          Export options.
+	 * @param {boolean} [options.includeConnection =false] Include the connection credentials.
 	 */
-	const exportBlueprint = async () => {
+	const exportBlueprint = async ( { includeConnection = false } = {} ) => {
 		setIsExporting( true );
 
 		try {
@@ -36,7 +60,12 @@ export const useBlueprintExport = () => {
 				method: 'POST',
 				data: {
 					steps: {
-						settings: [ 'paypalSettings', 'wcPaymentGateways' ],
+						settings: [
+							includeConnection
+								? EXPORTER_ALIAS_WITH_CONNECTION
+								: EXPORTER_ALIAS,
+							'wcPaymentGateways',
+						],
 					},
 				},
 			} );

--- a/modules/ppcp-settings/resources/js/hooks/useBlueprintExport.test.js
+++ b/modules/ppcp-settings/resources/js/hooks/useBlueprintExport.test.js
@@ -48,21 +48,6 @@ describe( 'useBlueprintExport', () => {
 		);
 	} );
 
-	it( 'requests the credential-free exporter when told not to include them', async () => {
-		const { result } = renderHook( () => useBlueprintExport() );
-
-		await act( async () => {
-			await result.current.exportBlueprint( {
-				includeConnection: false,
-			} );
-		} );
-
-		expect( requestedSteps() ).toContain( EXPORTER_ALIAS );
-		expect( requestedSteps() ).not.toContain(
-			EXPORTER_ALIAS_WITH_CONNECTION
-		);
-	} );
-
 	it( 'requests the connection exporter only when explicitly asked', async () => {
 		const { result } = renderHook( () => useBlueprintExport() );
 

--- a/modules/ppcp-settings/resources/js/hooks/useBlueprintExport.test.js
+++ b/modules/ppcp-settings/resources/js/hooks/useBlueprintExport.test.js
@@ -1,0 +1,98 @@
+import { renderHook, act } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+import {
+	useBlueprintExport,
+	EXPORTER_ALIAS,
+	EXPORTER_ALIAS_WITH_CONNECTION,
+} from './useBlueprintExport';
+
+jest.mock( '@wordpress/api-fetch' );
+
+jest.mock( '@wordpress/blob', () => ( {
+	downloadBlob: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		createErrorNotice: jest.fn(),
+		createSuccessNotice: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( { store: 'core/notices' } ) );
+
+/**
+ * Reads the step aliases from the single apiFetch call.
+ *
+ * @return {string[]} Requested setting step aliases.
+ */
+const requestedSteps = () => apiFetch.mock.calls[ 0 ][ 0 ].data.steps.settings;
+
+describe( 'useBlueprintExport', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		apiFetch.mockResolvedValue( { data: { steps: [] } } );
+	} );
+
+	it( 'requests the credential-free exporter by default', async () => {
+		const { result } = renderHook( () => useBlueprintExport() );
+
+		await act( async () => {
+			await result.current.exportBlueprint();
+		} );
+
+		expect( requestedSteps() ).toContain( EXPORTER_ALIAS );
+		expect( requestedSteps() ).not.toContain(
+			EXPORTER_ALIAS_WITH_CONNECTION
+		);
+	} );
+
+	it( 'requests the credential-free exporter when told not to include them', async () => {
+		const { result } = renderHook( () => useBlueprintExport() );
+
+		await act( async () => {
+			await result.current.exportBlueprint( {
+				includeConnection: false,
+			} );
+		} );
+
+		expect( requestedSteps() ).toContain( EXPORTER_ALIAS );
+		expect( requestedSteps() ).not.toContain(
+			EXPORTER_ALIAS_WITH_CONNECTION
+		);
+	} );
+
+	it( 'requests the connection exporter only when explicitly asked', async () => {
+		const { result } = renderHook( () => useBlueprintExport() );
+
+		await act( async () => {
+			await result.current.exportBlueprint( { includeConnection: true } );
+		} );
+
+		expect( requestedSteps() ).toContain( EXPORTER_ALIAS_WITH_CONNECTION );
+		expect( requestedSteps() ).not.toContain( EXPORTER_ALIAS );
+	} );
+
+	it( 'keeps exporting the payment gateway settings either way', async () => {
+		const { result } = renderHook( () => useBlueprintExport() );
+
+		await act( async () => {
+			await result.current.exportBlueprint( { includeConnection: true } );
+		} );
+
+		expect( requestedSteps() ).toContain( 'wcPaymentGateways' );
+	} );
+
+	it( 'clears the busy state after a failed export', async () => {
+		apiFetch.mockRejectedValue( new Error( 'nope' ) );
+
+		const { result } = renderHook( () => useBlueprintExport() );
+
+		await act( async () => {
+			await result.current.exportBlueprint();
+		} );
+
+		expect( result.current.isExporting ).toBe( false );
+	} );
+} );

--- a/tests/PHPUnit/Compat/WooCommerceBlueprint/BlueprintExporterWiringTest.php
+++ b/tests/PHPUnit/Compat/WooCommerceBlueprint/BlueprintExporterWiringTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Exercises the Blueprint exporters as modules/ppcp-compat/services.php actually
+ * wires them, rather than by constructing them directly.
+ *
+ * The unit tests build `new PayPalSettingsExporter( $sanitizer, $flag )` themselves,
+ * so they keep passing if both container entries are registered with the same flag.
+ * That mistake either stops the opt-in export carrying credentials or makes every
+ * export carry them, and nothing else in the suite would notice.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalSettingsExporter
+ * @covers \WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalBlueprintBootstrap
+ */
+class BlueprintExporterWiringTest extends TestCase {
+
+	private const CREDENTIAL_KEYS = array(
+		'client_id',
+		'client_secret',
+		'merchant_id',
+		'merchant_email',
+	);
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$stored = array(
+			'woocommerce-ppcp-data-common' => array(
+				'client_id'      => 'client-id-value',
+				'client_secret'  => 'client-secret-value',
+				'merchant_id'    => 'MERCHANT123',
+				'merchant_email' => 'merchant@example.com',
+			),
+		);
+
+		when( 'get_option' )->alias(
+			function ( $name, $default = false ) use ( $stored ) {
+				return $stored[ $name ] ?? $default;
+			}
+		);
+	}
+
+	/**
+	 * Loads the real services.php and resolves ids through it, so the closures under
+	 * test are the production ones.
+	 *
+	 * @param string $id Service id to resolve.
+	 * @return mixed
+	 */
+	private function resolve( string $id ) {
+		$services = require ROOT_DIR . '/modules/ppcp-compat/services.php';
+
+		$container = Mockery::mock( ContainerInterface::class );
+		$container->shouldReceive( 'get' )->andReturnUsing(
+			function ( string $requested ) use ( &$services, &$container ) {
+				if ( 'settings.service.sanitizer' === $requested ) {
+					return Mockery::mock( DataSanitizer::class );
+				}
+
+				$factory = $services[ $requested ];
+
+				return $factory( $container );
+			}
+		);
+
+		return $services[ $id ]( $container );
+	}
+
+	/**
+	 * @param PayPalSettingsExporter $exporter Exporter to run.
+	 * @return array<string, mixed>
+	 */
+	private function exported_common( PayPalSettingsExporter $exporter ): array {
+		return $exporter->export()->prepare_json_array()['options']['woocommerce-ppcp-data-common'];
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_the_default_service_strips_credentials(): void {
+		$common = $this->exported_common(
+			$this->resolve( 'compat.blueprint.paypal_settings_exporter' )
+		);
+
+		foreach ( self::CREDENTIAL_KEYS as $key ) {
+			self::assertSame( '', $common[ $key ], "$key should be stripped by the default service" );
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_the_opt_in_service_keeps_credentials(): void {
+		$common = $this->exported_common(
+			$this->resolve( 'compat.blueprint.paypal_settings_exporter_with_connection' )
+		);
+
+		foreach ( self::CREDENTIAL_KEYS as $key ) {
+			self::assertNotSame( '', $common[ $key ], "$key should survive the opt-in service" );
+		}
+	}
+
+	/**
+	 * The assertion that fails if both container entries are given the same flag.
+	 *
+	 * @test
+	 */
+	public function test_the_two_services_are_wired_with_opposite_flags(): void {
+		$default = $this->resolve( 'compat.blueprint.paypal_settings_exporter' );
+		$opt_in  = $this->resolve( 'compat.blueprint.paypal_settings_exporter_with_connection' );
+
+		self::assertSame( PayPalSettingsExporter::ALIAS, $default->get_alias() );
+		self::assertSame( PayPalSettingsExporter::ALIAS_WITH_CONNECTION, $opt_in->get_alias() );
+
+		$default_common = $this->exported_common( $default );
+		$opt_in_common  = $this->exported_common( $opt_in );
+
+		self::assertNotEquals(
+			$default_common,
+			$opt_in_common,
+			'Both services produced the same payload, so they are wired with the same flag.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_the_bootstrap_registers_both_exporters(): void {
+		$bootstrap = $this->resolve( 'compat.blueprint.bootstrap' );
+
+		$exporters = $bootstrap->register_exporters( array() );
+
+		$aliases = array_map(
+			static function ( $exporter ): string {
+				return $exporter->get_alias();
+			},
+			$exporters
+		);
+
+		self::assertContains( PayPalSettingsExporter::ALIAS, $aliases );
+		self::assertContains( PayPalSettingsExporter::ALIAS_WITH_CONNECTION, $aliases );
+		self::assertCount( 2, $aliases );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_the_bootstrap_preserves_exporters_from_other_plugins(): void {
+		$bootstrap = $this->resolve( 'compat.blueprint.bootstrap' );
+		$foreign   = Mockery::mock( 'Automattic\WooCommerce\Blueprint\Exporters\StepExporter' );
+
+		$exporters = $bootstrap->register_exporters( array( $foreign ) );
+
+		self::assertContains( $foreign, $exporters );
+		self::assertCount( 3, $exporters );
+	}
+}

--- a/tests/PHPUnit/Compat/WooCommerceBlueprint/ConnectionDataSanitizerTest.php
+++ b/tests/PHPUnit/Compat/WooCommerceBlueprint/ConnectionDataSanitizerTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+use ReflectionClass;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\TestCase;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\ConnectionDataSanitizer
+ */
+class ConnectionDataSanitizerTest extends TestCase {
+
+	private ConnectionDataSanitizer $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new ConnectionDataSanitizer();
+	}
+
+	/**
+	 * A fully populated common option, as exported from a connected store.
+	 */
+	private function connected_common_option(): array {
+		return array(
+			'use_sandbox'           => true,
+			'use_manual_connection' => true,
+			'is_send_only_country'  => true,
+			'merchant_connected'    => true,
+			'sandbox_merchant'      => true,
+			'merchant_id'           => 'MERCHANT123',
+			'merchant_email'        => 'merchant@example.com',
+			'merchant_country'      => 'US',
+			'client_id'             => 'client-id-value',
+			'client_secret'         => 'client-secret-value',
+			'seller_type'           => 'business',
+			'wc_installation_path'  => 'core_profiler',
+		);
+	}
+
+	/**
+	 * The credentials and identifiers named in the security report must never
+	 * survive a default export.
+	 *
+	 * @test
+	 */
+	public function test_credentials_are_removed(): void {
+		$result = $this->sut->sanitize(
+			array( ConnectionDataSanitizer::OPTION_COMMON => $this->connected_common_option() )
+		);
+
+		$common = $result[ ConnectionDataSanitizer::OPTION_COMMON ];
+
+		self::assertSame( '', $common['client_id'] );
+		self::assertSame( '', $common['client_secret'] );
+		self::assertSame( '', $common['merchant_id'] );
+		self::assertSame( '', $common['merchant_email'] );
+	}
+
+	/**
+	 * merchant_country and wc_installation_path are not recomputed when the target
+	 * store connects, so a stale value would silently mis-gate payment methods and
+	 * lock the store into the branded-only experience.
+	 *
+	 * @test
+	 */
+	public function test_configuration_the_target_store_cannot_recompute_is_removed(): void {
+		$result = $this->sut->sanitize(
+			array( ConnectionDataSanitizer::OPTION_COMMON => $this->connected_common_option() )
+		);
+
+		$common = $result[ ConnectionDataSanitizer::OPTION_COMMON ];
+
+		self::assertSame( '', $common['merchant_country'] );
+		self::assertSame( '', $common['wc_installation_path'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_connection_state_is_left_self_consistent(): void {
+		$result = $this->sut->sanitize(
+			array( ConnectionDataSanitizer::OPTION_COMMON => $this->connected_common_option() )
+		);
+
+		$common = $result[ ConnectionDataSanitizer::OPTION_COMMON ];
+
+		self::assertFalse( $common['merchant_connected'] );
+		self::assertFalse( $common['sandbox_merchant'] );
+		self::assertSame( 'unknown', $common['seller_type'] );
+		self::assertFalse( $common['use_sandbox'] );
+		self::assertFalse( $common['use_manual_connection'] );
+	}
+
+	/**
+	 * is_send_only_country describes the target store, not the exporting merchant,
+	 * and GeneralSettings recomputes it on every load.
+	 *
+	 * @test
+	 */
+	public function test_is_send_only_country_is_preserved(): void {
+		$result = $this->sut->sanitize(
+			array( ConnectionDataSanitizer::OPTION_COMMON => $this->connected_common_option() )
+		);
+
+		self::assertTrue( $result[ ConnectionDataSanitizer::OPTION_COMMON ]['is_send_only_country'] );
+	}
+
+	/**
+	 * Resetting setup_done would un-gate set_defaults_for_new_merchant(), which
+	 * overwrites the styling settings this export exists to carry.
+	 *
+	 * @test
+	 */
+	public function test_onboarding_mirrors_the_disconnect_state_and_keeps_setup_done(): void {
+		$result = $this->sut->sanitize(
+			array(
+				ConnectionDataSanitizer::OPTION_ONBOARDING => array(
+					'completed'            => true,
+					'step'                 => 5,
+					'is_casual_seller'     => false,
+					'accept_card_payments' => true,
+					'products'             => array( 'subscriptions' ),
+					'setup_done'           => true,
+					'gateways_synced'      => true,
+					'gateways_refreshed'   => true,
+				),
+			)
+		);
+
+		$onboarding = $result[ ConnectionDataSanitizer::OPTION_ONBOARDING ];
+
+		self::assertFalse( $onboarding['completed'] );
+		self::assertSame( 0, $onboarding['step'] );
+		self::assertFalse( $onboarding['gateways_synced'] );
+		self::assertFalse( $onboarding['gateways_refreshed'] );
+
+		self::assertTrue( $onboarding['setup_done'], 'setup_done must survive sanitization' );
+		self::assertFalse( $onboarding['is_casual_seller'] );
+		self::assertTrue( $onboarding['accept_card_payments'] );
+		self::assertSame( array( 'subscriptions' ), $onboarding['products'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_unrelated_options_are_untouched(): void {
+		$options = array(
+			'woocommerce-ppcp-data-styling' => array( 'cart' => array( 'shape' => 'pill' ) ),
+			'woocommerce_venmo_settings'    => array( 'enabled' => 'yes' ),
+		);
+
+		self::assertSame( $options, $this->sut->sanitize( $options ) );
+	}
+
+	/**
+	 * Sanitizing must not introduce keys the stored option never had, otherwise the
+	 * import would write defaults the source store did not have either.
+	 *
+	 * @test
+	 */
+	public function test_absent_keys_are_not_added(): void {
+		$result = $this->sut->sanitize(
+			array( ConnectionDataSanitizer::OPTION_COMMON => array( 'client_id' => 'abc' ) )
+		);
+
+		self::assertSame(
+			array( 'client_id' => '' ),
+			$result[ ConnectionDataSanitizer::OPTION_COMMON ]
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_non_array_option_values_are_ignored(): void {
+		$options = array(
+			ConnectionDataSanitizer::OPTION_COMMON     => 'unexpected-scalar',
+			ConnectionDataSanitizer::OPTION_ONBOARDING => null,
+		);
+
+		self::assertSame( $options, $this->sut->sanitize( $options ) );
+	}
+
+	/**
+	 * Drift guard: CONNECTION_DEFAULTS duplicates values owned by the protected
+	 * GeneralSettings::get_defaults(), so this fails if the model changes one.
+	 *
+	 * @test
+	 */
+	public function test_connection_defaults_match_the_general_settings_defaults(): void {
+		$reflection = new ReflectionClass( GeneralSettings::class );
+		$method     = $reflection->getMethod( 'get_defaults' );
+		$method->setAccessible( true );
+
+		$model_defaults = $method->invoke( $reflection->newInstanceWithoutConstructor() );
+
+		foreach ( ConnectionDataSanitizer::CONNECTION_DEFAULTS as $key => $neutral_value ) {
+			self::assertArrayHasKey(
+				$key,
+				$model_defaults,
+				"GeneralSettings no longer defines '{$key}'"
+			);
+			self::assertSame(
+				$model_defaults[ $key ],
+				$neutral_value,
+				"Neutral value for '{$key}' no longer matches GeneralSettings::get_defaults()"
+			);
+		}
+	}
+
+	/**
+	 * Reverse of the guard above: sanitize() only touches keys it knows about, so a
+	 * new merchant field must be neutralised or explicitly declared safe to export.
+	 *
+	 * @test
+	 */
+	public function test_every_merchant_field_is_either_sanitized_or_knowingly_exported(): void {
+		// Recomputed from the target store on every load, so exporting it is harmless.
+		$exported_on_purpose = array( 'is_send_only_country' );
+
+		$reflection = new ReflectionClass( GeneralSettings::class );
+		$method     = $reflection->getMethod( 'get_defaults' );
+		$method->setAccessible( true );
+
+		$model_defaults = $method->invoke( $reflection->newInstanceWithoutConstructor() );
+
+		$unaccounted = array_diff(
+			array_keys( $model_defaults ),
+			array_keys( ConnectionDataSanitizer::CONNECTION_DEFAULTS ),
+			$exported_on_purpose
+		);
+
+		self::assertSame(
+			array(),
+			$unaccounted,
+			'GeneralSettings defines field(s) the sanitizer does not handle: '
+				. implode( ', ', $unaccounted )
+				. '. Add each to ConnectionDataSanitizer::CONNECTION_DEFAULTS, or to '
+				. '$exported_on_purpose here once confirmed safe to share.'
+		);
+	}
+}

--- a/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsExporterTest.php
+++ b/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsExporterTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalSettingsExporter
+ */
+class PayPalSettingsExporterTest extends TestCase {
+
+	private const CREDENTIAL_KEYS = array(
+		'client_id',
+		'client_secret',
+		'merchant_id',
+		'merchant_email',
+	);
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$stored = array(
+			'woocommerce-ppcp-data-common'      => array(
+				'client_id'          => 'client-id-value',
+				'client_secret'      => 'client-secret-value',
+				'merchant_id'        => 'MERCHANT123',
+				'merchant_email'     => 'merchant@example.com',
+				'merchant_country'   => 'US',
+				'merchant_connected' => true,
+			),
+			'woocommerce-ppcp-data-styling'     => array( 'cart' => array( 'shape' => 'pill' ) ),
+			'woocommerce-ppcp-is-new-merchant'  => 1,
+		);
+
+		when( 'get_option' )->alias(
+			function ( $name, $default = false ) use ( $stored ) {
+				return $stored[ $name ] ?? $default;
+			}
+		);
+	}
+
+	private function exported_options( bool $include_connection ): array {
+		$exporter = new PayPalSettingsExporter( new ConnectionDataSanitizer(), $include_connection );
+
+		return $exporter->export()->prepare_json_array()['options'];
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_default_export_carries_no_credentials(): void {
+		$common = $this->exported_options( false )['woocommerce-ppcp-data-common'];
+
+		foreach ( self::CREDENTIAL_KEYS as $key ) {
+			self::assertSame( '', $common[ $key ], "'{$key}' was not cleared from the default export" );
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_opt_in_export_carries_the_credentials(): void {
+		$common = $this->exported_options( true )['woocommerce-ppcp-data-common'];
+
+		self::assertSame( 'client-id-value', $common['client_id'] );
+		self::assertSame( 'client-secret-value', $common['client_secret'] );
+		self::assertSame( 'MERCHANT123', $common['merchant_id'] );
+		self::assertSame( 'merchant@example.com', $common['merchant_email'] );
+	}
+
+	/**
+	 * Stripping the connection details must not strip the settings the export exists
+	 * to carry.
+	 *
+	 * @test
+	 */
+	public function test_default_export_still_carries_the_settings(): void {
+		self::assertSame(
+			array( 'cart' => array( 'shape' => 'pill' ) ),
+			$this->exported_options( false )['woocommerce-ppcp-data-styling']
+		);
+	}
+
+	/**
+	 * The legacy flag was removed from the allowlist: importing it as truthy makes
+	 * MigrationManager permanently skip the legacy migrations on the target store.
+	 *
+	 * @test
+	 */
+	public function test_legacy_new_merchant_flag_is_never_exported(): void {
+		self::assertArrayNotHasKey(
+			'woocommerce-ppcp-is-new-merchant',
+			$this->exported_options( false )
+		);
+		self::assertArrayNotHasKey(
+			'woocommerce-ppcp-is-new-merchant',
+			$this->exported_options( true )
+		);
+	}
+
+	/**
+	 * What an instance exports is fixed at construction, so the two registered
+	 * exporters cannot be made to swap behaviour at runtime.
+	 *
+	 * @test
+	 */
+	public function test_the_exported_payload_follows_the_constructor_flag(): void {
+		$default_common = $this->exported_options( false )['woocommerce-ppcp-data-common'];
+		$opt_in_common  = $this->exported_options( true )['woocommerce-ppcp-data-common'];
+
+		self::assertSame( '', $default_common['client_secret'] );
+		self::assertSame( 'client-secret-value', $opt_in_common['client_secret'] );
+	}
+
+	/**
+	 * Two exporters are distinguished purely by their selection identity. Asking for
+	 * the plain step name must never resolve to the credential-bearing exporter.
+	 *
+	 * @test
+	 */
+	public function test_the_two_exporters_have_distinct_selection_identities(): void {
+		$default  = new PayPalSettingsExporter( new ConnectionDataSanitizer(), false );
+		$with_conn = new PayPalSettingsExporter( new ConnectionDataSanitizer(), true );
+
+		self::assertSame( 'paypalSettings', $default->get_alias() );
+		self::assertSame( 'paypalSettingsWithConnection', $with_conn->get_alias() );
+
+		self::assertNotSame( $default->get_alias(), $with_conn->get_alias() );
+		self::assertNotSame( $default->get_step_name(), $with_conn->get_step_name() );
+	}
+
+	/**
+	 * Both exporters emit the same step, so the importer and the file format are
+	 * unchanged by the opt-in.
+	 *
+	 * @test
+	 */
+	public function test_both_exporters_emit_the_same_step(): void {
+		$default_step = ( new PayPalSettingsExporter( new ConnectionDataSanitizer(), false ) )->export();
+		$opt_in_step  = ( new PayPalSettingsExporter( new ConnectionDataSanitizer(), true ) )->export();
+
+		self::assertInstanceOf( SetPayPalSettings::class, $default_step );
+		self::assertInstanceOf( SetPayPalSettings::class, $opt_in_step );
+		self::assertSame(
+			$default_step->prepare_json_array()['step'],
+			$opt_in_step->prepare_json_array()['step']
+		);
+	}
+
+	/**
+	 * Exporting requires both capabilities, not either one.
+	 *
+	 * @dataProvider capability_combinations
+	 * @test
+	 *
+	 * @param bool $manage_woocommerce Whether the user can manage WooCommerce.
+	 * @param bool $manage_options     Whether the user can manage options.
+	 * @param bool $expected           Expected result of the capability check.
+	 */
+	public function test_export_requires_both_capabilities( bool $manage_woocommerce, bool $manage_options, bool $expected ): void {
+		when( 'current_user_can' )->alias(
+			function ( string $capability ) use ( $manage_woocommerce, $manage_options ): bool {
+				if ( 'manage_woocommerce' === $capability ) {
+					return $manage_woocommerce;
+				}
+
+				if ( 'manage_options' === $capability ) {
+					return $manage_options;
+				}
+
+				return false;
+			}
+		);
+
+		foreach ( array( false, true ) as $include_connection ) {
+			$exporter = new PayPalSettingsExporter( new ConnectionDataSanitizer(), $include_connection );
+
+			self::assertSame( $expected, $exporter->check_step_capabilities() );
+		}
+	}
+
+	/**
+	 * @return array<string, array{bool, bool, bool}>
+	 */
+	public function capability_combinations(): array {
+		return array(
+			'both capabilities'      => array( true, true, true ),
+			'only manage_woocommerce' => array( true, false, false ),
+			'only manage_options'    => array( false, true, false ),
+			'neither'                => array( false, false, false ),
+		);
+	}
+}

--- a/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsImporterTest.php
+++ b/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsImporterTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
+use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint\PayPalSettingsImporter
+ */
+class PayPalSettingsImporterTest extends TestCase {
+
+	/**
+	 * Options written during a test run.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $written = array();
+
+	/**
+	 * Location keys passed to the sanitizer, per option.
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	private array $hydrated = array();
+
+	/**
+	 * @var DataSanitizer|Mockery\MockInterface
+	 */
+	private $sanitizer;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->written = array();
+
+		when( 'get_option' )->alias(
+			function ( $name, $default = false ) {
+				return $this->written[ $name ] ?? $default;
+			}
+		);
+
+		when( 'update_option' )->alias(
+			function ( $name, $value ) {
+				$this->written[ $name ] = $value;
+
+				return true;
+			}
+		);
+
+		$this->hydrated  = array();
+		$this->sanitizer = Mockery::mock( DataSanitizer::class );
+		$this->sanitizer->shouldReceive( 'sanitize_location_style' )
+			->andReturnUsing(
+				function ( $value, $key ) {
+					$this->hydrated['styling'][] = $key;
+
+					return Mockery::mock( LocationStylingDTO::class );
+				}
+			);
+		$this->sanitizer->shouldReceive( 'sanitize_paylater_messaging' )
+			->andReturnUsing(
+				function ( $value, $key ) {
+					$this->hydrated['paylater'][] = $key;
+
+					return Mockery::mock( PayLaterMessagingDTO::class );
+				}
+			);
+	}
+
+	/**
+	 * @param array<string, mixed> $options Options to import.
+	 * @return \Automattic\WooCommerce\Blueprint\StepProcessorResult
+	 */
+	private function import( array $options ) {
+		$importer = new PayPalSettingsImporter( $this->sanitizer );
+
+		$schema = json_decode(
+			(string) wp_json_encode(
+				array(
+					'step'    => 'setPayPalSettings',
+					'options' => $options,
+				)
+			)
+		);
+
+		return $importer->process( $schema );
+	}
+
+	/**
+	 * The importer owns PayPal's own options only; everything else in a Blueprint
+	 * belongs to another step's processor.
+	 *
+	 * @test
+	 */
+	public function test_options_outside_the_allowlist_are_never_written(): void {
+		$this->import(
+			array(
+				'users_can_register'           => 1,
+				'default_role'                 => 'editor',
+				'siteurl'                      => 'https://other.example',
+				'woocommerce-ppcp-data-common' => array( 'client_id' => '' ),
+			)
+		);
+
+		self::assertArrayNotHasKey( 'users_can_register', $this->written );
+		self::assertArrayNotHasKey( 'default_role', $this->written );
+		self::assertArrayNotHasKey( 'siteurl', $this->written );
+		self::assertArrayHasKey( 'woocommerce-ppcp-data-common', $this->written );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_every_allowlisted_option_is_importable(): void {
+		$options = array();
+		foreach ( PayPalBlueprintOptions::OPTION_NAMES as $name ) {
+			$options[ $name ] = array( 'marker' => $name );
+		}
+
+		$this->import( $options );
+
+		foreach ( PayPalBlueprintOptions::OPTION_NAMES as $name ) {
+			self::assertArrayHasKey( $name, $this->written, "$name should be importable" );
+		}
+	}
+
+	/**
+	 * Styling is stored as typed DTOs, so a JSON payload of plain arrays has to be
+	 * hydrated before it is written or the data model cannot load it back.
+	 *
+	 * @test
+	 */
+	public function test_styling_locations_are_hydrated_into_dtos(): void {
+		$this->import(
+			array(
+				'woocommerce-ppcp-data-styling' => array(
+					'cart'    => array( 'color' => 'gold' ),
+					'product' => array( 'color' => 'blue' ),
+				),
+			)
+		);
+
+		$written = $this->written['woocommerce-ppcp-data-styling'];
+
+		self::assertInstanceOf( LocationStylingDTO::class, $written['cart'] );
+		self::assertInstanceOf( LocationStylingDTO::class, $written['product'] );
+		self::assertSame( array( 'cart', 'product' ), $this->hydrated['styling'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_paylater_messaging_locations_are_hydrated(): void {
+		$this->import(
+			array(
+				'woocommerce-ppcp-data-paylater-messaging' => array(
+					'cart'     => array( 'enabled' => true ),
+					'checkout' => array( 'enabled' => false ),
+				),
+			)
+		);
+
+		$written = $this->written['woocommerce-ppcp-data-paylater-messaging'];
+
+		self::assertInstanceOf( PayLaterMessagingDTO::class, $written['cart'] );
+		self::assertInstanceOf( PayLaterMessagingDTO::class, $written['checkout'] );
+		self::assertSame( array( 'cart', 'checkout' ), $this->hydrated['paylater'] );
+	}
+
+	/**
+	 * A credentials-free export must import without erroring, otherwise the safe
+	 * default is unusable.
+	 *
+	 * @test
+	 */
+	public function test_a_credential_free_payload_imports_without_errors(): void {
+		$result = $this->import(
+			array(
+				'woocommerce-ppcp-data-common'     => array(
+					'client_id'      => '',
+					'client_secret'  => '',
+					'merchant_id'    => '',
+					'merchant_email' => '',
+				),
+				'woocommerce-ppcp-data-onboarding' => array(
+					'completed'  => false,
+					'setup_done' => true,
+				),
+			)
+		);
+
+		self::assertTrue( $result->is_success() );
+		self::assertSame( array(), $result->get_messages( 'error' ) );
+		self::assertSame( '', $this->written['woocommerce-ppcp-data-common']['client_id'] );
+		self::assertTrue( $this->written['woocommerce-ppcp-data-onboarding']['setup_done'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_a_payload_without_options_is_rejected(): void {
+		$importer = new PayPalSettingsImporter( $this->sanitizer );
+
+		$result = $importer->process( (object) array( 'step' => 'setPayPalSettings' ) );
+
+		self::assertFalse( $result->is_success() );
+		self::assertNotEmpty( $result->get_messages( 'error' ) );
+		self::assertSame( array(), $this->written );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_the_import_requires_both_capabilities(): void {
+		$importer = new PayPalSettingsImporter( $this->sanitizer );
+		$schema   = (object) array( 'step' => 'setPayPalSettings' );
+
+		when( 'current_user_can' )->justReturn( true );
+		self::assertTrue( $importer->check_step_capabilities( $schema ) );
+
+		when( 'current_user_can' )->alias(
+			function ( string $capability ): bool {
+				return 'manage_woocommerce' === $capability;
+			}
+		);
+		self::assertFalse( $importer->check_step_capabilities( $schema ) );
+
+		when( 'current_user_can' )->justReturn( false );
+		self::assertFalse( $importer->check_step_capabilities( $schema ) );
+	}
+}

--- a/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsImporterTest.php
+++ b/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsImporterTest.php
@@ -187,6 +187,65 @@ class PayPalSettingsImporterTest extends TestCase {
 	}
 
 	/**
+	 * Options are written whole rather than merged, so a settings-only payload
+	 * would otherwise blank the credentials of a store that is already connected.
+	 *
+	 * @test
+	 */
+	public function test_a_settings_only_import_leaves_an_existing_connection_alone(): void {
+		$this->written['woocommerce-ppcp-data-common']     = array(
+			'client_id'          => 'TARGET-ID',
+			'client_secret'      => 'TARGET-SECRET',
+			'merchant_connected' => true,
+		);
+		$this->written['woocommerce-ppcp-data-onboarding'] = array(
+			'completed'  => true,
+			'setup_done' => true,
+		);
+
+		$this->import(
+			array(
+				'woocommerce-ppcp-data-common'     => array(
+					'client_id'          => '',
+					'client_secret'      => '',
+					'merchant_connected' => false,
+				),
+				'woocommerce-ppcp-data-onboarding' => array(
+					'completed'  => false,
+					'setup_done' => true,
+				),
+			)
+		);
+
+		self::assertSame( 'TARGET-ID', $this->written['woocommerce-ppcp-data-common']['client_id'] );
+		self::assertSame( 'TARGET-SECRET', $this->written['woocommerce-ppcp-data-common']['client_secret'] );
+		self::assertTrue( $this->written['woocommerce-ppcp-data-common']['merchant_connected'] );
+		self::assertTrue( $this->written['woocommerce-ppcp-data-onboarding']['completed'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_an_opt_in_import_replaces_the_existing_connection(): void {
+		$this->written['woocommerce-ppcp-data-common'] = array(
+			'client_id'     => 'TARGET-ID',
+			'client_secret' => 'TARGET-SECRET',
+		);
+
+		$this->import(
+			array(
+				'woocommerce-ppcp-data-common' => array(
+					'client_id'     => 'SOURCE-ID',
+					'client_secret' => 'SOURCE-SECRET',
+				),
+			)
+		);
+
+		self::assertSame( 'SOURCE-ID', $this->written['woocommerce-ppcp-data-common']['client_id'] );
+		self::assertSame( 'SOURCE-SECRET', $this->written['woocommerce-ppcp-data-common']['client_secret'] );
+	}
+
+	/**
 	 * @test
 	 */
 	public function test_a_payload_without_options_is_rejected(): void {

--- a/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsImporterTest.php
+++ b/tests/PHPUnit/Compat/WooCommerceBlueprint/PayPalSettingsImporterTest.php
@@ -116,22 +116,6 @@ class PayPalSettingsImporterTest extends TestCase {
 	}
 
 	/**
-	 * @test
-	 */
-	public function test_every_allowlisted_option_is_importable(): void {
-		$options = array();
-		foreach ( PayPalBlueprintOptions::OPTION_NAMES as $name ) {
-			$options[ $name ] = array( 'marker' => $name );
-		}
-
-		$this->import( $options );
-
-		foreach ( PayPalBlueprintOptions::OPTION_NAMES as $name ) {
-			self::assertArrayHasKey( $name, $this->written, "$name should be importable" );
-		}
-	}
-
-	/**
 	 * Styling is stored as typed DTOs, so a JSON payload of plain arrays has to be
 	 * hydrated before it is written or the data model cannot load it back.
 	 *

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -34,6 +34,7 @@ require_once TESTS_ROOT_DIR . '/stubs/AbilityDefinition.php';
 require_once TESTS_ROOT_DIR . '/stubs/StepExporter.php';
 require_once TESTS_ROOT_DIR . '/stubs/HasAlias.php';
 require_once TESTS_ROOT_DIR . '/stubs/StepProcessor.php';
+require_once TESTS_ROOT_DIR . '/stubs/StepProcessorResult.php';
 require_once TESTS_ROOT_DIR . '/stubs/Step.php';
 
 Hamcrest\Util::registerGlobalFunctions();

--- a/tests/stubs/StepProcessorResult.php
+++ b/tests/stubs/StepProcessorResult.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Minimal stub for the WooCommerce Blueprint StepProcessorResult class.
+ *
+ * The Blueprint package ships with WooCommerce core and is not autoloadable in
+ * the unit-test environment. Mirrors the copy WooCommerce actually loads
+ * (packages/blueprint), which is ahead of the one under vendor/woocommerce.
+ */
+
+namespace Automattic\WooCommerce\Blueprint;
+
+if ( ! class_exists( StepProcessorResult::class ) ) {
+	class StepProcessorResult {
+
+		/**
+		 * Accumulated messages.
+		 *
+		 * @var array<int, array{message: string, type: string}>
+		 */
+		private $messages = array();
+
+		/**
+		 * Whether the step succeeded.
+		 *
+		 * @var bool
+		 */
+		private $success;
+
+		/**
+		 * Step name.
+		 *
+		 * @var string
+		 */
+		private $step_name;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param bool   $success   Whether the step succeeded.
+		 * @param string $step_name Step name.
+		 */
+		public function __construct( bool $success, string $step_name ) {
+			$this->success   = $success;
+			$this->step_name = $step_name;
+		}
+
+		/**
+		 * Creates a successful result.
+		 *
+		 * @param string $step_name Step name.
+		 * @return self
+		 */
+		public static function success( string $step_name ): self {
+			return new self( true, $step_name );
+		}
+
+		/**
+		 * Records a message.
+		 *
+		 * @param string $message Message text.
+		 * @param string $type    Message type.
+		 * @return void
+		 */
+		public function add_message( string $message, string $type = 'error' ) {
+			$this->messages[] = array(
+				'message' => $message,
+				'type'    => $type,
+			);
+
+			if ( 'error' === $type ) {
+				$this->success = false;
+			}
+		}
+
+		/**
+		 * Records an error.
+		 *
+		 * @param string $message Message text.
+		 * @return void
+		 */
+		public function add_error( string $message ) {
+			$this->add_message( $message, 'error' );
+		}
+
+		/**
+		 * Records a warning.
+		 *
+		 * @param string $message Message text.
+		 * @return void
+		 */
+		public function add_warn( string $message ) {
+			$this->add_message( $message, 'warn' );
+		}
+
+		/**
+		 * Records an info message.
+		 *
+		 * @param string $message Message text.
+		 * @return void
+		 */
+		public function add_info( string $message ) {
+			$this->add_message( $message, 'info' );
+		}
+
+		/**
+		 * Records a debug message.
+		 *
+		 * @param string $message Message text.
+		 * @return void
+		 */
+		public function add_debug( string $message ) {
+			$this->add_message( $message, 'debug' );
+		}
+
+		/**
+		 * Returns recorded messages, optionally filtered by type.
+		 *
+		 * @param string $type Message type, or 'all'.
+		 * @return array<int, array{message: string, type: string}>
+		 */
+		public function get_messages( string $type = 'all' ): array {
+			if ( 'all' === $type ) {
+				return $this->messages;
+			}
+
+			return array_values(
+				array_filter(
+					$this->messages,
+					function ( $message ) use ( $type ) {
+						return $type === $message['type'];
+					}
+				)
+			);
+		}
+
+		/**
+		 * Whether the step succeeded.
+		 *
+		 * @return bool
+		 */
+		public function is_success(): bool {
+			return $this->success;
+		}
+
+		/**
+		 * Returns the step name.
+		 *
+		 * @return string
+		 */
+		public function get_step_name() {
+			return $this->step_name;
+		}
+	}
+}


### PR DESCRIPTION
### Description

Blueprint exports now carry PayPal settings **without** the connection details. Including them is an explicit per-export choice in a confirmation dialog.

Side cleanup: the dialog shell shared with `DisconnectButton` is extracted into a reusable `ConfirmationModal` (pinned with tests first), and the accordion reveal becomes a `grid-reveal` mixin.

### Screenshots

| Export | Export with connection details |
| :--- | :--- |
|<img width="1297" height="859" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress-16" src="https://github.com/user-attachments/assets/09684b7f-fc18-4432-9ad9-adc98dcc652b" />| <img width="1291" height="862" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress-17" src="https://github.com/user-attachments/assets/0d63eb4c-d3d9-4a22-8144-da1f734be1de" /> |

### Steps to Test

1. **PayPal → Settings → WooCommerce Blueprint Export & Import → Export**. Dialog appears, toggle **off**, no warning.
2. Export as-is. In the JSON: `client_id`, `client_secret`, `merchant_id`, `merchant_email`, `merchant_country`, `wc_installation_path` all empty; `onboarding.setup_done` is **`true`**.
3. Export with the toggle **on**. Amber warning appears, names sandbox vs live, file now contains the connection details.
4. Import the step-2 file into a store with no connection → onboarding wizard, no fatal. **Then connect it - the imported styling must survive.**
5. Open **Disconnect** - dialog still renders correctly in both toggle states (shared-modal refactor).