### PR TITLE
Declare each express method's own gateway features plus ppcp_continuation (6835)

### DIFF
--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -90,6 +90,17 @@ const FUNDING_SOURCES = config?.is_free_trial_cart
 	  );
 
 /**
+ * Blocks drops a method whose features miss a cart requirement, so a method
+ * that declares none is unusable everywhere; 'products' is the minimum claim.
+ *
+ * @param {string[]} [features] - The processing gateway's features.
+ * @return {string[]} The features to declare, never empty.
+ */
+function gatewayFeatures( features ) {
+	return features || [ 'products' ];
+}
+
+/**
  * Derives a decimal amount string from the WC Blocks cart totals.
  *
  * @param {Object} cartTotals - The canMakePayment cartTotals (minor units).
@@ -125,13 +136,10 @@ if ( config && config.page_context && config.continuation ) {
 		),
 		canMakePayment: () => true,
 		supports: {
-			// WooCommerce hides any method whose features do not cover every
-			// cart requirement, and v5's ppcp-gateway is unregistered here, so
-			// a missing feature leaves the buyer no way to pay or cancel. The
-			// gateway supports come from the server (subscription-aware);
-			// ppcp_continuation is always required in this branch.
+			// v5's ppcp-gateway is unregistered here, so a dropped method
+			// leaves the buyer no way to pay or cancel.
 			features: [
-				...( config.supported_features || [ 'products' ] ),
+				...gatewayFeatures( config.supported_features ),
 				'ppcp_continuation',
 			],
 		},
@@ -203,9 +211,9 @@ if ( config && config.page_context && config.continuation ) {
 			 * paymentMethodId: Clears the gateway from the editor's
 			 *   "incompatible with block-based checkout" list.
 			 * gatewayId: Links to the gateway's settings.
-			 * supports.features: Blocks drops a method whose features miss a
-			 *   cart requirement, which is what keeps the wallets off a
-			 *   subscription cart.
+			 * supports.features: ppcp_continuation is declared up front
+			 *   because approving in the wallet sheet raises that cart
+			 *   requirement mid-flow, after the method is chosen.
 			 * supports.style: Exposes the block's height/borderRadius controls.
 			 */
 			name,
