### PR TITLE
Prevent ACDC submission when Blocks checkout fields are invalid (v6)

### DIFF
--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -28,6 +28,12 @@ import {
 	hostedFieldTextStyles,
 } from '../cardFields/cardFieldStyles';
 import { V6CardFieldContainer } from './V6CardFieldContainer';
+import { hasCheckoutValidationErrors } from './checkoutValidation';
+
+const CHECKOUT_FIELDS_NOT_VALID_MESSAGE = __(
+	'Please complete all required checkout fields before continuing with payment.',
+	'woocommerce-paypal-payments'
+);
 
 /**
  * Creates the order, confirms it through the card session (which runs 3D
@@ -203,7 +209,7 @@ export function V6CardFieldsComponent( {
 	shouldSavePayment,
 	billing,
 } ) {
-	const { onPaymentSetup } = eventRegistration;
+	const { onPaymentSetup, onCheckoutValidation } = eventRegistration;
 	const { responseTypes } = emitResponse;
 
 	const context = config.page_context;
@@ -285,9 +291,8 @@ export function V6CardFieldsComponent( {
 	const cardFieldOverrides = config.card_fields.styles;
 	useEffect( () => {
 		const source =
-			document.querySelector(
-				'.wc-block-components-text-input input'
-			) || referenceRef.current;
+			document.querySelector( '.wc-block-components-text-input input' ) ||
+			referenceRef.current;
 		if ( source ) {
 			setInputStyle( cardFieldStyles( source ) );
 			setTextStyle( hostedFieldTextStyles( source, cardFieldOverrides ) );
@@ -303,8 +308,17 @@ export function V6CardFieldsComponent( {
 			return undefined;
 		}
 
-		return onPaymentSetup( () =>
-			isFreeTrial
+		return onPaymentSetup( () => {
+			// The onCheckoutValidation check ran earlier and its verdict can go
+			// stale, so re-check right before calling PayPal.
+			if ( hasCheckoutValidationErrors() ) {
+				return {
+					type: responseTypes.ERROR,
+					message: CHECKOUT_FIELDS_NOT_VALID_MESSAGE,
+				};
+			}
+
+			return isFreeTrial
 				? submitCardSave( {
 						config,
 						session: sessionRef.current,
@@ -319,8 +333,8 @@ export function V6CardFieldsComponent( {
 						cardName: cardNameRef.current?.trim() || '',
 						// null when no billing address is available.
 						billingAddress: billingRef.current,
-				  } )
-		);
+				  } );
+		} );
 	}, [
 		onPaymentSetup,
 		activePaymentMethod,
@@ -330,6 +344,32 @@ export function V6CardFieldsComponent( {
 		responseTypes,
 		isFreeTrial,
 	] );
+
+	// WooCommerce reaches payment processing with required fields still empty (its
+	// own validation observer returns a non-response for plain field errors), so
+	// without this check the card flow creates a PayPal order and runs 3D Secure
+	// against an invalid form.
+	//
+	// Gated on the active method because this is a global event.
+    // For other methods like express PayPal or Venmo checkout an invalid form
+    // can be ok, since PayPal returns the address.
+	useEffect( () => {
+		if (
+			activePaymentMethod !== methodId ||
+			typeof onCheckoutValidation !== 'function'
+		) {
+			return undefined;
+		}
+
+		return onCheckoutValidation( () => {
+			if ( hasCheckoutValidationErrors() ) {
+				// No message since WooCommerce shows the field errors itself.
+				return { type: responseTypes.ERROR };
+			}
+
+			return true;
+		} );
+	}, [ onCheckoutValidation, activePaymentMethod, methodId, responseTypes ] );
 
 	const fieldsReady = session && inputStyle && textStyle;
 

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -61,6 +61,9 @@ function cardConfig( overrides = {} ) {
 
 let onPaymentSetup;
 let paymentSetupCb;
+let onCheckoutValidation;
+let checkoutValidationCb;
+let hasValidationErrors;
 let eventRegistration;
 let session;
 const emitResponse = {
@@ -94,13 +97,37 @@ async function waitForSessionReady() {
 	);
 }
 
+async function waitForCheckoutValidationReady() {
+	await waitFor( () => expect( checkoutValidationCb ).not.toBeNull() );
+}
+
 beforeEach( () => {
 	paymentSetupCb = null;
 	onPaymentSetup = jest.fn( ( cb ) => {
 		paymentSetupCb = cb;
 		return () => {};
 	} );
-	eventRegistration = { onPaymentSetup };
+	checkoutValidationCb = null;
+	onCheckoutValidation = jest.fn( ( cb ) => {
+		checkoutValidationCb = cb;
+		return () => {};
+	} );
+	eventRegistration = { onPaymentSetup, onCheckoutValidation };
+
+	hasValidationErrors = false;
+	global.wp = {
+		data: {
+			select: ( store ) => {
+				if ( store === 'wc/store/validation' ) {
+					return {
+						hasValidationErrors: () => hasValidationErrors,
+					};
+				}
+
+				return {};
+			},
+		},
+	};
 
 	session = {
 		createCardFieldsComponent: jest.fn( () =>
@@ -140,6 +167,76 @@ describe( 'V6CardFieldsComponent', () => {
 			expect( mockCardFieldContainer ).toHaveBeenCalled()
 		);
 		expect( onPaymentSetup ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not subscribe to onCheckoutValidation when a different payment method is active', async () => {
+		renderComponent( { activePaymentMethod: 'ppcp-gateway-paypal' } );
+
+		await waitFor( () =>
+			expect( mockCardFieldContainer ).toHaveBeenCalled()
+		);
+		expect( onCheckoutValidation ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders and still subscribes to onPaymentSetup when the Blocks registry supplies no onCheckoutValidation', async () => {
+		renderComponent( { eventRegistration: { onPaymentSetup } } );
+
+		await waitForSessionReady();
+
+		expect( onPaymentSetup ).toHaveBeenCalled();
+	} );
+
+	test( 'a pending checkout validation error blocks the card submission before an order is created', async () => {
+		renderComponent();
+		await waitForSessionReady();
+
+		hasValidationErrors = true;
+
+		let result;
+		await act( async () => {
+			result = await paymentSetupCb();
+		} );
+
+		expect( mockCreateCardOrder ).not.toHaveBeenCalled();
+		expect( session.submit ).not.toHaveBeenCalled();
+		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
+		expect( result.type ).toBe( 'error' );
+	} );
+
+	describe( 'onCheckoutValidation observer', () => {
+		test( 'returns a bare error response when the form is invalid', async () => {
+			renderComponent();
+			await waitForCheckoutValidationReady();
+
+			hasValidationErrors = true;
+
+			expect( checkoutValidationCb() ).toEqual( { type: 'error' } );
+		} );
+
+		test( 'returns true when the form is valid', async () => {
+			renderComponent();
+			await waitForCheckoutValidationReady();
+
+			expect( checkoutValidationCb() ).toBe( true );
+		} );
+
+		test( 'a form that passes validation and then turns invalid before payment setup still blocks order creation', async () => {
+			renderComponent();
+			await waitForSessionReady();
+			await waitForCheckoutValidationReady();
+
+			expect( checkoutValidationCb() ).toBe( true );
+
+			hasValidationErrors = true;
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( mockCreateCardOrder ).not.toHaveBeenCalled();
+			expect( result.type ).toBe( 'error' );
+		} );
 	} );
 
 	test( 'a successful submission creates the order, submits the session, approves it, and reports success', async () => {
@@ -470,6 +567,22 @@ describe( 'V6CardFieldsComponent', () => {
 			expect( mockCardFieldContainer ).toHaveBeenCalledWith(
 				expect.objectContaining( { session } )
 			);
+		} );
+
+		test( 'a pending checkout validation error blocks the card save before a setup token is created', async () => {
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			hasValidationErrors = true;
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( mockCreateCardSetupToken ).not.toHaveBeenCalled();
+			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
+			expect( result.type ).toBe( 'error' );
 		} );
 
 		test( 'a successful save exchanges the setup token instead of creating and approving an order', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/blocks/checkoutValidation.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/checkoutValidation.js
@@ -1,0 +1,20 @@
+/**
+ * WooCommerce Blocks checkout validation state.
+ *
+ * @package
+ */
+
+/**
+ * Whether the WooCommerce Blocks checkout form currently has validation errors.
+ *
+ * Fails open: an unreadable store lets payment proceed rather than blocking the
+ * buyer on a missing dependency. Reached through `window`, since optional
+ * chaining does not protect an undeclared root identifier.
+ *
+ * @return {boolean} True when the checkout form has validation errors.
+ */
+export function hasCheckoutValidationErrors() {
+	const validationStore = window.wp?.data?.select?.( 'wc/store/validation' );
+
+	return validationStore?.hasValidationErrors?.() || false;
+}


### PR DESCRIPTION
Similar to #4435, handles the WooCommerce validation before submitting ACDC in block checkout when using the V6 JS SDK. 