### PR TITLE
Remove unneeded message

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -61,10 +61,7 @@ export function CardFields( { config, eventRegistration, emitResponse } ) {
 			return onCheckoutValidation(
 				() => {
 					if ( hasCheckoutValidationErrors() ) {
-						return {
-							type: responseTypes.ERROR,
-							message: CHECKOUT_FIELDS_NOT_VALID_MESSAGE,
-						};
+						return { type: responseTypes.ERROR };
 					}
 
 					return true;


### PR DESCRIPTION
A small improvement from https://github.com/woocommerce/woocommerce-paypal-payments/pull/4435#discussion_r3712114298

This message was ignored because the correct property name for `onCheckoutValidation` is `errorMessage`. But it is not really needed here because Woo already shows some error messages in this case, so simply removing it.