@@ -228,17 +236,8 @@ if ( config && config.page_context && config.continuation ) {
 				return Boolean( eligibility[ fundingSource ] );
 			},
 			supports: {
-				// ppcp_continuation is the cart requirement that appears the
-				// moment an approved order reaches the session, which happens
-				// while this method is mid-flow: the buyer approves in the
-				// sheet, the express handler stores the order and submits the
-				// Blocks checkout. Without the feature WooCommerce withdraws
-				// every method that lacks it, this one included, and the
-				// checkout POST goes out with no payment_method at all. The
-				// method holding the approved order is the one entitled to
-				// continue with it, so it declares the requirement it raised.
 				features: [
-					...( features || [ 'products' ] ),
+					...gatewayFeatures( features ),
 					'ppcp_continuation',
 				],
 				style: [ 'height', 'borderRadius' ],
@@ -342,9 +341,7 @@ if ( config?.card_fields?.enabled && ! config.continuation ) {
 		),
 		canMakePayment: () => true,
 		supports: {
-			// The credit-card gateway's supports from the server, so a
-			// subscription cart does not filter the card method out.
-			features: config.card_fields.supported_features || [ 'products' ],
+			features: gatewayFeatures( config.card_fields.supported_features ),
 			// WooCommerce Blocks renders its native "Save payment information…"
 			// checkbox and exposes the choice as the shouldSavePayment prop;
 			// only offered when card vaulting is enabled. Suppressed on a
@@ -399,7 +396,7 @@ if ( config?.vault_component?.is_eligible && ! config.continuation ) {
 		} ),
 		canMakePayment: () => true,
 		supports: {
-			features: config.supported_features || [ 'products' ],
+			features: gatewayFeatures( config.supported_features ),
 			// Renders WooCommerce Blocks' saved-token radio list for this gateway.
 			showSavedCards: true,
 			showSaveOption: false,

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -228,7 +228,19 @@ if ( config && config.page_context && config.continuation ) {
 				return Boolean( eligibility[ fundingSource ] );
 			},
 			supports: {
-				features: features || [ 'products' ],
+				// ppcp_continuation is the cart requirement that appears the
+				// moment an approved order reaches the session, which happens
+				// while this method is mid-flow: the buyer approves in the
+				// sheet, the express handler stores the order and submits the
+				// Blocks checkout. Without the feature WooCommerce withdraws
+				// every method that lacks it, this one included, and the
+				// checkout POST goes out with no payment_method at all. The
+				// method holding the approved order is the one entitled to
+				// continue with it, so it declares the requirement it raised.
+				features: [
+					...( features || [ 'products' ] ),
+					'ppcp_continuation',
+				],
 				style: [ 'height', 'borderRadius' ],
 			},
 		} );

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -192,8 +192,10 @@ if ( config && config.page_context && config.continuation ) {
 	 *                                          button.
 	 * @param {Function} [args.isDeviceCapable] - Synchronous capability check,
 	 *                                          asked before eligibility.
-	 * @param {string[]} [args.features]        - What the processing gateway
-	 *                                          supports; defaults to PayPal's.
+	 * @param {string[]} args.features          - What the processing gateway
+	 *                                          supports. Deliberately without
+	 *                                          a default, so a wallet cannot
+	 *                                          inherit PayPal's list.
 	 */
 	const registerExpress = ( {
 		name,
@@ -201,7 +203,7 @@ if ( config && config.page_context && config.continuation ) {
 		fundingSource,
 		content,
 		isDeviceCapable,
-		features = config.supported_features,
+		features,
 	} ) => {
 		const label = fundingSourceLabel( fundingSource );
 
@@ -254,6 +256,7 @@ if ( config && config.page_context && config.continuation ) {
 				config,
 				fundingSource,
 			} ),
+			features: config.supported_features,
 		} );
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -1,0 +1,170 @@
+const mockRegisterExpressPaymentMethod = jest.fn();
+const mockRegisterPaymentMethod = jest.fn();
+// virtual: webpack resolves this to the wc.wcBlocksRegistry global, so there is
+// no package under node_modules for Jest to find.
+jest.mock(
+	'@woocommerce/blocks-registry',
+	() => ( {
+		registerExpressPaymentMethod: ( ...args ) =>
+			mockRegisterExpressPaymentMethod( ...args ),
+		registerPaymentMethod: ( ...args ) =>
+			mockRegisterPaymentMethod( ...args ),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '../sdkLoader', () => ( { loadSdkV6: jest.fn() } ) );
+jest.mock( '../eligibility', () => ( { checkEligibility: jest.fn() } ) );
+jest.mock( '../utils/errorHandler', () => ( { setErrorLabels: jest.fn() } ) );
+jest.mock( '../blocks/V6ExpressComponent', () => ( {
+	V6ExpressComponent: () => null,
+} ) );
+jest.mock( '../blocks/V6WalletComponent', () => ( {
+	V6WalletComponent: () => null,
+} ) );
+jest.mock( '../blocks/V6ContinuationComponent', () => ( {
+	V6ContinuationComponent: () => null,
+} ) );
+jest.mock( '../blocks/V6CardFieldsComponent', () => ( {
+	V6CardFieldsComponent: () => null,
+} ) );
+jest.mock( '../blocks/V6EditorPreview', () => ( {
+	V6EditorPreview: () => null,
+} ) );
+jest.mock( '@ppcp-blocks/Components/paypal-saved-token', () => ( {
+	PayPalSavedToken: () => null,
+} ) );
+jest.mock( '../wallets/applePay', () => ( {
+	isDeviceEligible: jest.fn( () => true ),
+} ) );
+jest.mock( '../messages/renderer', () => ( {
+	initMessages: jest.fn( () => Promise.resolve() ),
+	updateMessagesAmount: jest.fn(),
+} ) );
+jest.mock( '../messages/cartTotalWatcher', () => ( {
+	watchBlockCartTotal: jest.fn(),
+} ) );
+
+/**
+ * The wc_ppcp_sdk_v6 config shape checkout-block.js reads for a normal
+ * (non-continuation) checkout, with both wallets enabled and styled so the
+ * express registration loop reaches every funding source.
+ */
+const baseConfig = ( overrides = {} ) => ( {
+	page_context: 'checkout',
+	supported_features: [ 'products', 'subscriptions' ],
+	pay_later_button: { checkout: true },
+	google_pay: {
+		enabled: true,
+		styles: { checkout: {} },
+		supported_features: [ 'products' ],
+	},
+	apple_pay: {
+		enabled: true,
+		styles: { checkout: {} },
+		supported_features: [ 'products' ],
+	},
+	...overrides,
+} );
+
+/**
+ * Sets the wcSettings global the module reads at import time, then imports it
+ * fresh so its module-scope registration runs against this test's config.
+ *
+ * @param {Object} config - The 'ppcp-sdk-v6' payment method data.
+ */
+function loadCheckoutBlock( config ) {
+	window.wc = {
+		wcSettings: {
+			getSetting: ( key ) =>
+				key === 'paymentMethodData' ? { 'ppcp-sdk-v6': config } : undefined,
+		},
+	};
+	jest.isolateModules( () => {
+		require( '../checkout-block.js' );
+	} );
+}
+
+/**
+ * The registerExpressPaymentMethod call for one registered name.
+ *
+ * @param {string} name - The registration name to find.
+ * @return {Object} The args object passed to registerExpressPaymentMethod.
+ */
+function expressCallFor( name ) {
+	const call = mockRegisterExpressPaymentMethod.mock.calls.find(
+		( [ args ] ) => args.name === name
+	);
+	return call[ 0 ];
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+afterEach( () => {
+	delete window.wc;
+} );
+
+describe( 'checkout-block', () => {
+	describe( 'express method registration', () => {
+		test.each( [
+			[ 'ppcp-gateway-paypal', [ 'products', 'subscriptions' ] ],
+			[ 'ppcp-gateway-venmo', [ 'products', 'subscriptions' ] ],
+			[ 'ppcp-gateway-paylater', [ 'products', 'subscriptions' ] ],
+			[ 'ppcp-googlepay', [ 'products' ] ],
+			[ 'ppcp-applepay', [ 'products' ] ],
+		] )(
+			'%s declares ppcp_continuation alongside its own supported features',
+			( name, ownFeatures ) => {
+				loadCheckoutBlock( baseConfig() );
+
+				const { supports } = expressCallFor( name );
+
+				expect( supports.features ).toEqual( [
+					...ownFeatures,
+					'ppcp_continuation',
+				] );
+			}
+		);
+
+		/**
+		 * Regression test: WooCommerce Blocks withdraws any payment method whose
+		 * supports.features misses a cart requirement. The plugin's Store API
+		 * requirement flips to ['ppcp_continuation'] the moment the buyer
+		 * approves in the express sheet, i.e. mid-flow for the very method that
+		 * is submitting the checkout. Without the feature here that method is
+		 * withdrawn along with the rest, activePaymentMethod clears, and the
+		 * checkout POST goes out with no payment_method.
+		 */
+		test( 'ppcp_continuation is present even when the gateway declares no supported_features of its own', () => {
+			loadCheckoutBlock( baseConfig( { supported_features: undefined } ) );
+
+			const { supports } = expressCallFor( 'ppcp-gateway-paypal' );
+
+			expect( supports.features ).toEqual( [
+				'products',
+				'ppcp_continuation',
+			] );
+		} );
+
+		test( 'a wallet with no supported_features of its own still gets ppcp_continuation', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					google_pay: {
+						enabled: true,
+						styles: { checkout: {} },
+						supported_features: undefined,
+					},
+				} )
+			);
+
+			const { supports } = expressCallFor( 'ppcp-googlepay' );
+
+			expect( supports.features ).toEqual( [
+				'products',
+				'ppcp_continuation',
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
*Changelog:* (none, feature not released yet)

# Description

## 🐛 The problem

On SDK v6 block checkout, a buyer who approves in the PayPal or wallet sheet returns to a page where the express method is gone, leaving no way to finish or cancel.

## 💡 Why it happens

Approving raises a `ppcp_continuation` cart requirement after the method was chosen, and Blocks drops any method whose `supports.features` misses a cart requirement. No express registration declared it. Separately, `registerExpress` defaulted `features` to PayPal's list, so the wallets inherited it instead of using their own gateway's.

## ✅ The fix

Every express registration declares `ppcp_continuation` plus its own gateway's features, and `features` has no default anymore.

## 🔍 What to review

- **Wallet visibility on special carts changes.** Wallets are now filtered by their own gateway's `supports`, not PayPal's. A narrower wallet gateway means that wallet stops appearing on carts where it used to. Intended, but the one user-visible side effect.
- `ppcp_continuation` is declared unconditionally, read as a capability claim rather than a state.
