### PR TITLE
Classic checkout - When vaulting disabled, disabled PayPal button visible for vaulting subscription (6847)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -75,6 +75,16 @@ class DisableGateways {
 			}
 		}
 
+		// Hide the PayPal gateway when the subscription cart cannot be processed (e.g. vaulting
+		// disabled for a subscription that requires it, with no PayPal plan or manual renewals),
+		// instead of showing it with a disabled button.
+		if (
+			isset( $methods[ PayPalGateway::ID ] )
+			&& ! $this->subscription_helper->subscription_cart_processable( $this->settings_provider )
+		) {
+			unset( $methods[ PayPalGateway::ID ] );
+		}
+
 		if ( $this->card_configuration->use_acdc() && $this->store_country !== 'MX' ) {
 			unset( $methods[ CardButtonGateway::ID ] );
 		}

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -233,6 +233,34 @@ class SubscriptionHelper {
 	}
 
 	/**
+	 * Whether the current (subscription) cart can actually be processed by the PayPal gateway.
+	 *
+	 * This resolves the mode-aware {@see self::paypal_subscription_button_allowed()} rule from
+	 * settings, so callers that only have a {@see SettingsProvider} (such as the classic-checkout
+	 * gateway-availability filter) can hide the PayPal gateway when it could not fulfil the payment
+	 * instead of leaving it visible with a disabled button. A non-subscription cart is always
+	 * processable.
+	 *
+	 * @param SettingsProvider $settings_provider The settings provider.
+	 * @return bool
+	 * @throws NotFoundException If setting is not found.
+	 */
+	public function subscription_cart_processable( SettingsProvider $settings_provider ): bool {
+		if ( ! $this->cart_contains_subscription() ) {
+			return true;
+		}
+
+		$is_paypal_subscription = self::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS === $this->resolve_subscription_mode( $settings_provider );
+
+		// Mirrors SmartButton::can_save_vault_token(): a token can only be saved with a
+		// connected merchant and vaulting ("Save PayPal and Venmo") enabled.
+		$can_save_vault_token = ! empty( $settings_provider->merchant_data()->client_id )
+			&& $settings_provider->save_paypal_and_venmo();
+
+		return $this->paypal_subscription_button_allowed( $is_paypal_subscription, $can_save_vault_token );
+	}
+
+	/**
 	 * Resolves how a subscription checkout must be routed.
 	 *
 	 * This is the single deciding function for the subscriptions mode. Rules:

--- a/tests/PHPUnit/WcGateway/Checkout/DisableGatewaysTest.php
+++ b/tests/PHPUnit/WcGateway/Checkout/DisableGatewaysTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Checkout;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * GIVEN scenarios only exercise the subscription-cart-processable branch of the handler; all
+ * other collaborators are stubbed to their "do nothing" outcome so that branch is isolated.
+ */
+class DisableGatewaysTest extends TestCase {
+
+	private SettingsProvider $settings_provider;
+	private SettingsStatus $settings_status;
+	private SubscriptionHelper $subscription_helper;
+	private Context $context;
+	private CardPaymentsConfiguration $card_configuration;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		when( 'WC' )->justReturn( (object) array( 'payment_gateways' => null ) );
+
+		$this->settings_provider = Mockery::mock( SettingsProvider::class );
+		$this->settings_provider->allows( 'merchant_data' )->andReturn(
+			new MerchantConnectionDTO( false, 'client-id-123', '', '' )
+		);
+
+		$this->settings_status = Mockery::mock( SettingsStatus::class );
+		$this->settings_status->allows( 'is_smart_button_enabled_for_location' )->andReturn( true );
+
+		$this->subscription_helper = Mockery::mock( SubscriptionHelper::class );
+		$this->subscription_helper->allows( 'cart_contains_paypal_subscription_product' )->andReturn( false );
+
+		$this->context = Mockery::mock( Context::class );
+		$this->context->allows( 'is_paypal_continuation' )->andReturn( false );
+
+		$this->card_configuration = Mockery::mock( CardPaymentsConfiguration::class );
+		$this->card_configuration->allows( 'use_acdc' )->andReturn( false );
+	}
+
+	/**
+	 * GIVEN the classic checkout is showing the PayPal gateway
+	 * AND the cart contains a subscription that cannot be processed (e.g. vaulting is disabled
+	 *     and the product has no linked PayPal plan)
+	 * WHEN DisableGateways::handler() filters the available payment methods
+	 * THEN the PayPal gateway is removed instead of being shown with a disabled button
+	 */
+	public function test_handler_hides_paypal_gateway_when_subscription_cart_not_processable(): void {
+		$this->subscription_helper->allows( 'subscription_cart_processable' )
+			->with( $this->settings_provider )
+			->andReturn( false );
+
+		$handler = $this->create_handler();
+
+		$methods = $handler->handler( array( PayPalGateway::ID => 'paypal-gateway' ) );
+
+		$this->assertArrayNotHasKey( PayPalGateway::ID, $methods );
+	}
+
+	/**
+	 * GIVEN the classic checkout is showing the PayPal gateway
+	 * AND the cart's subscription can be processed by PayPal (e.g. a linked plan exists or
+	 *     vaulting is available)
+	 * WHEN DisableGateways::handler() filters the available payment methods
+	 * THEN the PayPal gateway remains available
+	 */
+	public function test_handler_keeps_paypal_gateway_when_subscription_cart_is_processable(): void {
+		$this->subscription_helper->allows( 'subscription_cart_processable' )
+			->with( $this->settings_provider )
+			->andReturn( true );
+
+		$handler = $this->create_handler();
+
+		$methods = $handler->handler( array( PayPalGateway::ID => 'paypal-gateway' ) );
+
+		$this->assertArrayHasKey( PayPalGateway::ID, $methods );
+	}
+
+	private function create_handler(): DisableGateways {
+		return new DisableGateways(
+			$this->settings_provider,
+			$this->settings_status,
+			$this->subscription_helper,
+			$this->context,
+			$this->card_configuration,
+			'US'
+		);
+	}
+}

