### PR TITLE
fix(order-endpoints): copy cart fees onto the order built from an approved PayPal order

### DIFF
--- a/modules/ppcp-button/src/Session/CartData.php
+++ b/modules/ppcp-button/src/Session/CartData.php
@@ -20,6 +20,13 @@ class CartData {
 	 */
 	protected array $coupons;
 
+	/**
+	 * The cart fees, each normalized to an array as in CartDataFactory.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	protected array $fees = array();
+
 	protected bool $needs_shipping;
 
 	protected int $user_id;
@@ -36,19 +43,22 @@ class CartData {
 	 * @param bool                                $needs_shipping
 	 * @param int                                 $user_id
 	 * @param string                              $cart_hash
+	 * @param array<string, array<string, mixed>> $fees Optional, so existing callers keep working.
 	 */
 	public function __construct(
 		array $items,
 		array $coupons,
 		bool $needs_shipping,
 		int $user_id,
-		string $cart_hash
+		string $cart_hash,
+		array $fees = array()
 	) {
 		$this->items          = $items;
 		$this->coupons        = $coupons;
 		$this->needs_shipping = $needs_shipping;
 		$this->user_id        = $user_id;
 		$this->cart_hash      = $cart_hash;
+		$this->fees           = $fees;
 	}
 
 	/**
@@ -81,6 +91,15 @@ class CartData {
 		return $this->coupons;
 	}
 
+	/**
+	 * The cart fees, each normalized to an array as in CartDataFactory.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function fees(): array {
+		return $this->fees;
+	}
+
 	public function needs_shipping(): bool {
 		return $this->needs_shipping;
 	}
@@ -111,27 +130,29 @@ class CartData {
 
 	public function to_array(): array {
 		return array(
-			'items'                => $this->items,
-			'coupons'              => $this->coupons,
-			'needs_shipping'       => $this->needs_shipping,
-			'user_id'              => $this->user_id,
-			'cart_hash'            => $this->cart_hash,
-			'paypal_order_id'      => $this->paypal_order_id,
-			'session_customer_id'  => $this->session_customer_id,
+			'items'               => $this->items,
+			'coupons'             => $this->coupons,
+			'fees'                => $this->fees,
+			'needs_shipping'      => $this->needs_shipping,
+			'user_id'             => $this->user_id,
+			'cart_hash'           => $this->cart_hash,
+			'paypal_order_id'     => $this->paypal_order_id,
+			'session_customer_id' => $this->session_customer_id,
 		);
 	}
 
 	public static function from_array( array $data, ?string $key = null ): CartData {
-		$cart_data                       = new CartData(
+		$cart_data                      = new CartData(
 			$data['items'] ?? array(),
 			$data['coupons'] ?? array(),
 			(bool) ( $data['needs_shipping'] ?? false ),
 			(int) ( $data['user_id'] ?? 0 ),
-			$data['cart_hash'] ?? ''
+			$data['cart_hash'] ?? '',
+			$data['fees'] ?? array()
 		);
-		$cart_data->paypal_order_id      = $data['paypal_order_id'] ?? null;
-		$cart_data->session_customer_id  = $data['session_customer_id'] ?? null;
-		$cart_data->key                  = $key;
+		$cart_data->paypal_order_id     = $data['paypal_order_id'] ?? null;
+		$cart_data->session_customer_id = $data['session_customer_id'] ?? null;
+		$cart_data->key                 = $key;
 		return $cart_data;
 	}
 }

--- a/modules/ppcp-button/src/Session/CartDataFactory.php
+++ b/modules/ppcp-button/src/Session/CartDataFactory.php
@@ -29,7 +29,8 @@ class CartDataFactory {
 			$cart->get_applied_coupons(),
 			$cart->needs_shipping(),
 			get_current_user_id(),
-			$cart->get_cart_hash()
+			$cart->get_cart_hash(),
+			$this->fees( $cart )
 		);
 
 		if ( WC()->session ) {
@@ -37,5 +38,48 @@ class CartDataFactory {
 		}
 
 		return $cart_data;
+	}
+
+	/**
+	 * The cart fees as plain arrays, so the snapshot survives being stored and read back.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	protected function fees( WC_Cart $cart ): array {
+		$fees = $cart->get_fees();
+
+		/**
+		 * The cart only holds fees when its totals were recalculated during this
+		 * request. A cart restored from the session carries its fee totals but not
+		 * the fees themselves, which is the case in the approve-order request that
+		 * builds the order, so fall back to the snapshot stored on every
+		 * recalculation - the same source the PayPal line items are built from.
+		 */
+		if ( ! $fees && WC()->session ) {
+			$stored = WC()->session->get( 'ppcp_fees' );
+			$fees   = is_array( $stored ) ? $stored : array();
+		}
+
+		return array_map(
+			/**
+			 * Param type omitted: WooCommerce documents these as stdClass, but the
+			 * fee objects reach the cart through a filter any plugin can feed.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $fee ): array {
+				return array(
+					'id'        => (string) ( $fee->id ?? '' ),
+					'name'      => (string) ( $fee->name ?? '' ),
+					'taxable'   => (bool) ( $fee->taxable ?? false ),
+					'tax_class' => (string) ( $fee->tax_class ?? '' ),
+					'amount'    => (float) ( $fee->amount ?? 0 ),
+					'total'     => (float) ( $fee->total ?? 0 ),
+					'tax'       => (float) ( $fee->tax ?? 0 ),
+					'tax_data'  => (array) ( $fee->tax_data ?? array() ),
+				);
+			},
+			$fees
+		);
 	}
 }

--- a/modules/ppcp-order-endpoints/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-order-endpoints/src/Helper/WooCommerceOrderCreator.php
@@ -15,6 +15,7 @@ use WC_Cart;
 use WC_Customer;
 use WC_Data_Exception;
 use WC_Order;
+use WC_Order_Item_Fee;
 use WC_Order_Item_Product;
 use WC_Order_Item_Shipping;
 use WC_Product;
@@ -110,6 +111,7 @@ class WooCommerceOrderCreator {
 			$this->configure_payment_source( $wc_order );
 			$this->configure_customer( $wc_order, $cart_data );
 			$this->configure_line_items( $wc_order, $cart_data, $payer, $shipping );
+			$this->configure_fees( $wc_order, $cart_data );
 			$this->configure_addresses( $wc_order, $payer, $shipping, $cart_data->needs_shipping() );
 			$this->configure_coupons( $wc_order, $cart_data->coupons() );
 
@@ -222,6 +224,44 @@ class WooCommerceOrderCreator {
 			 * @param WC_Order              $wc_order      The order being built.
 			 */
 			do_action( 'woocommerce_checkout_create_order_line_item', $item, $cart_item_key, $cart_item, $wc_order );
+
+			$wc_order->add_item( $item );
+		}
+	}
+
+	/**
+	 * Copies the cart fees onto the order, mirroring WC_Checkout::create_order_fee_lines().
+	 *
+	 * Without this the order is built from line items, shipping and coupons alone, so a
+	 * cart fee is dropped and the order total no longer matches the amount the buyer
+	 * approved: it is charged short by a surcharge, or over by a negative fee.
+	 */
+	protected function configure_fees( WC_Order $wc_order, CartData $cart_data ): void {
+		foreach ( $cart_data->fees() as $fee_key => $fee ) {
+			$taxable = (bool) ( $fee['taxable'] ?? false );
+
+			$item = new WC_Order_Item_Fee();
+			$item->set_name( (string) ( $fee['name'] ?? '' ) );
+			$item->set_amount( (string) ( $fee['amount'] ?? 0 ) );
+			$item->set_total( (string) ( $fee['total'] ?? 0 ) );
+
+			/**
+			 * The totals are recalculated once the order is assembled, so a fee the cart
+			 * left untaxed has to say so here; the item defaults to taxable otherwise.
+			 */
+			$item->set_tax_status( $taxable ? 'taxable' : 'none' );
+			$item->set_tax_class( $taxable ? (string) ( $fee['tax_class'] ?? '' ) : '' );
+
+			/**
+			 * Fires the standard WooCommerce fee item action so third-party plugins can
+			 * augment the item. The fee is passed as an object, as WooCommerce passes it.
+			 *
+			 * @param WC_Order_Item_Fee $item     The order fee item.
+			 * @param string|int        $fee_key  The fee key.
+			 * @param object            $fee      The cart fee.
+			 * @param WC_Order          $wc_order The order being built.
+			 */
+			do_action( 'woocommerce_checkout_create_order_fee_item', $item, $fee_key, (object) $fee, $wc_order );
 
 			$wc_order->add_item( $item );
 		}

--- a/tests/PHPUnit/OrderEndpoints/Helper/WooCommerceOrderCreatorTest.php
+++ b/tests/PHPUnit/OrderEndpoints/Helper/WooCommerceOrderCreatorTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\OrderEndpoints\Helper;
 use Mockery;
 use ReflectionMethod;
 use WC_Order;
+use WC_Order_Item_Fee;
 use WC_Order_Item_Product;
 use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
@@ -45,14 +46,7 @@ class WooCommerceOrderCreatorTest extends TestCase {
 			)
 			->andReturn( $filter_shipping );
 
-		$sut = new WooCommerceOrderCreator(
-			Mockery::mock( FundingSourceRenderer::class ),
-			Mockery::mock( SessionHandler::class ),
-			Mockery::mock( SubscriptionHelper::class ),
-			Mockery::mock( CartDataFactory::class ),
-			Mockery::mock( ShippingFactory::class ),
-			Mockery::mock( PayerFactory::class )
-		);
+		$sut = $this->create_order_creator();
 
 		// Testing a private method, as we want to confirm the presence and ability of a WP filter.
 		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'get_shipping' );
