### PR TITLE
PayPal buttons are present along with selected vaulting component on classic checkout with SDK v6 (6842)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Helper/CheckoutMethodState.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/CheckoutMethodState.js
@@ -46,3 +46,19 @@ export const isSavedCardSelected = () => {
 	const savedCardList = document.querySelector( '#saved-credit-card' );
 	return savedCardList && savedCardList.value !== '';
 };
+
+/**
+ * Whether a saved PayPal token (not "Use a new payment method") is the selected
+ * token for the PayPal gateway on classic checkout.
+ *
+ * Such a payment is completed through the vault component and "Place order", so
+ * the express buttons must not stand in for it.
+ *
+ * @return {boolean} True when a saved ppcp-gateway token is selected.
+ */
+export const isSavedPayPalTokenSelected = () => {
+	const checked = document.querySelector(
+		'input[name="wc-ppcp-gateway-payment-token"]:checked'
+	);
+	return Boolean( checked && checked.value && checked.value !== 'new' );
+};

--- a/modules/ppcp-sdk-v6/resources/js/methods/gatewayPlacement.js
+++ b/modules/ppcp-sdk-v6/resources/js/methods/gatewayPlacement.js
@@ -16,6 +16,7 @@
 
 import {
 	getCurrentPaymentMethod,
+	isSavedPayPalTokenSelected,
 	ORDER_BUTTON_SELECTOR,
 	PaymentMethods,
 } from '@ppcp-button/Helper/CheckoutMethodState';
@@ -94,7 +95,14 @@ function rowContainer( methodId ) {
 		return walletRows.get( methodId );
 	}
 
