### PR TITLE
Variable product smart buttons stay enabled with unselected attributes - SDK v6 (6868)

### DIFF
--- a/modules/ppcp-sdk-v6/resources/css/gateway.scss
+++ b/modules/ppcp-sdk-v6/resources/css/gateway.scss
@@ -22,3 +22,20 @@
 		width: 100%;
 	}
 }
+
+// Gating the express stack until the product form is ready to be purchased
+// (e.g. a variable product with no variation selected). The wrapper carries
+// this class from ButtonDisabler; the grayscale dims the whole stack and
+// pointer-events blocks every button so the click lands on the wrapper, whose
+// handler routes it to WooCommerce's native "select your options" validation.
+// v5 ships the same rule in ppcp-button's gateway.css, but that stylesheet is
+// not enqueued on v6 pages, so it is repeated here for the v6 stack.
+.ppcp-disabled {
+	cursor: not-allowed;
+	-webkit-filter: grayscale(100%);
+	filter: grayscale(100%);
+
+	* {
+		pointer-events: none;
+	}
+}

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -31,6 +31,7 @@ import { initCardFields } from './cardFields/renderer';
 import { initCardButton } from './cardButton/renderCardButton';
 import { hasJQuery } from './utils/api';
 import { watchViewedTotal } from './utils/viewedTotal';
+import { initProductButtonGate } from './utils/productButtonGate';
 import { setErrorLabels } from './utils/errorHandler';
 import { isFreeTrialCart } from './utils/freeTrial';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
@@ -452,6 +453,7 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 		initCardButtonSafely();
 		initMessagesSafely();
 		trackProductTotal();
+		initProductButtonGate( config );
 		syncPlaceOrderButton();
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
@@ -73,6 +73,11 @@ jest.mock( '../utils/viewedTotal', () => ( {
 	watchViewedTotal: ( ...args ) => mockWatchViewedTotal( ...args ),
 } ) );
 
+const mockInitProductButtonGate = jest.fn();
+jest.mock( '../utils/productButtonGate', () => ( {
+	initProductButtonGate: ( ...args ) => mockInitProductButtonGate( ...args ),
+} ) );
+
 const WRAPPER_SELECTOR = '#ppcp-button-checkout';
 const MINI_CART_WRAPPER_SELECTOR = '#ppcp-mini-cart-button';
 
