### PR TITLE
Free trial subscription - PayPal gateway is missing on block checkout and PayPal button is missing on classic checkout (6853)

### DIFF
--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -248,17 +248,19 @@ if ( config && config.page_context && config.continuation ) {
 					return false;
 				}
 
-				// A $0 free-trial subscription is vaulted through the PayPal
-				// save flow (see V6ExpressComponent), which the amount-based
-				// eligibility check would reject for a zero amount. Only PayPal
-				// is offered on such carts (see FUNDING_SOURCES above), so guard
-				// on it; mirrors boot.js, which bypasses eligibility too.
-				if ( config.is_free_trial_cart ) {
-					return fundingSource === FundingSources.PAYPAL;
-				}
-
 				const amount =
 					amountFromCartTotals( cartTotals ) || config.amount;
+
+				// A free-trial ($0) subscription is vaulted through the PayPal
+				// save flow (see V6ExpressComponent), which the amount-based
+				// eligibility check would reject for a zero amount. Only PayPal
+				// is offered on such carts, so guard on it and bypass eligibility
+				// (mirrors boot.js). Read live from the amount, not the server's
+				// page-load flag, so a coupon that zeroes or un-zeroes the cart
+				// after render is honoured.
+				if ( isFreeTrialCart( config, amount ) ) {
+					return fundingSource === FundingSources.PAYPAL;
+				}
 
 				// Before the SDK is asked, so a cart that only PayPal can pay
 				// for costs no eligibility lookup for the other methods.

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -232,6 +232,15 @@ if ( config && config.page_context && config.continuation ) {
 					return false;
 				}
 
+				// A $0 free-trial subscription is vaulted through the PayPal
+				// save flow (see V6ExpressComponent), which the amount-based
+				// eligibility check would reject for a zero amount. Only PayPal
+				// is offered on such carts (see FUNDING_SOURCES above), so guard
+				// on it; mirrors boot.js, which bypasses eligibility too.
+				if ( config.is_free_trial_cart ) {
+					return fundingSource === FundingSources.PAYPAL;
+				}
+
 				const amount =
 					amountFromCartTotals( cartTotals ) || config.amount;
 				const eligibility = await getEligibility( amount );

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -13,8 +13,14 @@ jest.mock(
 	{ virtual: true }
 );
 
