### PR TITLE
fix(pui): give the Pay Upon Invoice phone field its own id

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PayUponInvoiceGateway.php
@@ -33,6 +33,11 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 
 	public const ID = 'ppcp-pay-upon-invoice-gateway';
 
+	/**
+	 * The phone field PUI renders itself when the checkout does not require one.
+	 */
+	public const PHONE_FIELD_ID = 'ppcp_pui_billing_phone';
+
 	private PayUponInvoiceOrderEndpoint $order_endpoint;
 	private PurchaseUnitFactory $purchase_unit_factory;
 	private PaymentSourceFactory $payment_source_factory;
@@ -186,10 +191,11 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 				);
 			}
 		}
-
-		$phone_number = wc_clean( wp_unslash( $_POST['billing_phone'] ?? '' ) );
-		$phone_number = is_string( $phone_number ) ? $phone_number : '';
 		// phpcs:enable WordPress.Security.NonceVerification
+
+		// PUI only renders a field of its own when the checkout does not require a phone number;
+		// otherwise the value arrives under WooCommerce's field id, as it does from the blocks checkout.
+		$phone_number = $this->checkout_helper->submitted_phone( self::PHONE_FIELD_ID, 'billing_phone' );
 		if ( $phone_number ) {
 			$wc_order->set_billing_phone( $phone_number );
 			$wc_order->save();

--- a/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PayUponInvoiceIntegration.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PayUponInvoiceIntegration.php
@@ -231,7 +231,7 @@ class PayUponInvoiceIntegration {
 					$checkout_phone_required = $checkout_fields['billing']['billing_phone']['required'] ?? false;
 					if ( ! array_key_exists( 'billing_phone', $checkout_fields['billing'] ) || $checkout_phone_required === false ) {
 						woocommerce_form_field(
-							'billing_phone',
+							PayUponInvoiceGateway::PHONE_FIELD_ID,
 							array(
 								// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 								'label'        => __( 'Phone', 'woocommerce' ),
@@ -297,9 +297,7 @@ class PayUponInvoiceIntegration {
 					$errors->add( 'validation', __( 'Invalid birth date.', 'woocommerce-paypal-payments' ) );
 				}
 
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing
-				$national_number = wc_clean( wp_unslash( $_POST['billing_phone'] ?? '' ) );
-				$national_number = is_string( $national_number ) ? $national_number : '';
+				$national_number = $this->checkout_helper->submitted_phone( PayUponInvoiceGateway::PHONE_FIELD_ID, 'billing_phone' );
 				if ( ! $national_number ) {
 					$errors->add( 'validation', __( 'Phone field cannot be empty.', 'woocommerce-paypal-payments' ) );
 				}

--- a/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PaymentSourceFactory.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PaymentSourceFactory.php
@@ -41,12 +41,8 @@ class PaymentSourceFactory {
 	 * @return array
 	 */
 	public function from_wc_order( WC_Order $order, string $birth_date ): array {
-		$address = $order->get_address();
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$phone = wc_clean( wp_unslash( $_POST['billing_phone'] ?? '' ) );
-		if ( ! $phone ) {
-			$phone = $address['phone'] ?? '';
-		}
+		$address            = $order->get_address();
+		$phone              = $address['phone'] ?? '';
 		$phone_country_code = WC()->countries->get_country_calling_code( $address['country'] );
 		$phone_country_code = is_array( $phone_country_code ) && ! empty( $phone_country_code ) ? $phone_country_code[0] : $phone_country_code;
 		if ( is_string( $phone_country_code ) && '' !== $phone_country_code ) {

--- a/modules/ppcp-wc-gateway/src/Helper/CheckoutHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CheckoutHelper.php
@@ -61,6 +61,24 @@ class CheckoutHelper {
 	}
 
 	/**
+	 * Returns the first non-empty phone number found among the submitted fields.
+	 *
+	 * @param string ...$field_ids The submitted field ids, in order of precedence.
+	 * @return string
+	 */
+	public function submitted_phone( string ...$field_ids ): string {
+		foreach ( $field_ids as $field_id ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$phone = wc_clean( wp_unslash( $_POST[ $field_id ] ?? '' ) );
+			if ( is_string( $phone ) && '' !== $phone ) {
+				return $phone;
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Ensures date is valid and at least 18 years back.
 	 *
 	 * @param string $date The date.

--- a/tests/PHPUnit/WcGateway/Helper/CheckoutHelperTest.php
+++ b/tests/PHPUnit/WcGateway/Helper/CheckoutHelperTest.php
@@ -8,6 +8,13 @@ use WooCommerce\PayPalCommerce\TestCase;
 
 class CheckoutHelperTest extends TestCase
 {
+	public function tearDown(): void
+	{
+		$_POST = [];
+
+		parent::tearDown();
+	}
+
 	/**
 	 * @dataProvider datesProvider
 	 */
@@ -28,6 +35,90 @@ class CheckoutHelperTest extends TestCase
 			['1942-01-01', true],
 			['0001-01-01', false],
 		];
+	}
+
+	/**
+	 * GIVEN both the PUI phone field and the WooCommerce billing phone field are submitted
+	 * WHEN submitted_phone is called with PUI's field name first, then WooCommerce's
+	 * THEN the first field's value is returned
+	 */
+	public function testSubmittedPhoneReturnsFirstFieldWhenBothPresent()
+	{
+		$_POST['ppcp_pui_billing_phone'] = '+1 555 0100';
+		$_POST['billing_phone'] = '+1 555 0200';
+
+		$result = (new CheckoutHelper())->submitted_phone('ppcp_pui_billing_phone', 'billing_phone');
+
+		$this->assertSame('+1 555 0100', $result);
+	}
+
+	/**
+	 * GIVEN only the WooCommerce billing phone field is submitted
+	 * WHEN submitted_phone is called with PUI's field name first, then WooCommerce's
+	 * THEN the second field's value is returned
+	 */
+	public function testSubmittedPhoneFallsBackToSecondFieldWhenFirstIsAbsent()
+	{
+		$_POST['billing_phone'] = '+1 555 0200';
+
+		$result = (new CheckoutHelper())->submitted_phone('ppcp_pui_billing_phone', 'billing_phone');
+
+		$this->assertSame('+1 555 0200', $result);
+	}
+
+	/**
+	 * GIVEN the PUI phone field is submitted as an empty string and the billing phone field has a value
+	 * WHEN submitted_phone is called with PUI's field name first, then WooCommerce's
+	 * THEN the second field's value is returned
+	 */
+	public function testSubmittedPhoneFallsBackToSecondFieldWhenFirstIsEmpty()
+	{
+		$_POST['ppcp_pui_billing_phone'] = '';
+		$_POST['billing_phone'] = '+1 555 0200';
+
+		$result = (new CheckoutHelper())->submitted_phone('ppcp_pui_billing_phone', 'billing_phone');
+
+		$this->assertSame('+1 555 0200', $result);
+	}
+
+	/**
+	 * GIVEN none of the requested fields are submitted
+	 * WHEN submitted_phone is called with any field names
+	 * THEN an empty string is returned
+	 */
+	public function testSubmittedPhoneReturnsEmptyStringWhenNoFieldIsPresent()
+	{
+		$result = (new CheckoutHelper())->submitted_phone('ppcp_pui_billing_phone', 'billing_phone');
+
+		$this->assertSame('', $result);
+	}
+
+	/**
+	 * GIVEN the only submitted field value is not a string (e.g. an array)
+	 * WHEN submitted_phone is called
+	 * THEN the non-string value is skipped and an empty string is returned
+	 */
+	public function testSubmittedPhoneSkipsNonStringValue()
+	{
+		$_POST['ppcp_pui_billing_phone'] = ['unexpected', 'array'];
+
+		$result = (new CheckoutHelper())->submitted_phone('ppcp_pui_billing_phone', 'billing_phone');
+
+		$this->assertSame('', $result);
+	}
+
+	/**
+	 * GIVEN a single field is submitted
+	 * WHEN submitted_phone is called with only that one field name
+	 * THEN the field's value is returned
+	 */
+	public function testSubmittedPhoneWorksWithSingleFieldArgument()
+	{
+		$_POST['billing_phone'] = '+1 555 0300';
+
+		$result = (new CheckoutHelper())->submitted_phone('billing_phone');
+
+		$this->assertSame('+1 555 0300', $result);
 	}
 
 }


### PR DESCRIPTION
### Description

Pay Upon Invoice renders a phone field of its own whenever the checkout does not already require one. It rendered that field under WooCommerce's `billing_phone` id, so the classic checkout carried two inputs sharing an `id` and a `name`.

The duplicate `id` makes the label inside the payment box focus the billing section's input, and breaks any selector expecting a single `#billing_phone`. The shared `name` is the more serious half: both inputs are submitted, PHP keeps only the last one, and whatever the customer typed into the billing phone field is silently replaced by the Pay Upon Invoice value — including on the address WooCommerce saves to their account. Because the precondition is that the checkout's phone field is optional, this passes validation without any warning.

PUI's field now renders under its own id, and the value is read back with a fallback to WooCommerce's field, which still supplies it when the checkout requires a phone number and from the blocks checkout. `PaymentSourceFactory` no longer reads the request at all — its single caller sets the order's billing phone immediately beforehand, so the order already carries the resolved number.

**Backward compatibility.** Two additions are purely additive: `CheckoutHelper::submitted_phone()` and `PayUponInvoiceGateway::PHONE_FIELD_ID`. Two changes are externally observable and worth review:

- The rendered field id changed from `billing_phone` to `ppcp_pui_billing_phone`. Third-party CSS or JS targeting `#billing_phone` *inside the payment box* will stop matching, though that selector already resolved to the billing-section field first. Code reading `$_POST['billing_phone']` for a PUI order still works when the checkout requires a phone; it no longer receives PUI's value when the field is optional or hidden.
- `PaymentSourceFactory::from_wc_order()` keeps its signature but no longer consults `$_POST`. It is a public method on a container-wired service, so an extension calling it directly with a request value not yet on the order would get a different result. Inside the plugin, behavior is identical.

Not tested under multisite.

### Steps to Test

Requires a German merchant with Pay Upon Invoice enabled (API shop country DE, and brand name, logo URL and customer service instructions all filled in), a physical product totalling €5–€2500 in EUR, and DE billing and shipping countries. The classic (shortcode) checkout, not the Checkout block.

Make WooCommerce's billing phone field optional, e.g. via an mu-plugin:

```php
add_filter( 'woocommerce_checkout_fields', function ( $fields ) {
	$fields['billing']['billing_phone']['required'] = false;
	return $fields;
}, 9999 );
```

1. Go to the checkout and fill in the billing address, entering `030 1111111` in the billing section's Phone field.
2. Select Pay Upon Invoice. A second Phone field appears inside the payment box.
3. In the console, confirm there is no collision:
   ```js
   document.querySelectorAll( '#billing_phone' ).length          // 1
   document.querySelectorAll( '#ppcp_pui_billing_phone' ).length // 1
   document.querySelectorAll( '[name="billing_phone"]' ).length  // 1
   ```
   On `trunk` the first and third return `2`.
4. Click the "Phone" label inside the Pay Upon Invoice box — it focuses PUI's own field. On `trunk` focus jumps to the billing section's input.
5. Enter `030 2222222` in PUI's phone field and a birth date 18 or over, then place the order.
6. Go to My Account → Addresses → Billing. The phone reads `030 1111111`, what was actually typed there. On `trunk` it reads `030 2222222`.

Regression checks, repeating the above with the filter changed:

- **Phone required** (remove the filter): PUI renders no field of its own; everything flows through `billing_phone` as before.
- **Phone hidden** (`unset( $fields['billing']['billing_phone'] )`): PUI's field is the only phone; confirm the order's billing phone is populated from it.
- **Blocks checkout**: unchanged by this PR; confirm the phone still reaches the order.
- **Validation**: leave PUI's phone empty and submit — "Phone field cannot be empty."

### Changelog Entry

> Fix: Pay Upon Invoice no longer overwrites the customer's billing phone number on the classic checkout, and no longer renders a phone field with a duplicate id.
