### PR TITLE
Classic checkout - When Fastlane enabled selecting PayPal as guest button Proceed to PayPal visible (6850)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -8,6 +8,7 @@ import ButtonStateManager from './ButtonStateManager';
 import PayPalInsights from './Insights/PayPalInsights';
 import { disable, enable } from '@ppcp-button/Helper/ButtonDisabler';
 import { getCurrentPaymentMethod } from '@ppcp-button/Helper/CheckoutMethodState';
+import { fastlaneSdkV6Config } from '@ppcp-sdk-v6/utils/config';
 
 /**
  * Internal customer details.
@@ -319,7 +320,14 @@ class AxoManager {
 		this.el.watermarkContainer.hide();
 
 		if ( scenario.defaultSubmitButton ) {
-			this.el.defaultSubmitButton.show();
+			// On v6 pages the SDK owns #place_order for every non-AXO gateway
+			// (it hides it for PayPal express/wallets and shows it otherwise), so
+			// re-showing it here would clobber that hide - jQuery .show() strips the
+			// inline `display:none !important` the v6 code sets. AXO still hides it
+			// in the else branch when the Fastlane gateway itself is selected.
+			if ( ! fastlaneSdkV6Config() ) {
+				this.el.defaultSubmitButton.show();
+			}
 			this.el.billingEmailSubmitButton.hide();
 		} else {
 			this.el.defaultSubmitButton.hide();

--- a/modules/ppcp-axo/resources/js/test/AxoManager.test.js
+++ b/modules/ppcp-axo/resources/js/test/AxoManager.test.js
@@ -1,4 +1,4 @@
-/* global describe, test, expect, afterEach */
+/* global describe, test, expect, afterEach, jest */
 import jQuery from 'jquery';
 import AxoManager from '../AxoManager';
 
@@ -15,6 +15,123 @@ function buildManager() {
 	instance.$ = ( selector ) => jQuery( selector );
 	return instance;
 }
+
+/**
+ * Builds a stub DOM-element wrapper compatible with `DomElementCollection` entries:
+ * exposes the selector plus `show`/`hide` spies, without touching the real DOM.
+ *
+ * @param {string} selector - CSS selector the real wrapper would expose.
+ * @return {{selector: string, show: Function, hide: Function}} The stub element.
+ */
+function stubElement( selector ) {
+	return {
+		selector,
+		show: jest.fn(),
+		hide: jest.fn(),
+	};
+}
+
+/**
+ * Builds an AxoManager with everything `rerender()` touches stubbed out, driven by
+ * the given `status` so the real `identifyScenario()` determines the scenario.
+ *
+ * @param {Object} status - Overrides merged into the manager's `status` object.
+ * @return {AxoManager} The manager instance, ready for `rerender()`.
+ */
+function buildRerenderManager( status ) {
+	const instance = buildManager();
+
+	instance.status = {
+		active: false,
+		validEmail: false,
+		hasProfile: false,
+		hasCard: false,
+		useEmailWidget: false,
+		...status,
+	};
+
+	instance.el = {
+		watermarkContainer: stubElement( '#ppcp-axo-watermark-container' ),
+		defaultSubmitButton: stubElement( '#place_order' ),
+		billingEmailSubmitButton: stubElement(
+			'#ppcp-axo-billing-email-submit-button'
+		),
+		fieldBillingEmail: stubElement( '#billing_email_field' ),
+		customerDetails: stubElement( '#ppcp-axo-customer-details' ),
+		emailWidgetContainer: stubElement( '#ppcp-axo-email-widget' ),
+		paymentContainer: stubElement( '#ppcp-axo-payment' ),
+		gatewayDescription: stubElement( '.ppcp-axo-gateway-description' ),
+		submitButtonContainer: stubElement( '#ppcp-axo-submit-button' ),
+		axoCustomerDetails: stubElement( '#ppcp-axo-customer-details-wrapper' ),
+		shippingAddressContainer: stubElement( '#ppcp-axo-shipping-address' ),
+	};
+
+	const view = () => ( {
+		activate: jest.fn(),
+		deactivate: jest.fn(),
+		refresh: jest.fn(),
+	} );
+	instance.shippingView = view();
+	instance.billingView = view();
+	instance.cardView = view();
+
+	return instance;
+}
+
+describe( 'AxoManager.rerender', () => {
+	afterEach( () => {
+		delete window.wc_ppcp_sdk_v6;
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'when AXO is inactive (the default place-order button owns the page)', () => {
+		test( 'does not re-show the default place-order button when the v6 SDK manages it', () => {
+			window.wc_ppcp_sdk_v6 = { fastlane: { enabled: true } };
+			const manager = buildRerenderManager( { active: false } );
+
+			manager.rerender();
+
+			expect(
+				manager.el.defaultSubmitButton.show
+			).not.toHaveBeenCalled();
+			expect(
+				manager.el.billingEmailSubmitButton.hide
+			).toHaveBeenCalled();
+		} );
+
+		test( 'shows the default place-order button on v5 pages without the v6 SDK config', () => {
+			const manager = buildRerenderManager( { active: false } );
+
+			manager.rerender();
+
+			expect( manager.el.defaultSubmitButton.show ).toHaveBeenCalled();
+			expect(
+				manager.el.billingEmailSubmitButton.hide
+			).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when AXO is active with a recognized profile (AXO owns the submit button)', () => {
+		test( 'hides the default place-order button even when the v6 SDK config is present', () => {
+			window.wc_ppcp_sdk_v6 = { fastlane: { enabled: true } };
+			document.body.innerHTML = `
+				<div id="ppcp-axo-shipping-address"></div>
+				<div id="ppcp-axo-watermark-container"></div>`;
+			const manager = buildRerenderManager( {
+				active: true,
+				validEmail: true,
+				hasProfile: true,
+			} );
+
+			manager.rerender();
+
+			expect( manager.el.defaultSubmitButton.hide ).toHaveBeenCalled();
+			expect(
+				manager.el.billingEmailSubmitButton.show
+			).toHaveBeenCalled();
+		} );
+	} );
+} );
 
 describe( 'AxoManager.ensureShippingFieldsConsistency', () => {
 	afterEach( () => {


### PR DESCRIPTION
On classic checkout with Fastlane and SDK v6 enabled, a guest selecting the PayPal gateway saw the standard "Proceed to PayPal" place-order button rendered alongside the PayPal smart buttons. The v6 SDK hides that button with an inline `display:none !important`, but AXO's `AxoManager.rerender()` re-showed it via `jQuery .show()` whenever a non-AXO gateway was selected and `.show()` strips the inline style. (v5 was unaffected because it hides via a stylesheet class jQuery .show() can't override.)                                                          
                                                                                                                                                                                             
In `AxoManager.rerender()`, guarded the `defaultSubmitButton.show()` call so AXO no longer re-shows `#place_order` on v6 pages (detected via `fastlaneSdkV6Config()`), deferring ownership of that button to the v6 SDK. AXO still hides it when the Fastlane gateway itself is active, and v5 behavior is unchanged.  