@@ -145,14 +139,7 @@ class WooCommerceOrderCreatorTest extends TestCase {
 		$subscription_helper = Mockery::mock( SubscriptionHelper::class );
 		$subscription_helper->shouldReceive( 'plugin_is_active' )->once()->andReturn( false );
 
-		$sut = new WooCommerceOrderCreator(
-			Mockery::mock( FundingSourceRenderer::class ),
-			Mockery::mock( SessionHandler::class ),
-			$subscription_helper,
-			Mockery::mock( CartDataFactory::class ),
-			Mockery::mock( ShippingFactory::class ),
-			Mockery::mock( PayerFactory::class )
-		);
+		$sut = $this->create_order_creator( $subscription_helper );
 
 		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'configure_line_items' );
 		$method->setAccessible( true );
@@ -160,5 +147,216 @@ class WooCommerceOrderCreatorTest extends TestCase {
 		$method->invoke( $sut, $wc_order, $cart_data, null, null );
 
 		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * GIVEN a cart with a single fee, e.g. a negative "discount" fee some plugins add
+	 *       via WC()->cart->add_fee()
+	 * WHEN configure_fees() copies the cart fees onto the WC order via reflection
+	 * THEN a WC_Order_Item_Fee carrying the fee's name, amount and total is added to the order
+	 * AND the "woocommerce_checkout_create_order_fee_item" action fires with the item,
+	 *      the fee key, the fee as an object (not the array), and the order
+	 *
+	 * This is the regression case for the reported bug: before the fix, cart fees were
+	 * dropped entirely and the order total silently diverged from what the buyer approved
+	 * in the wallet sheet.
+	 */
+	public function test_configure_fees_adds_order_item_for_a_cart_fee(): void {
+		$fee_key = 'negative12Fee';
+		$fee     = array(
+			'id'        => $fee_key,
+			'name'      => 'Loyalty discount',
+			'taxable'   => false,
+			'tax_class' => '',
+			'amount'    => '-12',
+			'total'     => '-12',
+			'tax'       => 0,
+			'tax_data'  => array(),
+		);
+
+		$cart_data = new CartData( array(), array(), false, 0, 'cart-hash', array( $fee_key => $fee ) );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$added_item = null;
+		$wc_order->shouldReceive( 'add_item' )
+			->once()
+			->with( Mockery::type( WC_Order_Item_Fee::class ) )
+			->andReturnUsing(
+				function ( $item ) use ( &$added_item ): void {
+					$added_item = $item;
+				}
+			);
+
+		expect( 'do_action' )
+			->once()
+			->with(
+				'woocommerce_checkout_create_order_fee_item',
+				Mockery::type( WC_Order_Item_Fee::class ),
+				$fee_key,
+				Mockery::on(
+					function ( $actual ) use ( $fee ) {
+						return is_object( $actual )
+							&& $actual->name === $fee['name']
+							&& $actual->amount === $fee['amount'];
+					}
+				),
+				$wc_order
+			);
+
+		$this->invoke_configure_fees( $this->create_order_creator(), $wc_order, $cart_data );
+
+		$this->assertNotNull( $added_item );
+		$this->assertSame( 'Loyalty discount', $added_item->get_name() );
+		$this->assertSame( '-12', $added_item->get_amount() );
+		$this->assertSame( '-12', $added_item->get_total() );
+	}
+
+	/**
+	 * GIVEN a cart fee that is or is not taxable
+	 * WHEN configure_fees() builds the order fee item via reflection
+	 * THEN the item's tax status and tax class mirror the cart fee
+	 *
+	 * Untaxed fees must say so explicitly: totals are recalculated once the order is
+	 * assembled, so a fee item would otherwise default to taxable and pick up tax the
+	 * cart never charged.
+	 *
+	 * @dataProvider fee_taxability_provider
+	 */
+	public function test_configure_fees_sets_tax_status_and_class_from_cart_fee(
+		bool $taxable,
+		string $tax_class,
+		string $expected_tax_status,
+		string $expected_tax_class
+	): void {
+		$fee_key = 'surchargeFee';
+		$fee     = array(
+			'id'        => $fee_key,
+			'name'      => 'Card surcharge',
+			'taxable'   => $taxable,
+			'tax_class' => $tax_class,
+			'amount'    => '5',
+			'total'     => '5',
+			'tax'       => 0,
+			'tax_data'  => array(),
+		);
+
+		$cart_data = new CartData( array(), array(), false, 0, 'cart-hash', array( $fee_key => $fee ) );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$added_item = null;
+		$wc_order->shouldReceive( 'add_item' )
+			->once()
+			->andReturnUsing(
+				function ( $item ) use ( &$added_item ): void {
+					$added_item = $item;
+				}
+			);
+
+		expect( 'do_action' )->once();
+
+		$this->invoke_configure_fees( $this->create_order_creator(), $wc_order, $cart_data );
+
+		$this->assertSame( $expected_tax_status, $added_item->get_tax_status() );
+		$this->assertSame( $expected_tax_class, $added_item->get_tax_class() );
+	}
+
+	public function fee_taxability_provider(): array {
+		return array(
+			'non-taxable fee is marked tax-exempt and loses its tax class' => array( false, 'reduced-rate', 'none', '' ),
+			'taxable fee keeps its taxable status and tax class'           => array( true, 'reduced-rate', 'taxable', 'reduced-rate' ),
+		);
+	}
+
+	/**
+	 * GIVEN a cart with no fees
+	 * WHEN configure_fees() runs via reflection
+	 * THEN no order item is added
+	 */
+	public function test_configure_fees_adds_no_items_when_cart_has_no_fees(): void {
+		$cart_data = new CartData( array(), array(), false, 0, 'cart-hash', array() );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'add_item' )->never();
+
+		$this->invoke_configure_fees( $this->create_order_creator(), $wc_order, $cart_data );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * GIVEN a cart with several fees, a surcharge and a discount
+	 * WHEN configure_fees() runs via reflection
+	 * THEN one order item is added per fee, each carrying its own total
+	 */
+	public function test_configure_fees_adds_an_item_for_every_cart_fee(): void {
+		$fees = array(
+			'cardSurcharge'   => array(
+				'id'        => 'cardSurcharge',
+				'name'      => 'Card surcharge',
+				'taxable'   => false,
+				'tax_class' => '',
+				'amount'    => '3',
+				'total'     => '3',
+				'tax'       => 0,
+				'tax_data'  => array(),
+			),
+			'loyaltyDiscount' => array(
+				'id'        => 'loyaltyDiscount',
+				'name'      => 'Loyalty discount',
+				'taxable'   => false,
+				'tax_class' => '',
+				'amount'    => '-12',
+				'total'     => '-12',
+				'tax'       => 0,
+				'tax_data'  => array(),
+			),
+		);
+
+		$cart_data = new CartData( array(), array(), false, 0, 'cart-hash', $fees );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$added_totals = array();
+		$wc_order->shouldReceive( 'add_item' )
+			->twice()
+			->with( Mockery::type( WC_Order_Item_Fee::class ) )
+			->andReturnUsing(
+				function ( $item ) use ( &$added_totals ): void {
+					$added_totals[] = $item->get_total();
+				}
+			);
+
+		expect( 'do_action' )->twice();
+
+		$this->invoke_configure_fees( $this->create_order_creator(), $wc_order, $cart_data );
+
+		$this->assertSame( array( '3', '-12' ), $added_totals );
+	}
+
+	/**
+	 * Builds a WooCommerceOrderCreator with all collaborators stubbed, so tests only
+	 * need to override the one dependency that matters for the case at hand.
+	 */
+	private function create_order_creator( ?SubscriptionHelper $subscription_helper = null ): WooCommerceOrderCreator {
+		return new WooCommerceOrderCreator(
+			Mockery::mock( FundingSourceRenderer::class ),
+			Mockery::mock( SessionHandler::class ),
+			$subscription_helper ?? Mockery::mock( SubscriptionHelper::class ),
+			Mockery::mock( CartDataFactory::class ),
+			Mockery::mock( ShippingFactory::class ),
+			Mockery::mock( PayerFactory::class )
+		);
+	}
+
+	/**
+	 * Invokes the protected configure_fees() method via reflection.
+	 */
+	private function invoke_configure_fees( WooCommerceOrderCreator $sut, WC_Order $wc_order, CartData $cart_data ): void {
+		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'configure_fees' );
+		$method->setAccessible( true );
+
+		$method->invoke( $sut, $wc_order, $cart_data );
 	}
 }

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -27,6 +27,7 @@ require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Response.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Controller.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_REST_Controller.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Product.php';
+require_once TESTS_ROOT_DIR . '/stubs/WC_Order_Item_Fee.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Coupon.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Discounts.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Countries.php';