-	return PaymentMethods.PAYPAL === methodId ? expressRow : null;
+	// PayPal's express buttons stand in for "Place order" only for a NEW payment.
+	// A saved PayPal token is completed through the vault component and "Place
+	// order", so its row offers no express button and keeps "Place order".
+	if ( PaymentMethods.PAYPAL === methodId ) {
+		return isSavedPayPalTokenSelected() ? null : expressRow;
+	}
+
+	return null;
 }
 
 /**
@@ -132,8 +140,13 @@ function updateVisibility() {
 	}
 
 	// The express buttons pay for PayPal's row only; left showing, they offer a
-	// PayPal payment while a wallet row is selected.
-	setVisible( expressRow, PaymentMethods.PAYPAL === selected );
+	// PayPal payment while a wallet row is selected. A selected saved PayPal token
+	// is paid through the vault component and "Place order", so the express buttons
+	// hide for it too, the same as for any other non-PayPal row.
+	setVisible(
+		expressRow,
+		PaymentMethods.PAYPAL === selected && ! isSavedPayPalTokenSelected()
+	);
 
 	// Answered once for all rows, not per wallet: each wallet asking only "am I
 	// selected" meant the last one to run always won, so selecting the first
@@ -173,6 +186,15 @@ function syncGatewayVisibility( {
 
 	jQuery( document.body ).on(
 		'payment_method_selected updated_checkout',
+		updateVisibility
+	);
+
+	// Switching between a saved PayPal token and "Use a new payment method" flips
+	// whether the express buttons or "Place order" should show, without a DOM
+	// rebuild, so re-run on that change too.
+	jQuery( document ).on(
+		'change',
+		'input[name="wc-ppcp-gateway-payment-token"]',
 		updateVisibility
 	);
 }

--- a/modules/ppcp-sdk-v6/resources/js/methods/gatewayPlacement.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/methods/gatewayPlacement.test.js
@@ -1,8 +1,10 @@
 import jQuery from 'jquery';
 
 const mockGetCurrentPaymentMethod = jest.fn();
+const mockIsSavedPayPalTokenSelected = jest.fn();
 jest.mock( '@ppcp-button/Helper/CheckoutMethodState', () => ( {
 	getCurrentPaymentMethod: () => mockGetCurrentPaymentMethod(),
+	isSavedPayPalTokenSelected: () => mockIsSavedPayPalTokenSelected(),
 	ORDER_BUTTON_SELECTOR: '#place_order',
 	PaymentMethods: { PAYPAL: 'ppcp-gateway' },
 } ) );
@@ -19,12 +21,15 @@ let revealMethodGateway;
 beforeEach( () => {
 	jest.resetModules();
 	mockGetCurrentPaymentMethod.mockReset();
+	mockIsSavedPayPalTokenSelected.mockReset();
+	mockIsSavedPayPalTokenSelected.mockReturnValue( false );
 	mockHasJQuery.mockReset();
 	mockHasJQuery.mockReturnValue( true );
 	// document.body.innerHTML only replaces the body's children, so handlers
-	// bound to the body itself by a previous test's module instance survive
-	// unless unbound here.
+	// bound to the body itself, or delegated from document, by a previous
+	// test's module instance survive unless unbound here.
 	jQuery( document.body ).off();
+	jQuery( document ).off( 'change', 'input[name="wc-ppcp-gateway-payment-token"]' );
 	document.body.innerHTML = '';
 	global.jQuery = jQuery;
 	( { revealMethodGateway } = require( './gatewayPlacement' ) );
@@ -373,6 +378,70 @@ describe( 'revealMethodGateway()', () => {
 
 				expect( displayOf( '#wallet-wrapper' ) ).toBe( '' );
 				expect( displayOf( '#place_order' ) ).toBe( 'none' );
+			}
+		);
+	} );
+
+	describe( "PayPal's row with a saved payment token", () => {
+		function setDomWithSavedToken() {
+			document.body.innerHTML =
+				'<div id="express-wrapper"><button></button></div>' +
+				'<div id="place_order"></div>' +
+				'<input type="radio" name="wc-ppcp-gateway-payment-token" ' +
+				'value="2" checked />' +
+				'<input type="radio" name="wc-ppcp-gateway-payment-token" ' +
+				'value="new" />';
+		}
+
+		test(
+			'hides the express wrapper and keeps "Place order" when ' +
+				"PayPal's row is selected with a saved token",
+			() => {
+				setDomWithSavedToken();
+				mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+				mockIsSavedPayPalTokenSelected.mockReturnValue( true );
+
+				reveal( { expressSelector: '#express-wrapper' } );
+
+				expect( displayOf( '#express-wrapper' ) ).toBe( 'none' );
+				expect( displayOf( '#place_order' ) ).toBe( '' );
+			}
+		);
+
+		test(
+			'shows the express wrapper and hides "Place order" when ' +
+				'"Use a new payment method" is selected instead',
+			() => {
+				setDomWithSavedToken();
+				mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+				mockIsSavedPayPalTokenSelected.mockReturnValue( false );
+
+				reveal( { expressSelector: '#express-wrapper' } );
+
+				expect( displayOf( '#express-wrapper' ) ).toBe( '' );
+				expect( displayOf( '#place_order' ) ).toBe( 'none' );
+			}
+		);
+
+		test(
+			're-evaluates visibility when the payment-token radio ' +
+				'changes, without a checkout DOM rebuild',
+			() => {
+				setDomWithSavedToken();
+				mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+				mockIsSavedPayPalTokenSelected.mockReturnValue( false );
+
+				reveal( { expressSelector: '#express-wrapper' } );
+				expect( displayOf( '#express-wrapper' ) ).toBe( '' );
+				expect( displayOf( '#place_order' ) ).toBe( 'none' );
+
+				mockIsSavedPayPalTokenSelected.mockReturnValue( true );
+				jQuery(
+					'input[name="wc-ppcp-gateway-payment-token"][value="2"]'
+				).trigger( 'change' );
+
+				expect( displayOf( '#express-wrapper' ) ).toBe( 'none' );
+				expect( displayOf( '#place_order' ) ).toBe( '' );
 			}
 		);
 	} );


### PR DESCRIPTION
On classic checkout with SDK v6, selecting a saved (vaulted) PayPal token kept showing the PayPal/Venmo express buttons and hid the Place Order button. The saved token is paid through the vault component plus Place Order, so the express buttons shouldn't appear and Place Order should.                                                                                                                                                                                                                                                              
                                                                                                                                                                                             
This PR mades `gatewayPlacement.js` (the single authority for the express-wrapper and Place Order visibility on classic checkout) saved-token-aware via a new shared `isSavedPayPalTokenSelected()` helper: when a saved PayPal token is selected, the express buttons are hidden and Place Order is kept; and visibility now re-evaluates on the saved-token change event so switching between the saved token and "Use a new payment method" flips correctly.       