### PR TITLE
Block checkout - When Fastlane enabled and v6 active ACDC is also present (6851)

### DIFF
--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -1044,7 +1044,12 @@ class SdkV6Manager {
 			$pay_later_button['mini-cart'] = $this->is_pay_later_button_enabled( 'mini-cart' );
 		}
 
-		$card_fields_enabled = $this->is_card_fields_enabled();
+		// Fastlane replaces the standalone ACDC card row when it renders (guest,
+		// non-subscription checkout), matching the v5 advanced-card block guard.
+		// Scoped to this JS flag only: is_card_fields_enabled() still gates the v5
+		// card block's suppression, so a page keeps exactly one card option.
+		$card_fields_enabled = $this->is_card_fields_enabled()
+			&& ! $this->is_fastlane_enabled();
 
 		$messages_settings_location = $this->messages_settings_location();
 

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -566,7 +566,7 @@ class SdkV6ManagerTest extends TestCase
     /**
      * GIVEN a checkout block page with Advanced Card Fields enabled for the merchant
      * WHEN the SDK bootstrap data is generated
-     * THEN card_fields.enabled is true
+     * THEN card_fields.enabled is true, unless Fastlane renders on the same page
      * AND the gateway title and name-field flag are carried into the payload
      * AND is_vaulting_enabled reflects the card vaulting setting
      * AND has_subscriptions reflects whether the cart contains a subscription
@@ -581,6 +581,7 @@ class SdkV6ManagerTest extends TestCase
         string $show_name_on_card,
         bool $card_vaulting_enabled,
         bool $cart_contains_subscription,
+        bool $fastlane_renders,
         bool $expected_enabled,
         bool $expected_name_field
     ): void {
@@ -589,6 +590,7 @@ class SdkV6ManagerTest extends TestCase
         $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn($gateway_title);
         $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn($show_name_on_card);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
+        $this->fastlane_config->shouldReceive('should_render')->andReturn($fastlane_renders);
 
         $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
         $this->session_handler->shouldReceive('order')->andReturn(null);
@@ -626,22 +628,31 @@ class SdkV6ManagerTest extends TestCase
     {
         return [
             'checkout-block with ACDC enabled and name field shown' => [
-                'checkout-block', true, 'Credit Card', 'yes', false, false, true, true,
+                'checkout-block', true, 'Credit Card', 'yes', false, false, false, true, true,
             ],
             'checkout-block with ACDC enabled and name field hidden' => [
-                'checkout-block', true, 'Credit Card', 'no', false, false, true, false,
+                'checkout-block', true, 'Credit Card', 'no', false, false, false, true, false,
             ],
             'checkout-block with ACDC disabled' => [
-                'checkout-block', false, 'Credit Card', 'yes', false, false, false, true,
+                'checkout-block', false, 'Credit Card', 'yes', false, false, false, false, true,
             ],
             'classic checkout with ACDC enabled' => [
-                'checkout', true, 'Credit Card', 'yes', false, false, true, true,
+                'checkout', true, 'Credit Card', 'yes', false, false, false, true, true,
             ],
             'checkout-block with card vaulting enabled' => [
-                'checkout-block', true, 'Credit Card', 'yes', true, false, true, true,
+                'checkout-block', true, 'Credit Card', 'yes', true, false, false, true, true,
             ],
             'checkout-block with a subscription in the cart' => [
-                'checkout-block', true, 'Credit Card', 'yes', false, true, true, true,
+                'checkout-block', true, 'Credit Card', 'yes', false, true, false, true, true,
+            ],
+            'checkout-block with ACDC enabled but Fastlane renders' => [
+                'checkout-block', true, 'Credit Card', 'yes', false, false, true, false, true,
+            ],
+            'classic checkout with ACDC enabled but Fastlane renders' => [
+                'checkout', true, 'Credit Card', 'yes', false, false, true, false, true,
+            ],
+            'checkout-block with ACDC disabled and Fastlane renders' => [
+                'checkout-block', false, 'Credit Card', 'yes', false, false, true, false, true,
             ],
         ];
     }


### PR DESCRIPTION
On block checkout with Fastlane enabled and SDK v6 active, guests saw two "Debit & Credit Cards" rows, Fastlane's and a redundant standalone ACDC card. v6 replaces the legacy per-gateway block methods with a single JS entry but never carried over the v5 guard that hides the standalone ACDC card when Fastlane renders. Since enabling Fastlane requires ACDC, the v6 card flag (keyed only off `is_acdc_enabled()`) always registered the extra card row.                                                                                                      
                                                                                                                                                                                             
This PR gates the v6 `card_fields.enabled` flag on Fastlane not being active, reusing the existing `is_fastlane_enabled()` check (which already encodes the v5 conditions: guest, no subscription, supported context). Scoped to only the JS flag, so the v5 ACDC block stays suppressed, leaving exactly one card row (Fastlane). Logged-in, subscription, and order-pay cases keep the ACDC card, matching legacy behavior.    