--- a/tests/stubs/WC_Order_Item_Fee.php
+++ b/tests/stubs/WC_Order_Item_Fee.php
@@ -1,0 +1,59 @@
+<?php
+
+if ( ! class_exists( 'WC_Order_Item_Fee' ) ) {
+	/**
+	 * Minimal stand-in for the WooCommerce fee line item.
+	 *
+	 * The real WooCommerce classes are not loaded in this unit test environment, and
+	 * WooCommerceOrderCreator::configure_fees() instantiates WC_Order_Item_Fee directly
+	 * (it is not injected, so it cannot be swapped for a Mockery mock). This stub only
+	 * implements the setters/getters configure_fees() actually uses.
+	 */
+	class WC_Order_Item_Fee {
+		private string $name = '';
+		private string $amount = '0';
+		private string $total = '0';
+		private string $tax_status = '';
+		private string $tax_class = '';
+
+		public function set_name( string $name ): void {
+			$this->name = $name;
+		}
+
+		public function get_name(): string {
+			return $this->name;
+		}
+
+		public function set_amount( string $amount ): void {
+			$this->amount = $amount;
+		}
+
+		public function get_amount(): string {
+			return $this->amount;
+		}
+
+		public function set_total( string $total ): void {
+			$this->total = $total;
+		}
+
+		public function get_total(): string {
+			return $this->total;
+		}
+
+		public function set_tax_status( string $tax_status ): void {
+			$this->tax_status = $tax_status;
+		}
+
+		public function get_tax_status(): string {
+			return $this->tax_status;
+		}
+
+		public function set_tax_class( string $tax_class ): void {
+			$this->tax_class = $tax_class;
+		}
+
+		public function get_tax_class(): string {
+			return $this->tax_class;
+		}
+	}
+}