-jest.mock( '../sdkLoader', () => ( { loadSdkV6: jest.fn() } ) );
-jest.mock( '../eligibility', () => ( { checkEligibility: jest.fn() } ) );
+const mockLoadSdkV6 = jest.fn();
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+const mockCheckEligibility = jest.fn();
+jest.mock( '../eligibility', () => ( {
+	checkEligibility: ( ...args ) => mockCheckEligibility( ...args ),
+} ) );
 jest.mock( '../utils/errorHandler', () => ( { setErrorLabels: jest.fn() } ) );
 jest.mock( '../blocks/V6ExpressComponent', () => ( {
 	V6ExpressComponent: () => null,
@@ -166,5 +172,42 @@ describe( 'checkout-block', () => {
 				'ppcp_continuation',
 			] );
 		} );
+	} );
+
+	describe( 'PayPal express canMakePayment()', () => {
+		const cartTotals = { total_price: '0', currency_minor_unit: 2 };
+
+		test( 'resolves to true on a free-trial cart without checking eligibility', async () => {
+			loadCheckoutBlock( baseConfig( { is_free_trial_cart: true } ) );
+
+			const { canMakePayment } = expressCallFor( 'ppcp-gateway-paypal' );
+
+			await expect( canMakePayment( { cartTotals } ) ).resolves.toBe(
+				true
+			);
+			expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+			expect( mockCheckEligibility ).not.toHaveBeenCalled();
+		} );
+
+		test.each( [
+			[ { paypal: true }, true ],
+			[ { paypal: false }, false ],
+		] )(
+			'on a non-free-trial cart, resolves to %s when eligibility reports %s',
+			async ( eligibility, expected ) => {
+				mockLoadSdkV6.mockResolvedValue( {} );
+				mockCheckEligibility.mockResolvedValue( eligibility );
+				loadCheckoutBlock( baseConfig() );
+
+				const { canMakePayment } = expressCallFor(
+					'ppcp-gateway-paypal'
+				);
+
+				await expect(
+					canMakePayment( { cartTotals } )
+				).resolves.toBe( expected );
+				expect( mockCheckEligibility ).toHaveBeenCalled();
+			}
+		);
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -1,6 +1,3 @@
-import { loadSdkV6 } from '../sdkLoader';
-import { checkEligibility } from '../eligibility';
-
 const mockRegisterExpressPaymentMethod = jest.fn();
 const mockRegisterPaymentMethod = jest.fn();
 // virtual: webpack resolves this to the wc.wcBlocksRegistry global, so there is
@@ -218,8 +215,8 @@ describe( 'checkout-block', () => {
 		};
 
 		beforeEach( () => {
-			loadSdkV6.mockResolvedValue( {} );
-			checkEligibility.mockResolvedValue( eligibleForEveryMethod );
+			mockLoadSdkV6.mockResolvedValue( {} );
+			mockCheckEligibility.mockResolvedValue( eligibleForEveryMethod );
 		} );
 
 		test( 'a cart that became $0 after page load is a free trial even though the server said it was not', async () => {
@@ -439,7 +436,12 @@ describe( 'checkout-block', () => {
 		const cartTotals = { total_price: '0', currency_minor_unit: 2 };
 
 		test( 'resolves to true on a free-trial cart without checking eligibility', async () => {
-			loadCheckoutBlock( baseConfig( { is_free_trial_cart: true } ) );
+			loadCheckoutBlock(
+				baseConfig( {
+					is_free_trial_cart: true,
+					cart_needs_vaulting: true,
+				} )
+			);
 
 			const { canMakePayment } = expressCallFor( 'ppcp-gateway-paypal' );
 

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -193,7 +193,7 @@ describe( 'checkout-block', () => {
 			[ { paypal: true }, true ],
 			[ { paypal: false }, false ],
 		] )(
-			'on a non-free-trial cart, resolves to %s when eligibility reports %s',
+			'on a non-free-trial cart, eligibility %s resolves to %s',
 			async ( eligibility, expected ) => {
 				mockLoadSdkV6.mockResolvedValue( {} );
 				mockCheckEligibility.mockResolvedValue( eligibility );

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -307,12 +307,19 @@ class SdkV6Manager {
 
 		$needs_payment = $this->cart_needs_payment();
 
+		// A free-trial ($0) subscription cart needs no one-time payment, so
+		// $needs_payment is false, but the checkout still needs the PayPal
+		// save-without-purchase button (boot.js renders it for the checkout /
+		// pay-now contexts only). Confined to checkout: the cart and mini-cart
+		// have no form to submit the vaulted token with.
+		$free_trial_checkout = $this->free_trial_helper->is_free_trial_cart();
+
 		// pay-now is driven by the existing WC order rather than the cart, so
 		// the zero-total guard does not apply to it.
 		return array(
 			'product'   => $this->settings_status->is_smart_button_enabled_for_location( 'product' ),
 			'cart'      => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'cart' ),
-			'checkout'  => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'checkout' ),
+			'checkout'  => ( $needs_payment || $free_trial_checkout ) && $this->settings_status->is_smart_button_enabled_for_location( 'checkout' ),
 			'pay-now'   => $this->settings_status->is_smart_button_enabled_for_location( 'pay-now' ),
 			'mini-cart' => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' ),
 		);
@@ -321,8 +328,10 @@ class SdkV6Manager {
 	/**
 	 * Whether the current cart still needs payment.
 	 *
-	 * Keeps buttons off $0 orders (a full-value coupon, a free trial), where no
-	 * payment method should be offered at all.
+	 * Keeps buttons off $0 orders (a full-value coupon), where no payment method
+	 * should be offered at all. A free-trial subscription cart is $0 too but is
+	 * handled separately in determine_render_places(), since it still needs the
+	 * PayPal save-without-purchase button on the checkout.
 	 */
 	private function cart_needs_payment(): bool {
 		$cart = WC()->cart;

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -328,6 +328,46 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
+     * GIVEN a subscription cart on a free trial ($0 today), which therefore needs no
+     *       one-time payment
+     * WHEN determining which locations should render on the current page
+     * THEN the checkout still renders, because it must offer the PayPal
+     *      save-without-purchase button for the vaulted token backing the future
+     *      recurring payment
+     * AND the cart and mini-cart stay suppressed regardless of the free-trial flag,
+     *     since neither has a form to submit that vaulted token from
+     * AND a $0 cart that is NOT a free trial (e.g. a full-value coupon) keeps the
+     *     checkout suppressed too, same as before the fix
+     *
+     * @dataProvider free_trial_checkout_provider
+     */
+    public function testDetermineRenderPlacesCheckoutOnFreeTrialCart(bool $needs_payment, bool $is_free_trial_cart, bool $expected_checkout): void
+    {
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(true);
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn($is_free_trial_cart);
+
+        $cart = Mockery::mock();
+        $cart->shouldReceive('needs_payment')->andReturn($needs_payment);
+        when('WC')->justReturn((object) ['cart' => $cart]);
+
+        $testee = $this->createTestee();
+        $result = $testee->determine_render_places();
+
+        $this->assertSame($expected_checkout, $result['checkout']);
+        $this->assertSame($needs_payment, $result['cart']);
+        $this->assertSame($needs_payment, $result['mini-cart']);
+    }
+
+    public function free_trial_checkout_provider(): array
+    {
+        return [
+            'free-trial cart needing no payment still enables checkout' => [false, true, true],
+            'zero-total non-free-trial cart keeps checkout suppressed'  => [false, false, false],
+            'ordinary cart needing payment enables checkout regardless of free trial' => [true, false, true],
+        ];
+    }
+
+    /**
      * GIVEN the mini-cart smart button location is enabled sitewide
      * WHEN checking whether the v6 SDK should load on a page with no matching page context
      *      (e.g. the shop or home page, where a block Mini-Cart may still appear)


### PR DESCRIPTION
For free-trial subscriptions (initial cart total $0) with SDK v6 active, the PayPal gateway was missing on block checkout and the PayPal button was missing on classic checkout. v6's zero-total gating treated these carts as "no payment needed", even though they still require the PayPal save-without-purchase (vaulting) flow.

Solution: Carved free-trial subscription carts out of v6's zero-total gating in two places:                                                                                                
  - Classic: `SdkV6Manager::determine_render_places()` now renders the checkout button wrapper for free-trial carts (previously gated on `cart->needs_payment()`, which is false at $0).         
  - Block: the express `canMakePayment` in `checkout-block.js` now short-circuits to allow PayPal on free-trial carts, instead of running the amount-based eligibility check that rejects a $0 amount.         