@@ -334,6 +339,9 @@ describe( 'boot', () => {
 			expect( mockWatchViewedTotal ).toHaveBeenCalledWith(
 				expect.objectContaining( { page_context: 'product' } ),
 				'product'
+			);
+			expect( mockInitProductButtonGate ).toHaveBeenCalledWith(
+				expect.objectContaining( { page_context: 'product' } )
 			);
 
 			notify( '42.00' );

--- a/modules/ppcp-sdk-v6/resources/js/test/productButtonGate.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/productButtonGate.test.js
@@ -1,0 +1,334 @@
+import jQuery from 'jquery';
+
+const mockHasJQuery = jest.fn( () => true );
+jest.mock( '../utils/api', () => ( {
+	hasJQuery: () => mockHasJQuery(),
+} ) );
+
+jest.mock( '../endpointsAdapter', () => ( {
+	// Not stubbed: it only reads the DOM the fixtures below build, and the
+	// selector pair it uses must live in one place.
+	productForm: jest.requireActual( '../endpointsAdapter' ).productForm,
+} ) );
+
+import {
+	initProductButtonGate,
+	resetProductButtonGate,
+} from '../utils/productButtonGate';
+
+const WRAPPER_ID = 'ppc-button-ppcp-gateway-v6';
+const WRAPPER_SELECTOR = `#${ WRAPPER_ID }`;
+
+const baseConfig = ( overrides = {} ) => ( {
+	page_context: 'product',
+	wrapper: WRAPPER_SELECTOR,
+	...overrides,
+} );
+
+/**
+ * Builds a classic product form plus its native add-to-cart button and the
+ * express-button wrapper this gate controls.
+ *
+ * The add-to-cart button is deliberately `type="button"`, not `type="submit"`,
+ * so it never itself matches the `:submit` selector the gate's mouseup handler
+ * clicks — keeping the "did the native submit get triggered" assertions
+ * unambiguous.
+ *
+ * @param {Object}  options
+ * @param {boolean} options.hasAddToCartButton
+ * @param {boolean} options.disabled
+ * @return {HTMLFormElement} The rendered product form.
+ */
+function buildDom( { hasAddToCartButton = true, disabled = false } = {} ) {
+	const addToCartButtonHtml = hasAddToCartButton
+		? `<button type="button" class="single_add_to_cart_button${
+				disabled ? ' disabled' : ''
+		  }"></button>`
+		: '';
+
+	document.body.innerHTML = `
+		<form class="cart variations_form">
+			<input name="add-to-cart" value="1" />
+			${ addToCartButtonHtml }
+			<button type="submit" class="submit-trigger"></button>
+		</form>
+		<div id="${ WRAPPER_ID }"></div>
+	`;
+
+	return document.querySelector( 'form' );
+}
+
+function wrapperEl() {
+	return document.querySelector( WRAPPER_SELECTOR );
+}
+
+/**
+ * Attaches a spy to the form's native submit trigger and returns it, so tests
+ * can assert whether the gate's mouseup handler routed a click to it.
+ *
+ * @param {HTMLFormElement} form
+ * @return {jest.Mock}
+ */
+function spyOnSubmit( form ) {
+	const spy = jest.fn();
+	form.querySelector( '.submit-trigger' ).addEventListener( 'click', spy );
+	return spy;
+}
+
+// jsdom's internal form-submission algorithm (run when a submit button's
+// default click action fires) hits an unimplemented path and throws. Every
+// test in this file that fires a wrapper mouseup while disabled ends up
+// clicking the form's :submit control, so the real submission is cancelled
+// globally by capturing the submit event itself, rather than in only the
+// tests that happen to spy on the click.
+const preventSubmit = ( event ) => event.preventDefault();
+
+beforeEach( () => {
+	mockHasJQuery.mockReturnValue( true );
+	global.jQuery = jQuery;
+	document.addEventListener( 'submit', preventSubmit, true );
+} );
+
+afterEach( () => {
+	resetProductButtonGate();
+	document.body.innerHTML = '';
+	delete global.jQuery;
+	document.removeEventListener( 'submit', preventSubmit, true );
+} );
+
+describe( 'initProductButtonGate()', () => {
+	describe( 'page_context guard', () => {
+		test.each( [ 'checkout', 'cart', 'mini-cart', undefined ] )(
+			'does nothing when page_context is %s',
+			( pageContext ) => {
+				const form = buildDom( { disabled: true } );
+
+				initProductButtonGate(
+					baseConfig( { page_context: pageContext } )
+				);
+
+				expect(
+					wrapperEl().classList.contains( 'ppcp-disabled' )
+				).toBe( false );
+
+				// No listeners were attached: toggling the button and firing
+				// the events the gate would otherwise react to changes nothing.
+				form
+					.querySelector( '.single_add_to_cart_button' )
+					.classList.remove( 'disabled' );
+				form.dispatchEvent( new Event( 'change' ) );
+
+				expect(
+					wrapperEl().classList.contains( 'ppcp-disabled' )
+				).toBe( false );
+			}
+		);
+	} );
+
+	describe( 'initial gating decision', () => {
+		test( 'adds ppcp-disabled to the wrapper when the add-to-cart button is disabled', () => {
+			buildDom( { disabled: true } );
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+		} );
+
+		test( 'leaves the wrapper enabled when the add-to-cart button is not disabled', () => {
+			buildDom( { disabled: false } );
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+
+		test( 'leaves the wrapper enabled when the form has no classic add-to-cart button (simple product)', () => {
+			buildDom( { hasAddToCartButton: false } );
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+
+		test( 'does nothing when the page has no product form', () => {
+			document.body.innerHTML = `<div id="${ WRAPPER_ID }"></div>`;
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+	} );
+
+	describe( 'mouseup on a disabled wrapper', () => {
+		test( 'routes the click to the form\'s native submit', () => {
+			const form = buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			const submitSpy = spyOnSubmit( form );
+
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'stops immediate propagation so no other handler on the wrapper receives it', () => {
+			buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			const wrapper = wrapperEl();
+			const laterListener = jest.fn();
+			wrapper.addEventListener( 'mouseup', laterListener );
+
+			wrapper.dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( laterListener ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does not submit the form when the wrapper is enabled', () => {
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+			const submitSpy = spyOnSubmit( form );
+
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'transition guard against stacking mouseup handlers', () => {
+		/**
+		 * Regression test: disable() binds a fresh mouseup handler on every
+		 * call, so re-running it without an intervening enable() would stack
+		 * handlers and submit the form once per stacked handler.
+		 */
+		test( 'a burst of sync triggers while the button stays disabled still results in exactly one submit per click', () => {
+			const form = buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			form.dispatchEvent( new Event( 'change' ) );
+			form.dispatchEvent( new Event( 'change' ) );
+
+			const submitSpy = spyOnSubmit( form );
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'calling init again for the same page does not attach a second set of listeners', () => {
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+			initProductButtonGate( baseConfig() );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.add( 'disabled' );
+			form.dispatchEvent( new Event( 'change' ) );
+			form.dispatchEvent( new Event( 'change' ) );
+
+			const submitSpy = spyOnSubmit( form );
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 're-enabling once the button stops being disabled', () => {
+		test( 'removes ppcp-disabled from the wrapper and stops routing clicks to the native submit', () => {
+			const form = buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.remove( 'disabled' );
+			form.dispatchEvent( new Event( 'change' ) );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+
+			const submitSpy = spyOnSubmit( form );
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'MutationObserver on the add-to-cart button', () => {
+		test( 're-syncs the wrapper when WooCommerce toggles the disabled class', async () => {
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.add( 'disabled' );
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'jQuery variation events', () => {
+		test.each( [ 'found_variation', 'reset_data' ] )(
+			'a %s event on the form re-syncs the wrapper',
+			( eventName ) => {
+				const form = buildDom( { disabled: false } );
+				initProductButtonGate( baseConfig() );
+
+				form
+					.querySelector( '.single_add_to_cart_button' )
+					.classList.add( 'disabled' );
+				jQuery( form ).trigger( eventName );
+
+				expect(
+					wrapperEl().classList.contains( 'ppcp-disabled' )
+				).toBe( true );
+			}
+		);
+
+		test( 'is not wired up when hasJQuery() reports jQuery is unavailable', () => {
+			mockHasJQuery.mockReturnValue( false );
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.add( 'disabled' );
+			jQuery( form ).trigger( 'found_variation' );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/utils/productButtonGate.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/productButtonGate.js
@@ -1,0 +1,101 @@
+/**
+ * Gates the product-page express buttons behind the native add-to-cart state.
+ *
+ * When WooCommerce disables `.single_add_to_cart_button` (e.g. a variable
+ * product with no variation chosen), this mirrors v5's SingleProductBootstrap
+ * via the shared ButtonDisabler: it disables the wrapper so a click surfaces
+ * WooCommerce's own validation instead of reaching ppc-change-cart.
+ *
+ * @package
+ */
+
+import { disable, enable, isDisabled } from '@ppcp-button/Helper/ButtonDisabler';
+import { productForm } from '../endpointsAdapter';
+import { hasJQuery } from './api';
+
+// The native submit whose disabled state WooCommerce drives from the variation
+// selection. Its absence marks a non-classic form (e.g. the block add-to-cart),
+// which this gate deliberately leaves alone.
+const ADD_TO_CART_SELECTOR = '.single_add_to_cart_button';
+
+// Attached once per page, however many times init is called.
+let initialized = false;
+let buttonObserver = null;
+
+/**
+ * Resets module state. Test seam only.
+ */
+export function resetProductButtonGate() {
+	initialized = false;
+	if ( buttonObserver ) {
+		buttonObserver.disconnect();
+		buttonObserver = null;
+	}
+}
+
+/**
+ * Starts gating the product-page express buttons.
+ *
+ * No-ops off product pages and on forms without a classic add-to-cart button,
+ * so it is safe to call unconditionally.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ */
+export function initProductButtonGate( config ) {
+	if ( 'product' !== config?.page_context || initialized ) {
+		return;
+	}
+
+	const form = productForm();
+	if ( ! form ) {
+		return;
+	}
+
+	// A missing button is treated as "enabled", not as a reason to bail: a simple
+	// product still has one and must stay live, and only a classic form carries
+	// this selector, which scopes the gate to classic themes.
+	const addToCartButton = form.querySelector( ADD_TO_CART_SELECTOR );
+
+	const shouldEnable = () => {
+		// Re-queried each time: WooCommerce can re-render the button.
+		const button = form.querySelector( ADD_TO_CART_SELECTOR );
+		return ! button || ! button.classList.contains( 'disabled' );
+	};
+
+	const sync = () => {
+		const wrapper = document.querySelector( config.wrapper );
+		if ( ! wrapper ) {
+			return;
+		}
+
+		const enableNow = shouldEnable();
+		const wasDisabled = isDisabled( wrapper );
+
+		// Only act on a transition: disable() binds a fresh mouseup handler each
+		// call, so calling it twice without an intervening enable() would stack
+		// handlers and submit the form more than once.
+		if ( enableNow && wasDisabled ) {
+			enable( wrapper );
+		} else if ( ! enableNow && ! wasDisabled ) {
+			disable( wrapper, form );
+		}
+	};
+
+	initialized = true;
+
+	sync();
+
+	if ( addToCartButton ) {
+		buttonObserver = new MutationObserver( sync );
+		buttonObserver.observe( addToCartButton, { attributes: true } );
+	}
+
+	// Covers quantity changes and the attribute selects.
+	form.addEventListener( 'change', sync );
+
+	if ( hasJQuery() ) {
+		// WooCommerce fills variation_id and flips the add-to-cart button only
+		// after these fire, so the change event above can run a beat too early.
+		jQuery( form ).on( 'found_variation reset_data', sync );
+	}
+}


### PR DESCRIPTION
On classic variable-product pages with PayPal SDK v6, the express buttons (PayPal/Venmo/Pay Later/Google Pay) rendered fully enabled even when no variation was selected and "Add to cart" was disabled. The v6 bootstrap had no equivalent of v5's `SingleProductBootstrap` gating, and the v6 stylesheet (its own `gateway.css`, not ppcp-button's) lacked the `.ppcp-disabled` rule.                   
                                                                                                                                                                                             
This PR adds a small `productButtonGate` module that, on product pages, watches the native `.single_add_to_cart_button` state and toggles the wrapper's disabled state via the shared `ButtonDisabler`, dimming the buttons and routing a click to WooCommerce's own validation. Also added the missing `.ppcp-disabled` rule to the v6 stylesheet so the dimming and click-blocking actually apply. 