### PR DESCRIPTION
### Description

On the express-checkout paths that build the WooCommerce order directly from the approved PayPal order - Google Pay and Apple Pay on the block checkout, and any express button on the cart or product page, whenever Pay Now is enabled - a cart fee was silently dropped from the created order. `WooCommerceOrderCreator` copied line items, shipping and coupons, but never fees.

The buyer still approved the correct, fee-inclusive amount in the wallet sheet, but the order that got built and charged was off by the fee: undercharged for a surcharge, overcharged for a negative fee. Confirmed live with a -12 fee: the buyer approved 98.00 in the Google Pay sheet and was charged 110.00.

`configure_fees()` now mirrors `WC_Checkout::create_order_fee_lines()`, adding a `WC_Order_Item_Fee` per cart fee and firing the same `woocommerce_checkout_create_order_fee_item` action third-party plugins already rely on. `CartData` carries the fees through its snapshot via an optional constructor argument, so existing callers and stored snapshots are unaffected. The snapshot falls back to the `ppcp_fees` session cache when the cart wasn't recalculated this request (the same source the PayPal purchase unit's own line items are built from), since a session-restored cart carries its fee totals but not the fees themselves.

Not tested under multisite.

### Steps to Test

Requires Pay Now enabled, since that determines whether this class or WooCommerce itself builds the order.

1. Add a cart fee via `woocommerce_cart_calculate_fees`, e.g. `$cart->add_fee( 'testFee', -12, false );`.
2. Add a physical product to the cart and go to the block checkout. Confirm the fee shows in the order summary and the total reflects it.
3. Click an express button (Google Pay or Apple Pay) and approve.
4. Check the created order: it should have a fee line item, and its total should match what was shown at checkout.
5. Regression: repeat with Pay Now disabled. The order is built by WooCommerce as before and should be unaffected.
6. Regression: repeat with a positive fee (e.g. a surcharge) to confirm the merchant is no longer undercharged either.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: Cart fees are no longer dropped from the order when paying with an express button (Google Pay, Apple Pay) on the block checkout, or from the cart/product page, with Pay Now enabled.
