### PR TITLE
PayPal saved payment is not displayed for free trial subscription on SDK v6 for guest users (6841)

### DIFF
--- a/modules/ppcp-vault-component/services.php
+++ b/modules/ppcp-vault-component/services.php
@@ -11,7 +11,6 @@ use WooCommerce\PayPalCommerce\VaultComponent\Authentication\VaultClientToken;
 use WooCommerce\PayPalCommerce\VaultComponent\Endpoint\CreateVaultOrderEndpoint;
 use WooCommerce\PayPalCommerce\VaultComponent\Helper\VaultComponentApplies;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
-use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
@@ -22,16 +21,17 @@ return array(
 		$settings_provider = $container->get( 'settings.settings-provider' );
 		assert( $settings_provider instanceof SettingsProvider );
 
-		$free_trial_helper = $container->get( 'wc-subscriptions.free-trial-subscription-helper' );
-		assert( $free_trial_helper instanceof FreeTrialSubscriptionHelper );
-
-		return static function () use ( $vault_component_applies, $settings_provider, $free_trial_helper ): bool {
-			// A zero-total subscription cart (free trial or 100% coupon) uses the
-			// save-without-purchase flow. The order-based Vault Component would
-			// create a $0 order (rejected by PayPal with CANNOT_BE_ZERO_OR_NEGATIVE)
-			// and only renders an empty paysheet, so disable it entirely here.
+		return static function () use ( $vault_component_applies, $settings_provider ): bool {
+			// This is a capability check only (merchant setting + country + reference
+			// transactions). It deliberately does NOT exclude zero-total subscription
+			// carts (free trial or 100% coupon): under SDK v6 this value gates whether
+			// the saved-token payment method is registered at all, so excluding free
+			// trials here hid the saved PayPal option entirely for returning buyers.
+			// The order-based Vault Component overlay (which would create a $0 order
+			// PayPal rejects with CANNOT_BE_ZERO_OR_NEGATIVE) is suppressed for those
+			// carts at render time instead - see paypal-saved-token.js and the classic
+			// checkout.js `is_free_trial_cart` guards.
 			return $settings_provider->save_paypal_and_venmo()
-				&& ! $free_trial_helper->is_free_trial_cart()
 				&& $vault_component_applies->for_country()
 				&& $vault_component_applies->for_merchant();
 		};

--- a/modules/ppcp-vault-component/src/VaultComponentModule.php
+++ b/modules/ppcp-vault-component/src/VaultComponentModule.php
@@ -56,11 +56,21 @@ class VaultComponentModule implements ServiceModule, ExecutableModule {
 		$vault_injected = false;
 		add_filter(
 			'woocommerce_payment_gateway_get_saved_payment_method_option_html',
-			static function ( string $html, WC_Payment_Token $token, $gateway ) use ( &$vault_injected, $eligibility_check ): string {
+			static function ( string $html, WC_Payment_Token $token, $gateway ) use ( &$vault_injected, $eligibility_check, $c ): string {
 				if ( $vault_injected || PayPalGateway::ID !== $gateway->id || ! $token instanceof PaymentTokenPayPal ) {
 					return $html;
 				}
 				if ( ! $eligibility_check() ) {
+					return $html;
+				}
+				$free_trial_helper = $c->get( 'wc-subscriptions.free-trial-subscription-helper' );
+				assert( $free_trial_helper instanceof FreeTrialSubscriptionHelper );
+
+				// A zero-total free-trial cart uses the save-without-purchase flow, so the
+				// order-based vault overlay never renders here (see checkout.js). Leave the
+				// native saved-token label visible and skip the empty container so the buyer
+				// can still select the already-saved PayPal token.
+				if ( $free_trial_helper->is_free_trial_cart() ) {
 					return $html;
 				}
 				$vault_injected = true;


### PR DESCRIPTION
 On block checkout with SDK v6, the saved (vaulted) PayPal option didn't show for free-trial subscription carts. The free-trial exclusion lived inside the vault-component eligibility check, which under SDK v6 also gates whether the saved-token payment method registers at all so free-trial carts lost the saved PayPal selector entirely (v5 still showed it and only hid the approval overlay).                                                                                                                                                                     
                                                                                                                                                                                             
This PR makes the eligibility check a pure capability check (merchant setting + country + reference transactions) by dropping the free-trial condition, so the saved-token method registers and the saved PayPal option shows again for free-trial carts. The $0 order-based vault overlay stays suppressed for those carts via the existing render-time guards, with a free-trial guard on the classic saved-method filter so its label/container injection is skipped there.