### PR TITLE
PayPal gateway not visible on block checkout when WC Subscription Auto renewal are enabled (6844)

### DIFF
--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -237,9 +237,16 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 
 		$smart_buttons_enabled = ! $this->use_place_order
 			&& $this->settings_status->is_smart_button_enabled_for_location( $script_data['context'] ?? 'block-checkout' );
-		$place_order_enabled   = ( $this->use_place_order || $this->add_place_order_method )
-			&& ( ! $this->subscription_helper->cart_contains_subscription() || ( $script_data['can_save_vault_token'] ?? false ) );
-		$cart                  = WC()->cart;
+		// A subscription cart may still use the standard "Place order" flow when a vault
+		// token can be saved (vaulting mode) or when manual renewals are accepted (the
+		// subscription is charged as a plain, one-time Orders API payment).
+		$place_order_enabled = ( $this->use_place_order || $this->add_place_order_method )
+			&& (
+				! $this->subscription_helper->cart_contains_subscription()
+				|| ( $script_data['can_save_vault_token'] ?? false )
+				|| $this->subscription_helper->accept_manual_renewals()
+			);
+		$cart                = WC()->cart;
 
 		return array(
 			'id'                          => $this->gateway->id,


### PR DESCRIPTION
On Block Checkout, the standard PayPal gateway was hidden whenever the cart contained a subscription, "Accept Manual Renewals" was enabled, and Save/Vault PayPal was disabled.

The `placeOrderEnabled` flag in `PayPalPaymentMethod::get_payment_method_data()` only allowed subscription carts when a vault token could be saved, so with vaulting off the gateway was never registered by the block.                                                                                                                                                                   
                                                                                                                                                                                             
This PR broads that condition to also allow the manual-renewal case (`accept_manual_renewals()`), reusing the existing SubscriptionHelper method. This matches `resolve_subscription_mode()`, which already treats manual renewals + vaulting-off as a plain one-time Orders API payment, so the gateway now shows and processes a standard redirect.    