### PR TITLE
fix: Update reusable workflow references to correct commit hash

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build-and-distribute:
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-playwright-matrix.outputs.matrix) }}
-    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     with:
       PLAYWRIGHT_SCRIPT: ${{ matrix.script }}
       PLAYWRIGHT_ARTIFACT_NAME: ${{ matrix.artifact_name }}

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -28,7 +28,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     with:
       PHP_VERSION: 7.4
       NODE_VERSION: 22

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,12 +4,12 @@ on: [push]
 
 jobs:
   coding-standards-analysis-php:
-    uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/coding-standards-php.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     with:
       PHP_VERSION: '8.0'
       PHPCS_ARGS: '--report-full --runtime-set ignore_warnings_on_exit 1'
   static-code-analysis-php:
-    uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/static-analysis-php.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     with:
       PHP_VERSION: '8.0'
       PHPSTAN_ARGS: '--no-progress --memory-limit=2G'
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-php.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     with:
       PHPUNIT_ARGS: ''
       PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/weekly-builds.yml
+++ b/.github/workflows/weekly-builds.yml
@@ -70,7 +70,7 @@ jobs:
     if: github.repository_owner == 'woocommerce'
     name: Build package
     needs: create-tag
-    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@e37849e94ffc3e8b7aaae853471815e1b74f99e8 # pinning PR #278
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@64f8f3a974b508dfa76ea278b748228c6ffed1b6 # pinning PR #278
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
       GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}


### PR DESCRIPTION


### Description

#4644 introduced version/hash pinning for our reusable workflow - but anticipated that no followup commits would be made.
This - together with the fact that we squash-merged the contribution (thanks @nerrad) - broke our workflow since the reference commit existed nowhere.


