### PR TITLE
Fix webhook registration authenticating with a placeholder token right after onboarding (6878)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\ResolvingBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\ClientCredentials;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\ConnectBearer;
@@ -105,6 +106,23 @@ return array(
 	},
 	'api.host-resolver'                              => static function ( ContainerInterface $container ): ApiHostResolver {
 		return new ApiHostResolver( $container->get( 'settings.connection-state' ) );
+	},
+	/**
+	 * Scoped the same way as api.host-resolver; see ResolvingBearer's class
+	 * docblock for the rationale. The shared api.bearer service below is
+	 * intentionally left untouched.
+	 */
+	'api.bearer-resolver'                            => static function ( ContainerInterface $container ): ResolvingBearer {
+		return new ResolvingBearer(
+			$container->get( 'settings.connection-state' ),
+			$container->get( 'api.paypal-bearer-cache' ),
+			$container->get( 'api.host-resolver' ),
+			$container->get( 'api.key' ),
+			$container->get( 'api.secret' ),
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'settings.settings-provider' ),
+			$container->get( 'api.token-rate-limiter' )
+		);
 	},
 	'api.paypal-host'                                => function ( ContainerInterface $container ): string {
 		return PAYPAL_API_URL;
@@ -219,7 +237,7 @@ return array(
 	'api.endpoint.webhook'                           => static function ( ContainerInterface $container ): WebhookEndpoint {
 		return new WebhookEndpoint(
 			$container->get( 'api.host-resolver' ),
-			$container->get( 'api.bearer' ),
+			$container->get( 'api.bearer-resolver' ),
 			$container->get( 'api.factory.webhook' ),
 			$container->get( 'api.factory.webhook-event' ),
 			$container->get( 'woocommerce.logger.woocommerce' )

--- a/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Resolves the API bearer to use for the current connection state.
- *
- * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
- */
 
 declare(strict_types=1);
 
@@ -17,7 +12,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 
 /**
- * Class ResolvingBearer
+ * Resolves the API bearer to use for the current connection state.
  *
  * A Bearer that mirrors ApiHostResolver's approach for the host: is_connected()
  * decides between ConnectBearer and PayPalBearer on every call rather than

--- a/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Resolves the API bearer to use for the current connection state.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ApiHostResolver;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
+
+/**
+ * Class ResolvingBearer
+ *
+ * A Bearer that mirrors ApiHostResolver's approach for the host: is_connected()
+ * decides between ConnectBearer and PayPalBearer on every call rather than
+ * freezing that choice at construction time. Without this, a Bearer resolved
+ * (e.g. via rest_api_init building the webhook controller) before
+ * ConnectionState::connect() runs in the same request stays a ConnectBearer -
+ * a hardcoded placeholder token - for the rest of that request, even after
+ * the merchant is connected and api.host has moved on to the real PayPal API.
+ */
+class ResolvingBearer implements Bearer {
+
+	private ConnectionState $connection_state;
+
+	private Cache $cache;
+
+	private ApiHostResolver $host_resolver;
+
+	private string $key;
+
+	private string $secret;
+
+	private LoggerInterface $logger;
+
+	private ?SettingsProvider $settings;
+
+	private TokenRateLimiter $rate_limiter;
+
+	public function __construct(
+		ConnectionState $connection_state,
+		Cache $cache,
+		ApiHostResolver $host_resolver,
+		string $key,
+		string $secret,
+		LoggerInterface $logger,
+		?SettingsProvider $settings,
+		TokenRateLimiter $rate_limiter
+	) {
+		$this->connection_state = $connection_state;
+		$this->cache            = $cache;
+		$this->host_resolver    = $host_resolver;
+		$this->key              = $key;
+		$this->secret           = $secret;
+		$this->logger           = $logger;
+		$this->settings         = $settings;
+		$this->rate_limiter     = $rate_limiter;
+	}
+
+	/**
+	 * Returns the bearer to use right now.
+	 *
+	 * Must be called fresh for every request, not resolved once and cached -
+	 * see the class docblock.
+	 */
+	public function bearer(): Token {
+		if ( ! $this->connection_state->is_connected() ) {
+			return ( new ConnectBearer() )->bearer();
+		}
+
+		return ( new PayPalBearer(
+			$this->cache,
+			$this->host_resolver->host(),
+			$this->key,
+			$this->secret,
+			$this->logger,
+			$this->settings,
+			$this->rate_limiter
+		) )->bearer();
+	}
+}

--- a/tests/PHPUnit/ApiClient/Authentication/ResolvingBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/ResolvingBearerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ApiHostResolver;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\ApiClient\Authentication\ResolvingBearer
+ */
+class ResolvingBearerTest extends TestCase
+{
+    /**
+     * Builds a Cache stub whose get() returns an already-valid, non-expired
+     * cached token JSON, so PayPalBearer::bearer() short-circuits on its
+     * cache hit and never performs a real HTTP request.
+     */
+    private function cache_with_valid_token(string $access_token): Cache
+    {
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('get')
+            ->andReturn('{"access_token":"' . $access_token . '","expires_in":100, "created":' . time() . '}');
+
+        return $cache;
+    }
+
+    private function host_resolver(): ApiHostResolver
+    {
+        $host_resolver = Mockery::mock(ApiHostResolver::class);
+        $host_resolver->shouldReceive('host')->andReturn('https://example.com');
+
+        return $host_resolver;
+    }
+
+    private function logger(): LoggerInterface
+    {
+        return Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
+    }
+
+    /**
+     * GIVEN a merchant who has not completed onboarding
+     * WHEN the current bearer is resolved
+     * THEN the placeholder ConnectBearer token is returned instead of a real PayPal token
+     */
+    public function test_bearer_reflects_disconnected_state(): void
+    {
+        $connection_state = new ConnectionState(false, new Environment(false));
+
+        $testee = new ResolvingBearer(
+            $connection_state,
+            $this->cache_with_valid_token('paypal-token'),
+            $this->host_resolver(),
+            'key',
+            'secret',
+            $this->logger(),
+            null,
+            Mockery::mock(TokenRateLimiter::class)
+        );
+
+        $this->assertSame('token', $testee->bearer()->token());
+    }
+
+    /**
+     * GIVEN a merchant who has completed onboarding and has a valid cached PayPal token
+     * WHEN the current bearer is resolved
+     * THEN the cached PayPal token is returned instead of the ConnectBearer placeholder
+     */
+    public function test_bearer_reflects_connected_state(): void
+    {
+        $connection_state = new ConnectionState(true, new Environment(false));
+
+        $testee = new ResolvingBearer(
+            $connection_state,
+            $this->cache_with_valid_token('paypal-token'),
+            $this->host_resolver(),
+            'key',
+            'secret',
+            $this->logger(),
+            null,
+            Mockery::mock(TokenRateLimiter::class)
+        );
+
+        $this->assertSame('paypal-token', $testee->bearer()->token());
+    }
+
+    /**
+     * GIVEN a merchant who is not yet connected, resolved once before onboarding completes
+     * WHEN the merchant's connection state switches to connected mid-request, as
+     * ConnectionState::connect() does right after onboarding finishes
+     * AND the bearer is resolved again on the same resolver instance
+     * THEN the second resolution reflects the new connection state instead of returning a
+     * bearer cached from before the switch
+     */
+    public function test_bearer_reflects_connection_state_changes_mid_request_without_caching(): void
+    {
+        $connection_state = new ConnectionState(false, new Environment(false));
+
+        $testee = new ResolvingBearer(
+            $connection_state,
+            $this->cache_with_valid_token('paypal-token'),
+            $this->host_resolver(),
+            'key',
+            'secret',
+            $this->logger(),
+            null,
+            Mockery::mock(TokenRateLimiter::class)
+        );
+
+        $bearer_before_connect = $testee->bearer();
+
+        $connection_state->connect(false);
+
+        $bearer_after_connect = $testee->bearer();
+
+        $this->assertSame('token', $bearer_before_connect->token());
+        $this->assertSame('paypal-token', $bearer_after_connect->token());
+        $this->assertNotSame($bearer_before_connect->token(), $bearer_after_connect->token());
+    }
+}


### PR DESCRIPTION
*Changelog:* `Fix - Webhook registration no longer fails right after connecting a PayPal account #4675`

# Description

## 🐛 The problem

Right after a merchant finishes connecting a PayPal account (via OAuth or by entering credentials manually), webhook registration for that same request can fail with a 401 from PayPal, leaving the merchant stuck on "PayPal Payments is almost ready" even though the connection itself succeeded.

_Note: this is a distinct bug from #934, which describes background 404s on the settings page before connecting - an unrelated, still-open issue. There's also a known, separate problem where invalid credentials cause repeated OAuth polling on every admin page; neither is addressed here._

## 💡 Why it happens

This is the sibling of #4669, which fixed the *host* half of the same bug. `WebhookEndpoint` also needs a `Bearer`, resolved once from the container's `api.bearer` service and frozen for the rest of that request. `api.bearer` decides between a placeholder `ConnectBearer` (pre-connection) and a real `PayPalBearer` (post-connection) the moment it's first resolved, and `WebhookEndpoint` gets built early enough - WordPress builds all REST controllers on `rest_api_init`, before any route runs - that it can freeze to the placeholder bearer before `ConnectionState::connect()` runs later in the same request. Once #4669 fixed the host, the bearer became the next thing pointing the request at the real PayPal API with the wrong, placeholder credentials.

## ✅ The fix

`ResolvingBearer` mirrors `ApiHostResolver` from #4669: it implements `Bearer` and picks between `ConnectBearer` and `PayPalBearer` fresh on every call instead of once at construction. `WebhookEndpoint` itself doesn't change - it already calls `$this->bearer->bearer()` at call time - so wiring `api.endpoint.webhook` to the new `api.bearer-resolver` service instead of the shared, still-frozen `api.bearer` is enough. The shared `api.bearer` service and its other consumers are intentionally left untouched, the same scoping call #4669 made for `api.host`.

## 🧪 Tests

`ResolvingBearerTest.php` covers the disconnected and connected branches, plus a regression test that resolves the bearer, mutates the same `ConnectionState` instance mid-test, and asserts the second resolution picks up the change - the actual scenario this fixes.

## 🔍 What to review

The same staleness bug still exists in the shared `api.bearer`/`api.host` services for their ~15 other consumers (`OrderEndpoint`, `PartnersEndpoint`, etc.). None are known to run synchronously inside the connect-completing request the way webhook registration does, so this PR leaves them as-is rather than widening scope - flag it if that assumption doesn't hold for a case we missed.

## 🧪 How to verify

1. Connect a sandbox account via manual credential entry (Direct API flow) and confirm the settings screen completes without looping back to "almost ready".
2. Repeat via the OAuth popup flow.
3. Check the plugin log for the connecting request - no 401 from `api-m.sandbox.paypal.com`.

