### PR TITLE
Fix missing PayPal redirect gateway in blocks for subscriptions in v6 (6852)

### DIFF
--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -240,10 +240,13 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		// A subscription cart may still use the standard "Place order" flow when a vault
 		// token can be saved (vaulting mode) or when manual renewals are accepted (the
 		// subscription is charged as a plain, one-time Orders API payment).
+		//
+		// The vaulting capability comes from the settings, not $script_data: under SDK v6
+		// the smart button is a DisabledSmartButton whose script_data() is empty.
 		$place_order_enabled = ( $this->use_place_order || $this->add_place_order_method )
 			&& (
 				! $this->subscription_helper->cart_contains_subscription()
-				|| ( $script_data['can_save_vault_token'] ?? false )
+				|| $this->plugin_settings->can_save_vault_token()
 				|| $this->subscription_helper->accept_manual_renewals()
 			);
 		$cart                = WC()->cart;

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -909,16 +909,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 * @return bool
 	 */
 	public function can_save_vault_token(): bool {
-		$merchant_data = $this->settings_provider->merchant_data();
-		if ( ! $merchant_data->client_id ) {
-			return false;
-		}
-
-		if ( ! $this->settings_provider->save_paypal_and_venmo() ) {
-			return false;
-		}
-
-		return true;
+		return $this->settings_provider->can_save_vault_token();
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -428,6 +428,16 @@ class SettingsProvider {
 	}
 
 	/**
+	 * Whether a PayPal/Venmo vault token can be saved for this merchant.
+	 *
+	 * @return bool True if PayPal/Venmo vaulting is available, false otherwise.
+	 */
+	public function can_save_vault_token(): bool {
+		return (bool) $this->merchant_data()->client_id
+			&& $this->save_paypal_and_venmo();
+	}
+
+	/**
 	 * Whether Pay Later may run alongside vaulting ("Save PayPal and Venmo").
 	 *
 	 * Allowed whenever the merchant may use Pay Later at all, which is the same

--- a/tests/PHPUnit/Blocks/PayPalPaymentMethodTest.php
+++ b/tests/PHPUnit/Blocks/PayPalPaymentMethodTest.php
@@ -1,0 +1,213 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Blocks;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use function Brain\Monkey\Functions\when;
+
+class PayPalPaymentMethodTest extends TestCase
+{
+    private $asset_getter;
+    private $smart_button;
+    private $plugin_settings;
+    private $settings_status;
+    private $gateway;
+    private $cancellation_view;
+    private $session_handler;
+    private $subscription_helper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->asset_getter        = Mockery::mock(AssetGetter::class);
+        $this->smart_button        = Mockery::mock(SmartButtonInterface::class);
+        $this->plugin_settings     = Mockery::mock(SettingsProvider::class);
+        $this->settings_status     = Mockery::mock(SettingsStatus::class);
+        $this->gateway             = Mockery::mock(PayPalGateway::class);
+        $this->cancellation_view   = Mockery::mock(CancelView::class);
+        $this->session_handler     = Mockery::mock(SessionHandler::class);
+        $this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
+
+        $this->gateway->id          = PayPalGateway::ID;
+        $this->gateway->title       = 'PayPal';
+        $this->gateway->icon        = 'https://example.test/paypal.svg';
+        $this->gateway->supports    = array('products');
+        $this->gateway->shouldReceive('get_description')->andReturn('Pay with PayPal');
+
+        $this->session_handler->shouldReceive('funding_source')->andReturn('paypal');
+
+        when('wp_create_nonce')->justReturn('nonce');
+
+        $cart = Mockery::mock(\WC_Cart::class);
+        $cart->shouldReceive('needs_shipping')->andReturn(false);
+        $wc = Mockery::mock();
+        $wc->cart = $cart;
+        when('WC')->justReturn($wc);
+    }
+
+    /**
+     * @param array<string, mixed> $script_data
+     */
+    private function createTestee(
+        array $script_data,
+        bool $add_place_order_method,
+        bool $use_place_order
+    ): PayPalPaymentMethod {
+        $this->smart_button->shouldReceive('script_data')->andReturn($script_data);
+
+        return new PayPalPaymentMethod(
+            $this->asset_getter,
+            '1.0.0',
+            $this->smart_button,
+            $this->plugin_settings,
+            $this->settings_status,
+            $this->gateway,
+            false,
+            $this->cancellation_view,
+            $this->session_handler,
+            $this->subscription_helper,
+            $add_place_order_method,
+            $use_place_order,
+            'Place order',
+            'Pay with PayPal',
+            array()
+        );
+    }
+
+    /**
+     * GIVEN a subscription cart, a "Place order" method, and whether a vault token can be
+     *      saved or manual renewals are accepted
+     * WHEN get_payment_method_data() is called
+     * THEN the standard "Place order" row is only enabled when a vault token can be saved
+     *      or manual renewals are accepted for the subscription
+     * AND under SDK v6, where the v5 smart button script data is empty, the row's smart
+     *      buttons stay disabled since the v6 express button covers that surface
+     *
+     * @dataProvider place_order_enabled_provider
+     */
+    public function test_place_order_enabled(
+        array $script_data,
+        bool $cart_contains_subscription,
+        bool $can_save_vault_token,
+        bool $accept_manual_renewals,
+        bool $add_place_order_method,
+        bool $use_place_order,
+        bool $expected,
+        bool $assert_smart_buttons_disabled
+    ): void {
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn($accept_manual_renewals);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn($can_save_vault_token);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+
+        $testee = $this->createTestee($script_data, $add_place_order_method, $use_place_order);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertSame($expected, $data['placeOrderEnabled']);
+
+        if ($assert_smart_buttons_disabled) {
+            $this->assertFalse($data['smartButtonsEnabled']);
+        }
+    }
+
+    public function place_order_enabled_provider(): array
+    {
+        return array(
+            'sdk v6, subscription cart, vaulting on, automatic renewals' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => true,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v6, subscription cart, vaulting off, automatic renewals' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => false,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v6, subscription cart, vaulting off, manual renewals accepted' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => true,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v6, no subscription in cart' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => false,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v5, subscription cart, vaulting on' => array(
+                'script_data'                    => array(
+                    'context'              => 'checkout-block',
+                    'can_save_vault_token' => true,
+                ),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => true,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => false,
+            ),
+            'place-order method filtered off' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => false,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => false,
+                'use_place_order'                 => false,
+                'expected'                        => false,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+        );
+    }
+
+    /**
+     * GIVEN a gateway whose supported features vary by mode (e.g. vaulting adds
+     *      "tokenization")
+     * WHEN get_payment_method_data() is called
+     * THEN the block declares exactly those features to WooCommerce Blocks
+     */
+    public function test_supported_features_come_from_the_gateway(): void
+    {
+        $this->gateway->supports = array('products', 'subscriptions', 'tokenization');
+
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn(false);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+
+        $testee = $this->createTestee(array(), true, false);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertSame(array('products', 'subscriptions', 'tokenization'), $data['supportedFeatures']);
+    }
+}

