### PR TITLE
fix(googlepay,applepay): stand down on block pages the v6 SDK owns

### DIFF
--- a/modules/ppcp-applepay/resources/js/Block/hooks/usePayPalScript.js
+++ b/modules/ppcp-applepay/resources/js/Block/hooks/usePayPalScript.js
@@ -4,7 +4,11 @@ import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
 const usePayPalScript = ( namespace, ppcpConfig ) => {
 	const [ isPayPalLoaded, setIsPayPalLoaded ] = useState( false );
 
-	ppcpConfig.url_params.components += ',applepay';
+	// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+	// there and localizes no script data.
+	if ( ppcpConfig.url_params ) {
+		ppcpConfig.url_params.components += ',applepay';
+	}
 
 	useEffect( () => {
 		const loadScript = async () => {

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -36,7 +36,11 @@ const ApplePayComponent = ( { isEditing, buttonAttributes } ) => {
 			setApplePayLoaded( true );
 		} );
 
-		ppcpConfig.url_params.components += ',applepay';
+		// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+		// there and localizes no script data.
+		if ( ppcpConfig.url_params ) {
+			ppcpConfig.url_params.components += ',applepay';
+		}
 
 		// Load PayPal
 		loadPayPalScript( namespace, ppcpConfig )

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -171,7 +171,20 @@ return array(
 			$container->get( 'applepay.button' ),
 			$container->get( 'blocks.method' ),
 			$container->get( 'button.helper.context' ),
-			$container->get( 'settings.settings-provider' )
+			$container->get( 'settings.settings-provider' ),
+			/**
+			 * The v6 module is feature-flagged and may not be loaded, hence the has()
+			 * guard. Resolved on each call so it reflects the page being rendered.
+			 */
+			static function () use ( $container ): bool {
+				if ( ! $container->has( 'sdk-v6.owns-current-page' ) ) {
+					return false;
+				}
+
+				$owns_current_page = $container->get( 'sdk-v6.owns-current-page' );
+
+				return $owns_current_page();
+			}
 		);
 	},
 

--- a/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
@@ -25,6 +25,13 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private Context $context;
 	private SettingsProvider $settings_provider;
 
+	/**
+	 * Answers whether the SDK v6 module renders the PayPal stack on the current page.
+	 *
+	 * @var (callable():bool)|null
+	 */
+	private $v6_owns_current_page;
+
 	public function __construct(
 		string $name,
 		AssetGetter $asset_getter,
@@ -32,7 +39,8 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		ButtonInterface $button,
 		PaymentMethodTypeInterface $paypal_payment_method,
 		Context $context,
-		SettingsProvider $settings_provider
+		SettingsProvider $settings_provider,
+		?callable $v6_owns_current_page = null
 	) {
 		$this->name                  = $name;
 		$this->asset_getter          = $asset_getter;
@@ -41,11 +49,21 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		$this->paypal_payment_method = $paypal_payment_method;
 		$this->context               = $context;
 		$this->settings_provider     = $settings_provider;
+		$this->v6_owns_current_page  = $v6_owns_current_page;
 	}
 
 	public function initialize() {  }
 
 	public function is_active(): bool {
+		/*
+		 * On a page the v6 SDK owns, the v5 smart button is swapped for a disabled
+		 * one whose script data is empty, and this block bundle reads that data
+		 * expecting the v5 shape. v6 renders Apple Pay on those pages itself.
+		 */
+		if ( is_callable( $this->v6_owns_current_page ) && ( $this->v6_owns_current_page )() ) {
+			return false;
+		}
+
 		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
 
 		if ( ! in_array( ApplePayGateway::ID, $methods, true ) ) {

--- a/modules/ppcp-googlepay/resources/js/Block/hooks/usePayPalScript.js
+++ b/modules/ppcp-googlepay/resources/js/Block/hooks/usePayPalScript.js
@@ -4,7 +4,11 @@ import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
 const usePayPalScript = ( namespace, ppcpConfig ) => {
 	const [ isPayPalLoaded, setIsPayPalLoaded ] = useState( false );
 
-	ppcpConfig.url_params.components += ',googlepay';
+	// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+	// there and localizes no script data.
+	if ( ppcpConfig.url_params ) {
+		ppcpConfig.url_params.components += ',googlepay';
+	}
 
 	useEffect( () => {
 		const loadScript = async () => {

--- a/modules/ppcp-googlepay/resources/js/boot-block.js
+++ b/modules/ppcp-googlepay/resources/js/boot-block.js
@@ -29,7 +29,11 @@ const GooglePayComponent = ( { isEditing, buttonAttributes, onClick } ) => {
 				setGooglePayLoaded( true );
 			} );
 
-			ppcpConfig.url_params.components += ',googlepay';
+			// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+			// there and localizes no script data.
+			if ( ppcpConfig.url_params ) {
+				ppcpConfig.url_params.components += ',googlepay';
+			}
 
 			loadPayPalScript( namespace, ppcpConfig )
 				.then( () => {

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -202,7 +202,20 @@ return array(
 			$container->get( 'googlepay.button' ),
 			$container->get( 'blocks.method' ),
 			$container->get( 'button.helper.context' ),
-			$container->get( 'settings.settings-provider' )
+			$container->get( 'settings.settings-provider' ),
+			/**
+			 * The v6 module is feature-flagged and may not be loaded, hence the has()
+			 * guard. Resolved on each call so it reflects the page being rendered.
+			 */
+			static function () use ( $container ): bool {
+				if ( ! $container->has( 'sdk-v6.owns-current-page' ) ) {
+					return false;
+				}
+
+				$owns_current_page = $container->get( 'sdk-v6.owns-current-page' );
+
+				return $owns_current_page();
+			}
 		);
 	},
 

--- a/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
@@ -25,6 +25,13 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private Context $context;
 	private SettingsProvider $settings_provider;
 
+	/**
+	 * Answers whether the SDK v6 module renders the PayPal stack on the current page.
+	 *
+	 * @var (callable():bool)|null
+	 */
+	private $v6_owns_current_page;
+
 	public function __construct(
 		string $name,
 		AssetGetter $asset_getter,
@@ -32,7 +39,8 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		ButtonInterface $button,
 		PaymentMethodTypeInterface $paypal_payment_method,
 		Context $context,
-		SettingsProvider $settings_provider
+		SettingsProvider $settings_provider,
+		?callable $v6_owns_current_page = null
 	) {
 		$this->name                  = $name;
 		$this->asset_getter          = $asset_getter;
@@ -41,11 +49,21 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		$this->paypal_payment_method = $paypal_payment_method;
 		$this->context               = $context;
 		$this->settings_provider     = $settings_provider;
+		$this->v6_owns_current_page  = $v6_owns_current_page;
 	}
 
 	public function initialize() {  }
 
 	public function is_active() {
+		/*
+		 * On a page the v6 SDK owns, the v5 smart button is swapped for a disabled
+		 * one whose script data is empty, and this block bundle reads that data
+		 * expecting the v5 shape. v6 renders Google Pay on those pages itself.
+		 */
+		if ( is_callable( $this->v6_owns_current_page ) && ( $this->v6_owns_current_page )() ) {
+			return false;
+		}
+
 		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
 
 		if ( ! in_array( GooglePayGateway::ID, $methods, true ) ) {


### PR DESCRIPTION
### Description

With the v6 SDK active and Google Pay enabled for block pages in the Styling tab, the express checkout area on the block cart/checkout rendered **empty** - no buttons at all, not just a missing Google Pay one.

On a page v6 owns, `button.smart-button` is swapped for `DisabledSmartButton`, whose `script_data()` returns an empty array. Google Pay's v5 block bundle still registered there and appended its funding source to `ppcpConfig.url_params` unconditionally, so it threw `Cannot read properties of undefined (reading 'components')` from inside a React effect, taking the surrounding express block down with it.

`GooglepayModule` already stands down on v6-owned pages for the classic container (`v6_owns_current_page()`); the blocks registration was simply missed. `BlocksPaymentMethod::is_active()` now applies the same guard, so the bundle is never enqueued there.

This removes a *duplicate* registration rather than a button: v6 registers both wallets on those pages itself, under the identical `ppcp-googlepay` / `ppcp-applepay` method names, so before this the two stacks were also competing for one registration.

Apple Pay carries the same unguarded read and is fixed identically - it fails the same way as soon as its button is enabled for block pages. The four read sites also now tolerate absent script data, as defence in depth.

**Backward compatibility.** Both `BlocksPaymentMethod` constructors gained an **optional** trailing `?callable` argument, so existing construction is unaffected. The behaviour change is intended: these block methods report inactive on v6-owned pages.

Not tested under multisite.

### Steps to Test

Requires the v6 SDK active and a block cart/checkout page (a block theme is not itself the trigger - the Cart/Checkout blocks are, which a classic theme can also use).

1. Enable Google Pay for the block locations in the Styling tab.
2. Add a product to the cart and open the block checkout with the browser console open.
3. On `dev/develop`: the Express Checkout area is empty and the console shows `Cannot read properties of undefined (reading 'components')`.
4. On this branch: exactly one Google Pay button renders, from v6, with no console error. Complete a payment to confirm the flow still works.
5. Repeat steps 1-4 with Apple Pay.
6. Regression, classic checkout: Google Pay and Apple Pay still render and pay as before.
7. Regression, v6 disabled: the v5 block bundles load and behave as before on block pages.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: Express checkout buttons no longer disappear on block cart and checkout pages when the v6 SDK is active and Google Pay or Apple Pay is enabled for those pages.