--- a/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
+++ b/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
@@ -7,6 +7,7 @@ use Mockery;
 use WC_Order;
 use WC_Subscription;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use function Brain\Monkey\Filters\expectApplied;
@@ -310,5 +311,135 @@ class SubscriptionHelperTest extends TestCase
 		$helper->shouldReceive('cart_contains_renewal')->andReturn($cart_contains_renewal);
 
 		return $helper;
+	}
+
+	/**
+	 * GIVEN the cart does not contain a subscription
+	 * WHEN subscription_cart_processable() is called
+	 * THEN it returns true without resolving the subscription mode or checking button eligibility,
+	 *      since a non-subscription cart is always processable
+	 */
+	public function test_subscription_cart_processable_returns_true_when_cart_has_no_subscription(): void {
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+
+		$helper = Mockery::mock( SubscriptionHelper::class )->makePartial();
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( false );
+		$helper->shouldNotReceive( 'resolve_subscription_mode' );
+		$helper->shouldNotReceive( 'paypal_subscription_button_allowed' );
+
+		$this->assertTrue( $helper->subscription_cart_processable( $settings_provider ) );
+	}
+
+	/**
+	 * GIVEN a subscription is in the cart
+	 * WHEN subscription_cart_processable() is called
+	 * THEN it resolves whether PayPal Subscriptions mode applies and whether a vault token can be
+	 *      saved, then defers the final decision to paypal_subscription_button_allowed()
+	 * AND a vault token can only be saved when both a connected merchant (client_id) and
+	 *     "Save PayPal and Venmo" are present - one without the other keeps it un-savable
+	 *
+	 * @dataProvider subscription_cart_processable_wiring_provider
+	 */
+	public function test_subscription_cart_processable_wires_mode_and_vault_token_signals(
+		string $resolved_mode,
+		bool $save_paypal_and_venmo,
+		string $client_id,
+		bool $expected_is_paypal_subscription,
+		bool $expected_can_save_vault_token,
+		bool $button_allowed_result
+	): void {
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->allows( 'save_paypal_and_venmo' )->andReturn( $save_paypal_and_venmo );
+		$settings_provider->allows( 'merchant_data' )->andReturn(
+			new MerchantConnectionDTO( false, $client_id, '', '' )
+		);
+
+		$helper = Mockery::mock( SubscriptionHelper::class )->makePartial();
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( true );
+		$helper->shouldReceive( 'resolve_subscription_mode' )
+			->with( $settings_provider )
+			->andReturn( $resolved_mode );
+		$helper->shouldReceive( 'paypal_subscription_button_allowed' )
+			->with( $expected_is_paypal_subscription, $expected_can_save_vault_token )
+			->andReturn( $button_allowed_result );
+
+		$this->assertSame(
+			$button_allowed_result,
+			$helper->subscription_cart_processable( $settings_provider )
+		);
+	}
+
+	public function subscription_cart_processable_wiring_provider(): array {
+		return array(
+			'vaulting mode with vaulting enabled and connected merchant allows the button' => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING,
+				true,
+				'client-id-123',
+				false,
+				true,
+				true,
+			),
+			'subscriptions API mode with a PayPal plan allows the button'                  => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS,
+				false,
+				'',
+				true,
+				false,
+				true,
+			),
+			'subscriptions API mode without a plan and vaulting disabled hides the button' => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS,
+				false,
+				'',
+				true,
+				false,
+				false,
+			),
+			'manual-renewal-only subscription allows the button'                           => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_DISABLED,
+				false,
+				'',
+				false,
+				false,
+				true,
+			),
+			'vaulting enabled but no connected merchant keeps the vault token un-savable'   => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING,
+				true,
+				'',
+				false,
+				false,
+				false,
+			),
+		);
+	}
+
+	/**
+	 * GIVEN a subscription requiring a PayPal plan is in the cart
+	 * AND no PayPal plan is linked to the product
+	 * AND vaulting ("Save PayPal and Venmo") is disabled
+	 * WHEN subscription_cart_processable() runs end-to-end (mode resolution and button
+	 *      eligibility are not stubbed)
+	 * THEN it returns false, so the PayPal gateway is hidden instead of shown disabled
+	 */
+	public function test_subscription_cart_processable_end_to_end_hides_gateway_when_vaulting_disabled_and_no_plan(): void {
+		expectApplied( 'woocommerce_paypal_payments_subscription_mode_disabled' )
+			->once()
+			->with( false )
+			->andReturn( false );
+
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->allows( 'save_paypal_and_venmo' )->andReturn( false );
+		$settings_provider->allows( 'merchant_data' )->andReturn(
+			new MerchantConnectionDTO( false, '', '', '' )
+		);
+
+		$helper = Mockery::mock( SubscriptionHelper::class )->makePartial();
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( true );
+		$helper->shouldReceive( 'plugin_is_active' )->andReturn( true );
+		$helper->shouldReceive( 'accept_manual_renewals' )->andReturn( false );
+		$helper->shouldReceive( 'checkout_subscription_product_allowed' )->andReturn( false );
+
+		$this->assertFalse( $helper->subscription_cart_processable( $settings_provider ) );
 	}
 }


### PR DESCRIPTION
On the classic checkout, when PayPal vaulting is disabled and the cart holds a subscription that requires vaulting (no PayPal plan, manual renewals off), the PayPal gateway appeared with a greyed-out, unusable button instead of being hidden.                                                                                                                       
                                                                                                                                                                                             
This PR adds a mode-aware `SubscriptionHelper::subscription_cart_processable()` gate and used it in `DisableGateways::handler()` to remove the PayPal gateway entirely when the subscription cart can't be processed, matching the cart, mini-cart, and block-checkout behavior.