--- a/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
@@ -622,4 +622,54 @@ class SettingsProviderTest extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * GIVEN a merchant connection with or without a client ID, and vaulting ("Save PayPal
+	 *      and Venmo") on or off
+	 * WHEN can_save_vault_token() is called
+	 * THEN a vault token can only be saved when the merchant is connected (has a client ID)
+	 *      and vaulting is enabled
+	 *
+	 * @dataProvider can_save_vault_token_provider
+	 */
+	public function test_can_save_vault_token(
+		string $client_id,
+		bool $save_paypal_and_venmo,
+		bool $expected
+	): void {
+		$this->general_settings
+			->shouldReceive( 'get_merchant_data' )
+			->andReturn( new MerchantConnectionDTO( true, $client_id, '', '' ) );
+
+		$this->settings_model
+			->shouldReceive( 'get_save_paypal_and_venmo' )
+			->andReturn( $save_paypal_and_venmo );
+
+		$this->assertSame( $expected, $this->provider->can_save_vault_token() );
+	}
+
+	public function can_save_vault_token_provider(): array {
+		return [
+			'connected merchant, vaulting on'      => [
+				'client_id'             => 'client-id',
+				'save_paypal_and_venmo' => true,
+				'expected'              => true,
+			],
+			'connected merchant, vaulting off'     => [
+				'client_id'             => 'client-id',
+				'save_paypal_and_venmo' => false,
+				'expected'              => false,
+			],
+			'unconnected merchant, vaulting on'    => [
+				'client_id'             => '',
+				'save_paypal_and_venmo' => true,
+				'expected'              => false,
+			],
+			'unconnected merchant, vaulting off'   => [
+				'client_id'             => '',
+				'save_paypal_and_venmo' => false,
+				'expected'              => false,
+			],
+		];
+	}
 }


### PR DESCRIPTION
The PayPal redirect gateway ("Proceed to PayPal") was missing on checkout block for subscription products when using the V6 SDK. The issue was that it was checking the parameters from the disabled V5 button. So now fixed it by using the settings instead. 

## 🧪 How to verify

1. Set `PCP_SDK_V6_ENABLED=1`, enable **Save PayPal and Venmo**, and run WooCommerce Subscriptions with automatic renewals.
2. Put a subscription product with a non-zero first payment in the cart and open block checkout.
3. Confirm **PayPal** is listed in the payment options (not the express buttons).
4. Select PayPal, place the order, complete the approval, and confirm the subscription is created with a vaulted token.
5. Disable **Save PayPal and Venmo**, reload: the PayPal row is gone again for the subscription cart.