### PR TITLE
Show a usable card decline message on the v6 checkout (6858)

### DIFF
--- a/modules/ppcp-blocks/resources/css/gateway.scss
+++ b/modules/ppcp-blocks/resources/css/gateway.scss
@@ -24,3 +24,36 @@ li[id^="express-payment-method-ppcp-"] {
 	}
 }
 
+
+// The v6 advanced card fields, whose elements are created by the SDK bundle.
+.ppcp-sdk-v6-card-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	// WooCommerce's "save payment information" checkbox follows this block
+	// with no margin of its own.
+	margin-bottom: 16px;
+}
+
+.ppcp-sdk-v6-card-fields__row {
+	display: flex;
+	gap: 16px;
+
+	> .ppcp-sdk-v6-card-field {
+		flex: 1;
+	}
+}
+
+// The wc-block-components-text-input class carries a top margin that Blocks
+// resets only for :first-of-type. The flex gap already spaces these fields.
+.ppcp-sdk-v6-card-fields .ppcp-sdk-v6-card-field.wc-block-components-text-input {
+	margin-top: 0;
+}
+
+// A hosted field is a cross-origin iframe that a label cannot focus, so its
+// label passes clicks through to it. The cardholder-name label has a real
+// for/id target and keeps its clicks.
+.ppcp-sdk-v6-card-field__label {
+	pointer-events: none;
+}

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldContainer.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldContainer.js
@@ -2,8 +2,8 @@
  * Renders one v6 card field into React.
  *
  * React owns an empty container and never reconciles the SDK-owned subtree:
- * the field element is appended imperatively and removed on cleanup, and is
- * recreated only when the session or field type changes.
+ * the field element and its label are appended imperatively and removed on
+ * cleanup, and are recreated only when the session or field type changes.
  *
  * @package
  */
@@ -11,13 +11,14 @@
 import { createElement, useEffect, useRef } from '@wordpress/element';
 
 /**
- * @param {Object} props                  - Component props.
- * @param {Object} props.session          - The v6 card-fields session.
- * @param {string} props.type             - The field type (number, expiry, cvv, name).
- * @param {Object} props.style            - The `style.input` object for the field.
- * @param {string} [props.height]         - CSS height for the field's own box.
- * @param {string} [props.placeholder]    - The field placeholder text.
- * @param {Object} [props.containerStyle] - Extra styles for the wrapper (e.g. flex sizing).
+ * @param {Object}  props                  - Component props.
+ * @param {Object}  props.session          - The v6 card-fields session.
+ * @param {string}  props.type             - The field type (number, expiry, cvv, name).
+ * @param {Object}  props.style            - The `style.input` object for the field.
+ * @param {string}  [props.height]         - CSS height for the field's own box.
+ * @param {string}  [props.label]          - The field's visible name.
+ * @param {boolean} [props.floatingLabel]  - Whether the page carries WooCommerce's floating-label CSS.
+ * @param {boolean} [props.isActive]       - Whether the field is focused or filled.
  * @return {Object} The container element.
  */
 export function V6CardFieldContainer( {
@@ -25,8 +26,9 @@ export function V6CardFieldContainer( {
 	type,
 	style,
 	height,
-	placeholder,
-	containerStyle,
+	label,
+	floatingLabel = false,
+	isActive = false,
 } ) {
 	const containerRef = useRef( null );
 
@@ -37,31 +39,62 @@ export function V6CardFieldContainer( {
 		}
 
 		const options = { type, style: { input: style } };
-		if ( placeholder ) {
-			options.placeholder = placeholder;
+		if ( label ) {
+			// A floating label covers the empty field, leaving no room
+			// for a placeholder; ariaLabel then carries the name.
+			if ( floatingLabel ) {
+				options.ariaLabel = label;
+			} else {
+				options.placeholder = label;
+			}
 		}
 
 		const field = session.createCardFieldsComponent( options );
-		// style.input only reaches the text inside the element, so its box is
-		// sized here or it keeps the SDK default (much taller than the form
-		// inputs) — hence height as its own prop rather than part of style.
+		// style.input only reaches the text inside the element. Its box keeps
+		// the SDK default height, much taller than the form inputs, unless
+		// sized here.
 		field.style.width = '100%';
 		if ( height ) {
 			field.style.height = height;
 		}
 		container.appendChild( field );
 
+		// WooCommerce's floating-label CSS expects the label after the input.
+		// It is aria-hidden: the hosted field is a cross-origin iframe with
+		// its own aria-label.
+		let labelElement = null;
+		if ( floatingLabel && label ) {
+			labelElement = document.createElement( 'label' );
+			labelElement.className = 'ppcp-sdk-v6-card-field__label';
+			labelElement.textContent = label;
+			labelElement.setAttribute( 'aria-hidden', 'true' );
+			container.appendChild( labelElement );
+		}
+
 		return () => {
 			field.remove();
+			if ( labelElement ) {
+				labelElement.remove();
+			}
 		};
-		// style, height and placeholder are captured at mount: depending on them
-		// would recreate the field on every render.
+		// Everything but session and type is captured at mount: depending on
+		// it would recreate the field on every render.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ session, type ] );
 
+	const classNames = [
+		'ppcp-sdk-v6-card-field',
+		`ppcp-sdk-v6-card-field--${ type }`,
+	];
+	if ( floatingLabel ) {
+		classNames.push( 'wc-block-components-text-input' );
+		if ( isActive ) {
+			classNames.push( 'is-active' );
+		}
+	}
+
 	return createElement( 'div', {
 		ref: containerRef,
-		className: `ppcp-sdk-v6-card-field ppcp-sdk-v6-card-field--${ type }`,
-		style: containerStyle,
+		className: classNames.join( ' ' ),
 	} );
 }

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -31,6 +31,11 @@ import { V6CardFieldContainer } from './V6CardFieldContainer';
 import { amountFromBilling } from '../utils/amount';
 import { isFreeTrialCart } from '../utils/freeTrial';
 import { hasCheckoutValidationErrors } from './checkoutValidation';
+import {
+	CARD_DECLINE_MESSAGE,
+	CARD_SAVE_DECLINE_MESSAGE,
+	userFacingMessage,
+} from '../utils/cardDeclineMessages';
 
 const CHECKOUT_FIELDS_NOT_VALID_MESSAGE = __(
 	'Please complete all required checkout fields before continuing with payment.',
@@ -97,10 +102,7 @@ async function submitCardPayment( {
 		if ( result.state !== 'succeeded' ) {
 			return {
 				type: responseTypes.ERROR,
-				message: __(
-					'Card payment failed.',
-					'woocommerce-paypal-payments'
-				),
+				message: CARD_DECLINE_MESSAGE,
 			};
 		}
 
@@ -110,9 +112,7 @@ async function submitCardPayment( {
 	} catch ( error ) {
 		return {
 			type: responseTypes.ERROR,
-			message:
-				error?.message ||
-				__( 'Card payment failed.', 'woocommerce-paypal-payments' ),
+			message: userFacingMessage( error, CARD_DECLINE_MESSAGE ),
 		};
 	}
 }
@@ -173,10 +173,7 @@ async function submitCardSave( { config, session, responseTypes } ) {
 		if ( result.state !== 'succeeded' ) {
 			return {
 				type: responseTypes.ERROR,
-				message: __(
-					'Card could not be saved.',
-					'woocommerce-paypal-payments'
-				),
+				message: CARD_SAVE_DECLINE_MESSAGE,
 			};
 		}
 
@@ -186,9 +183,7 @@ async function submitCardSave( { config, session, responseTypes } ) {
 	} catch ( error ) {
 		return {
 			type: responseTypes.ERROR,
-			message:
-				error?.message ||
-				__( 'Card could not be saved.', 'woocommerce-paypal-payments' ),
+			message: userFacingMessage( error, CARD_SAVE_DECLINE_MESSAGE ),
 		};
 	}
 }
@@ -211,7 +206,8 @@ export function V6CardFieldsComponent( {
 	shouldSavePayment,
 	billing,
 } ) {
-	const { onPaymentSetup, onCheckoutValidation } = eventRegistration;
+	const { onPaymentSetup, onCheckoutValidation, onCheckoutFail } =
+		eventRegistration;
 	const { responseTypes } = emitResponse;
 
 	const context = config.page_context;
@@ -367,6 +363,28 @@ export function V6CardFieldsComponent( {
 			return true;
 		} );
 	}, [ onCheckoutValidation, activePaymentMethod, methodId, responseTypes ] );
+
+	// The Store API clears the gateway's notices and Blocks ignores the
+	// errorMessage it returns, so a decline raised during process_payment
+	// reaches the shopper as WooCommerce's generic string unless it is put
+	// back here.
+	useEffect( () => {
+		if (
+			activePaymentMethod !== methodId ||
+			typeof onCheckoutFail !== 'function'
+		) {
+			return undefined;
+		}
+
+		return onCheckoutFail( ( { processingResponse } ) => {
+			const message = processingResponse?.paymentDetails?.errorMessage;
+			if ( ! message ) {
+				return true;
+			}
+
+			return { type: responseTypes.ERROR, message };
+		} );
+	}, [ onCheckoutFail, activePaymentMethod, methodId, responseTypes ] );
 
 	const fieldsReady = session && inputStyle && textStyle;
 

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -42,6 +42,23 @@ const CHECKOUT_FIELDS_NOT_VALID_MESSAGE = __(
 	'woocommerce-paypal-payments'
 );
 
+const FIELD_LABELS = {
+	number: __( 'Card number', 'woocommerce-paypal-payments' ),
+	expiry: __( 'Expiry (MM/YY)', 'woocommerce-paypal-payments' ),
+	cvv: __( 'CVV', 'woocommerce-paypal-payments' ),
+};
+
+const CARD_NAME_LABEL = __(
+	'Cardholder name (optional)',
+	'woocommerce-paypal-payments'
+);
+
+// Each event payload carries the state of all three fields, so these four
+// events keep every label in sync.
+const FIELD_STATE_EVENTS = [ 'focus', 'blur', 'empty', 'notempty' ];
+
+const NAME_FIELD_ID = 'ppcp-sdk-v6-card-name';
+
 /**
  * Creates the order, confirms it through the card session (which runs 3D
  * Secure), approves it, and maps the outcome to a Blocks onPaymentSetup
@@ -224,6 +241,9 @@ export function V6CardFieldsComponent( {
 	const [ inputStyle, setInputStyle ] = useState( null );
 	const [ textStyle, setTextStyle ] = useState( null );
 	const [ cardName, setCardName ] = useState( '' );
+	const [ nameFocused, setNameFocused ] = useState( false );
+	const [ floatingLabel, setFloatingLabel ] = useState( false );
+	const [ fieldStates, setFieldStates ] = useState( {} );
 	const referenceRef = useRef( null );
 
 	// The choice comes from WC Blocks' native "Save payment information…"
@@ -283,14 +303,61 @@ export function V6CardFieldsComponent( {
 	// decoration has no business.
 	const cardFieldOverrides = config.card_fields.styles;
 	useEffect( () => {
-		const source =
-			document.querySelector( '.wc-block-components-text-input input' ) ||
-			referenceRef.current;
+		const blockInput = document.querySelector(
+			'.wc-block-components-text-input input'
+		);
+		const source = blockInput || referenceRef.current;
+
+		// A Blocks text input on the page means its floating-label CSS is
+		// loaded. Without one, the fields fall back to plain placeholders.
+		setFloatingLabel( Boolean( blockInput ) );
+
 		if ( source ) {
 			setInputStyle( cardFieldStyles( source ) );
 			setTextStyle( hostedFieldTextStyles( source, cardFieldOverrides ) );
 		}
 	}, [ cardFieldOverrides ] );
+
+	// Mirrors the SDK's field state onto the wrappers so WooCommerce's CSS can
+	// float each label.
+	useEffect( () => {
+		if ( ! session || ! floatingLabel ) {
+			return undefined;
+		}
+
+		let listening = true;
+		const handler = ( payload ) => {
+			if ( ! listening || ! payload?.data ) {
+				return;
+			}
+
+			const { number, expiry, cvv } = payload.data;
+			setFieldStates( { number, expiry, cvv } );
+		};
+
+		// The session exposes no per-listener removal, only destroy(), so this
+		// flag is what stops a late event from reaching an unmounted component.
+		FIELD_STATE_EVENTS.forEach( ( event ) => {
+			Promise.resolve( session.on( event, handler ) ).catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[PPCP SDK v6] card field event not available',
+					event,
+					error
+				);
+			} );
+		} );
+
+		return () => {
+			listening = false;
+		};
+	}, [ session, floatingLabel ] );
+
+	// WooCommerce floats a label once its field is focused or filled.
+	const isFieldActive = ( type ) => {
+		const state = fieldStates[ type ];
+		return Boolean( state && ( state.isFocused || ! state.isEmpty ) );
+	};
 
 	const sessionRef = useLatestRef( session );
 
@@ -386,13 +453,21 @@ export function V6CardFieldsComponent( {
 		} );
 	}, [ onCheckoutFail, activePaymentMethod, methodId, responseTypes ] );
 
+	const nameFieldClassName = [
+		'ppcp-sdk-v6-card-field',
+		'ppcp-sdk-v6-card-field--name',
+		floatingLabel && 'wc-block-components-text-input',
+		floatingLabel && ( nameFocused || cardName !== '' ) && 'is-active',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
 	const fieldsReady = session && inputStyle && textStyle;
 
 	return createElement(
 		'div',
 		{
 			className: 'ppcp-sdk-v6-card-fields',
-			style: { display: 'flex', flexDirection: 'column', gap: '16px' },
 		},
 		// Off-screen rather than display:none, which would make getComputedStyle
 		// return nothing.
@@ -419,56 +494,60 @@ export function V6CardFieldsComponent( {
 					createElement(
 						'div',
 						{
-							className:
-								'ppcp-sdk-v6-card-field ppcp-sdk-v6-card-field--name',
+							className: nameFieldClassName,
 						},
 						createElement( 'input', {
+							id: NAME_FIELD_ID,
 							type: 'text',
 							className: 'input-text',
 							value: cardName,
 							onChange: ( event ) =>
 								setCardName( event.target.value ),
-							placeholder: __(
-								'Cardholder name (optional)',
-								'woocommerce-paypal-payments'
-							),
+							onFocus: () => setNameFocused( true ),
+							onBlur: () => setNameFocused( false ),
+							placeholder: floatingLabel
+								? undefined
+								: CARD_NAME_LABEL,
 							style: { width: '100%', ...inputStyle },
-						} )
+						} ),
+						// A real input, so this label uses for/id where the
+						// hosted fields' labels are aria-hidden.
+						floatingLabel &&
+							createElement(
+								'label',
+								{ htmlFor: NAME_FIELD_ID },
+								CARD_NAME_LABEL
+							)
 					),
 				createElement( V6CardFieldContainer, {
 					session,
 					type: 'number',
 					style: textStyle,
 					height: inputStyle.height,
-					placeholder: __(
-						'Card number',
-						'woocommerce-paypal-payments'
-					),
+					label: FIELD_LABELS.number,
+					floatingLabel,
+					isActive: isFieldActive( 'number' ),
 				} ),
 				createElement(
 					'div',
-					{
-						className: 'ppcp-sdk-v6-card-fields__row',
-						style: { display: 'flex', gap: '16px' },
-					},
+					{ className: 'ppcp-sdk-v6-card-fields__row' },
 					createElement( V6CardFieldContainer, {
 						session,
 						type: 'expiry',
 						style: textStyle,
 						height: inputStyle.height,
-						placeholder: __(
-							'MM / YY',
-							'woocommerce-paypal-payments'
-						),
-						containerStyle: { flex: 1 },
+						label: FIELD_LABELS.expiry,
+						floatingLabel,
+						isActive: isFieldActive( 'expiry' ),
 					} ),
 					createElement( V6CardFieldContainer, {
 						session,
 						type: 'cvv',
 						style: textStyle,
 						height: inputStyle.height,
-						placeholder: __( 'CVV', 'woocommerce-paypal-payments' ),
-						containerStyle: { flex: 1 },
+						label: FIELD_LABELS.cvv,
+						floatingLabel,
+						isActive: isFieldActive( 'cvv' ),
 					} )
 				)
 			),

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -39,6 +39,18 @@ import {
 import '@testing-library/jest-dom';
 import { createElement } from '@wordpress/element';
 import { V6CardFieldsComponent } from './V6CardFieldsComponent';
+const { V6CardFieldContainer: ActualV6CardFieldContainer } = jest.requireActual(
+	'./V6CardFieldContainer'
+);
+
+// The component detects floating-label support by querying for this markup.
+function appendFloatingLabelMarker() {
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'wc-block-components-text-input';
+	wrapper.appendChild( document.createElement( 'input' ) );
+	document.body.appendChild( wrapper );
+	return wrapper;
+}
 
 function cardConfig( overrides = {} ) {
 	return {
@@ -149,6 +161,7 @@ beforeEach( () => {
 			document.createElement( 'div' )
 		),
 		submit: jest.fn(),
+		on: jest.fn(),
 	};
 
 	mockLoadSdkV6.mockReset().mockResolvedValue( {
@@ -199,6 +212,18 @@ describe( 'V6CardFieldsComponent', () => {
 		await waitForSessionReady();
 
 		expect( onPaymentSetup ).toHaveBeenCalled();
+	} );
+
+	test( 'the root container and the expiry/CVV row carry the class hooks the stylesheet spacing depends on', async () => {
+		renderComponent();
+		await waitForSessionReady();
+
+		expect(
+			document.querySelector( '.ppcp-sdk-v6-card-fields' )
+		).toBeInTheDocument();
+		expect(
+			document.querySelector( '.ppcp-sdk-v6-card-fields__row' )
+		).toBeInTheDocument();
 	} );
 
 	test( 'a pending checkout validation error blocks the card submission before an order is created', async () => {
@@ -530,6 +555,25 @@ describe( 'V6CardFieldsComponent', () => {
 		expect( types ).toContain( 'number' );
 	} );
 
+	test( 'keeps the plain placeholder and passes floatingLabel false to each field when no Blocks text-input markup is on the page', async () => {
+		renderComponent();
+		await waitForSessionReady();
+
+		[ 'number', 'expiry', 'cvv' ].forEach( ( type ) => {
+			const call = mockCardFieldContainer.mock.calls.find(
+				( c ) => c[ 0 ].type === type
+			);
+			expect( call[ 0 ].floatingLabel ).toBe( false );
+		} );
+
+		expect(
+			screen.getByPlaceholderText( 'Cardholder name (optional)' )
+		).toBeInTheDocument();
+		expect(
+			document.querySelector( 'label[for="ppcp-sdk-v6-card-name"]' )
+		).not.toBeInTheDocument();
+	} );
+
 	test( 'forwards the typed cardholder name to createCardOrder on submit', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
@@ -766,5 +810,257 @@ describe( 'V6CardFieldsComponent', () => {
 			).toBe( true );
 		} );
 	} );
+
+	describe( 'floating-label mode (Blocks text-input markup present)', () => {
+		let marker;
+
+		beforeEach( () => {
+			marker = appendFloatingLabelMarker();
+		} );
+
+		afterEach( () => {
+			marker.remove();
+		} );
+
+		function lastCallFor( type ) {
+			const calls = mockCardFieldContainer.mock.calls.filter(
+				( call ) => call[ 0 ].type === type
+			);
+			return calls[ calls.length - 1 ][ 0 ];
+		}
+
+		test( 'passes floatingLabel true to each V6CardFieldContainer', async () => {
+			renderComponent();
+			await waitForSessionReady();
+
+			expect( lastCallFor( 'number' ).floatingLabel ).toBe( true );
+			expect( lastCallFor( 'expiry' ).floatingLabel ).toBe( true );
+			expect( lastCallFor( 'cvv' ).floatingLabel ).toBe( true );
+		} );
+
+		test( 'subscribes to focus, blur, empty and notempty on the card session', async () => {
+			renderComponent();
+			await waitForSessionReady();
+
+			await waitFor( () =>
+				expect(
+					session.on.mock.calls.map( ( call ) => call[ 0 ] )
+				).toEqual(
+					expect.arrayContaining( [
+						'focus',
+						'blur',
+						'empty',
+						'notempty',
+					] )
+				)
+			);
+		} );
+
+		describe( 'is-active derivation from the session event payload', () => {
+			function fieldState( overrides ) {
+				return {
+					isEmpty: true,
+					isFocused: false,
+					isPotentiallyValid: true,
+					isValid: false,
+					...overrides,
+				};
+			}
+
+			test.each( [
+				[
+					'a focused but still empty field',
+					fieldState( { isFocused: true, isEmpty: true } ),
+					true,
+				],
+				[
+					'a blurred field that already holds a value',
+					fieldState( { isFocused: false, isEmpty: false } ),
+					true,
+				],
+				[
+					'a blurred, empty field',
+					fieldState( { isFocused: false, isEmpty: true } ),
+					false,
+				],
+			] )(
+				'marks the wrapper active=%p for %s',
+				async ( _label, numberState, expectedActive ) => {
+					renderComponent();
+					await waitForSessionReady();
+
+					await waitFor( () =>
+						expect( session.on ).toHaveBeenCalled()
+					);
+					const handler = session.on.mock.calls[ 0 ][ 1 ];
+
+					act( () => {
+						handler( {
+							data: {
+								cards: [],
+								emittedBy: 'number',
+								number: numberState,
+								expiry: fieldState(),
+								cvv: fieldState(),
+							},
+							instanceId: 'instance-1',
+							sender: 'number',
+						} );
+					} );
+
+					expect( lastCallFor( 'number' ).isActive ).toBe(
+						expectedActive
+					);
+				}
+			);
+		} );
+
+		describe( 'cardholder name field', () => {
+			test( 'the label is associated with the input via for/id', async () => {
+				renderComponent();
+				await waitForSessionReady();
+
+				const input = screen.getByLabelText(
+					'Cardholder name (optional)'
+				);
+				expect( input ).toHaveAttribute(
+					'id',
+					'ppcp-sdk-v6-card-name'
+				);
+			} );
+
+			test( 'the wrapper carries the Blocks text-input class the stylesheet margin rule targets', async () => {
+				renderComponent();
+				await waitForSessionReady();
+
+				const input = screen.getByLabelText(
+					'Cardholder name (optional)'
+				);
+				const wrapper = input.closest( 'div' );
+
+				expect( wrapper ).toHaveClass(
+					'wc-block-components-text-input'
+				);
+			} );
+
+			test( 'the wrapper becomes active on focus and stays active once the field holds a value', async () => {
+				renderComponent();
+				await waitForSessionReady();
+
+				const input = screen.getByLabelText(
+					'Cardholder name (optional)'
+				);
+				const wrapper = input.closest( 'div' );
+
+				expect( wrapper ).not.toHaveClass( 'is-active' );
+
+				fireEvent.focus( input );
+				expect( wrapper ).toHaveClass( 'is-active' );
+
+				fireEvent.blur( input );
+				expect( wrapper ).not.toHaveClass( 'is-active' );
+
+				fireEvent.change( input, {
+					target: { value: 'Jane Doe' },
+				} );
+				fireEvent.blur( input );
+				expect( wrapper ).toHaveClass( 'is-active' );
+			} );
+		} );
+	} );
 } );
 
+describe( 'V6CardFieldContainer', () => {
+	function containerSession( fieldElement ) {
+		return {
+			createCardFieldsComponent: jest.fn(
+				() => fieldElement || document.createElement( 'div' )
+			),
+		};
+	}
+
+	test( 'in fallback mode, the SDK receives a placeholder, not an aria-label, and no label element is appended', () => {
+		const session = containerSession();
+
+		const { container } = render(
+			createElement( ActualV6CardFieldContainer, {
+				session,
+				type: 'number',
+				style: {},
+				label: 'Card number',
+			} )
+		);
+
+		expect( session.createCardFieldsComponent ).toHaveBeenCalledWith(
+			expect.objectContaining( { placeholder: 'Card number' } )
+		);
+		expect(
+			session.createCardFieldsComponent.mock.calls[ 0 ][ 0 ]
+		).not.toHaveProperty( 'ariaLabel' );
+		expect( container.firstChild ).not.toHaveClass(
+			'wc-block-components-text-input'
+		);
+		expect( container.querySelector( 'label' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'in floating-label mode, the SDK receives an aria-label, the wrapper gets the Blocks class, and an aria-hidden label is appended after the field', () => {
+		const field = document.createElement( 'div' );
+		const session = containerSession( field );
+
+		const { container } = render(
+			createElement( ActualV6CardFieldContainer, {
+				session,
+				type: 'number',
+				style: {},
+				label: 'Card number',
+				floatingLabel: true,
+			} )
+		);
+
+		expect( session.createCardFieldsComponent ).toHaveBeenCalledWith(
+			expect.objectContaining( { ariaLabel: 'Card number' } )
+		);
+		expect(
+			session.createCardFieldsComponent.mock.calls[ 0 ][ 0 ]
+		).not.toHaveProperty( 'placeholder' );
+
+		const wrapper = container.firstChild;
+		expect( wrapper ).toHaveClass( 'wc-block-components-text-input' );
+
+		expect( wrapper.children[ 0 ] ).toBe( field );
+
+		const label = wrapper.querySelector( 'label' );
+		expect( label ).toHaveTextContent( 'Card number' );
+		expect( label ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( label ).toHaveClass( 'ppcp-sdk-v6-card-field__label' );
+		expect( wrapper.lastChild ).toBe( label );
+	} );
+
+	test.each( [
+		[ true, true ],
+		[ false, false ],
+	] )(
+		'the wrapper is-active class follows the isActive prop (%p) in floating-label mode',
+		( isActive, expectActive ) => {
+			const session = containerSession();
+
+			const { container } = render(
+				createElement( ActualV6CardFieldContainer, {
+					session,
+					type: 'number',
+					style: {},
+					floatingLabel: true,
+					isActive,
+				} )
+			);
+
+			if ( expectActive ) {
+				expect( container.firstChild ).toHaveClass( 'is-active' );
+			} else {
+				expect( container.firstChild ).not.toHaveClass(
+					'is-active'
+				);
+			}
+		}
+	);
+} );

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -63,6 +63,8 @@ let onPaymentSetup;
 let paymentSetupCb;
 let onCheckoutValidation;
 let checkoutValidationCb;
+let onCheckoutFail;
+let checkoutFailCb;
 let hasValidationErrors;
 let eventRegistration;
 let session;
@@ -101,6 +103,10 @@ async function waitForCheckoutValidationReady() {
 	await waitFor( () => expect( checkoutValidationCb ).not.toBeNull() );
 }
 
+async function waitForCheckoutFailReady() {
+	await waitFor( () => expect( checkoutFailCb ).not.toBeNull() );
+}
+
 beforeEach( () => {
 	paymentSetupCb = null;
 	onPaymentSetup = jest.fn( ( cb ) => {
@@ -112,7 +118,16 @@ beforeEach( () => {
 		checkoutValidationCb = cb;
 		return () => {};
 	} );
-	eventRegistration = { onPaymentSetup, onCheckoutValidation };
+	checkoutFailCb = null;
+	onCheckoutFail = jest.fn( ( cb ) => {
+		checkoutFailCb = cb;
+		return () => {};
+	} );
+	eventRegistration = {
+		onPaymentSetup,
+		onCheckoutValidation,
+		onCheckoutFail,
+	};
 
 	hasValidationErrors = false;
 	global.wp = {
@@ -378,7 +393,7 @@ describe( 'V6CardFieldsComponent', () => {
 		);
 	} );
 
-	test( 'reports an error and skips approval when 3D Secure is canceled', async () => {
+	test( 'reports the "authentication not completed" message and skips approval when 3D Secure is canceled', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'canceled' } );
 
@@ -390,12 +405,14 @@ describe( 'V6CardFieldsComponent', () => {
 			result = await paymentSetupCb();
 		} );
 
-		expect( result.type ).toBe( 'error' );
-		expect( result.message ).toBeTruthy();
+		expect( result ).toEqual( {
+			type: 'error',
+			message: 'Card authentication was not completed. Please try again.',
+		} );
 		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
 	} );
 
-	test( 'reports an error and skips approval when the card payment fails', async () => {
+	test( 'reports the friendly decline message and skips approval when the card payment does not succeed', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'failed' } );
 
@@ -407,13 +424,17 @@ describe( 'V6CardFieldsComponent', () => {
 			result = await paymentSetupCb();
 		} );
 
-		expect( result.type ).toBe( 'error' );
+		expect( result ).toEqual( {
+			type: 'error',
+			message:
+				'This card could not be authorized. Please try a different payment method.',
+		} );
 		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
 	} );
 
-	test( 'reports the thrown error message when creating the order fails', async () => {
+	test( 'shows the friendly decline message instead of leaking a thrown error that is not marked user-facing', async () => {
 		mockCreateCardOrder.mockRejectedValueOnce(
-			new Error( 'nonce expired' )
+			new Error( 'PayPal SDK internal failure XYZ' )
 		);
 
 		renderComponent();
@@ -424,7 +445,30 @@ describe( 'V6CardFieldsComponent', () => {
 			result = await paymentSetupCb();
 		} );
 
-		expect( result ).toEqual( { type: 'error', message: 'nonce expired' } );
+		expect( result ).toEqual( {
+			type: 'error',
+			message:
+				'This card could not be authorized. Please try a different payment method.',
+		} );
+	} );
+
+	test( 'shows a thrown error verbatim when it is marked user-facing', async () => {
+		const userFacing = new Error( 'Your card was declined by the bank.' );
+		userFacing.isUserFacing = true;
+		mockCreateCardOrder.mockRejectedValueOnce( userFacing );
+
+		renderComponent();
+		await waitForSessionReady();
+
+		let result;
+		await act( async () => {
+			result = await paymentSetupCb();
+		} );
+
+		expect( result ).toEqual( {
+			type: 'error',
+			message: 'Your card was declined by the bank.',
+		} );
 	} );
 
 	test( "passes the reference input's height to each V6CardFieldContainer via its own height prop, not inside style", async () => {
@@ -610,7 +654,7 @@ describe( 'V6CardFieldsComponent', () => {
 			expect( result ).toEqual( { type: 'success' } );
 		} );
 
-		test( 'reports an error and skips the exchange when 3D Secure is canceled', async () => {
+		test( 'reports the "authentication not completed" message and skips the exchange when 3D Secure is canceled', async () => {
 			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
 			session.submit.mockResolvedValueOnce( { state: 'canceled' } );
 
@@ -622,12 +666,15 @@ describe( 'V6CardFieldsComponent', () => {
 				result = await paymentSetupCb();
 			} );
 
-			expect( result.type ).toBe( 'error' );
-			expect( result.message ).toBeTruthy();
+			expect( result ).toEqual( {
+				type: 'error',
+				message:
+					'Card authentication was not completed. Please try again.',
+			} );
 			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
 		} );
 
-		test( 'reports an error and skips the exchange when the save session fails', async () => {
+		test( 'reports the friendly decline message and skips the exchange when the save session does not succeed', async () => {
 			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
 			session.submit.mockResolvedValueOnce( { state: 'failed' } );
 
@@ -639,15 +686,19 @@ describe( 'V6CardFieldsComponent', () => {
 				result = await paymentSetupCb();
 			} );
 
-			expect( result.type ).toBe( 'error' );
+			expect( result ).toEqual( {
+				type: 'error',
+				message:
+					'This card could not be authorized. Please try a different card.',
+			} );
 			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
 		} );
 
-		test( 'reports the thrown error message when the token exchange fails', async () => {
+		test( 'shows the friendly save-decline message instead of leaking a thrown error that is not marked user-facing', async () => {
 			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
 			session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
 			mockExchangeSetupToken.mockRejectedValueOnce(
-				new Error( 'exchange failed' )
+				new Error( 'internal exchange error' )
 			);
 
 			renderComponent( { config: freeTrialConfig() } );
@@ -660,8 +711,60 @@ describe( 'V6CardFieldsComponent', () => {
 
 			expect( result ).toEqual( {
 				type: 'error',
-				message: 'exchange failed',
+				message:
+					'This card could not be authorized. Please try a different card.',
+			} );
+		} );
+
+		test( 'shows a thrown error verbatim when it is marked user-facing', async () => {
+			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
+			session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+			const userFacing = new Error( 'This card is already saved.' );
+			userFacing.isUserFacing = true;
+			mockExchangeSetupToken.mockRejectedValueOnce( userFacing );
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( result ).toEqual( {
+				type: 'error',
+				message: 'This card is already saved.',
 			} );
 		} );
 	} );
+
+	describe( 'onCheckoutFail observer', () => {
+		test( 'surfaces the gateway decline message from processingResponse when present', async () => {
+			renderComponent();
+			await waitForCheckoutFailReady();
+
+			const result = checkoutFailCb( {
+				processingResponse: {
+					paymentDetails: {
+						errorMessage: 'Card declined during capture.',
+					},
+				},
+			} );
+
+			expect( result ).toEqual( {
+				type: 'error',
+				message: 'Card declined during capture.',
+			} );
+		} );
+
+		test( 'returns true, leaving the default checkout error, when no gateway error message is present', async () => {
+			renderComponent();
+			await waitForCheckoutFailReady();
+
+			expect(
+				checkoutFailCb( { processingResponse: {} } )
+			).toBe( true );
+		} );
+	} );
 } );
+

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
@@ -12,6 +12,72 @@ import { hide } from '@ppcp-button/Helper/Hiding';
 import { hostedFieldTextStyles } from './cardFieldStyles';
 
 /**
+ * Reads the input's rendered height, briefly undoing the hiding applied here.
+ *
+ * getComputedStyle() resolves height to pixels only for an element that has a
+ * layout box, and yields the literal "auto" otherwise. Showing and restoring
+ * happen within one task, so nothing is painted in between. display is set
+ * directly rather than through show()/hide(), which broadcast jQuery events
+ * other code listens for.
+ *
+ * @param {HTMLElement} inputField - The WC input being replaced.
+ * @return {string|null} The height in pixels, or null when it has no box.
+ */
+function measureHeight( inputField ) {
+	const wasHidden = inputField.hidden;
+	const display = inputField.style.getPropertyValue( 'display' );
+	const priority = inputField.style.getPropertyPriority( 'display' );
+
+	inputField.hidden = false;
+	inputField.style.removeProperty( 'display' );
+
+	const height = window.getComputedStyle( inputField ).height;
+
+	if ( display ) {
+		inputField.style.setProperty( 'display', display, priority );
+	}
+	inputField.hidden = wasHidden;
+
+	return height.endsWith( 'px' ) ? height : null;
+}
+
+/**
+ * Sizes the field to the input it replaced, correcting later when the form is
+ * not on screen yet.
+ *
+ * WooCommerce keeps the new-card form display:none while a saved payment token
+ * is selected, so a field mounted there has no layout box and measures as auto.
+ * The observer applies the height once the form is revealed. Nothing in the
+ * payment flow depends on the height being correct.
+ *
+ * @param {HTMLElement} fieldElement - The mounted v6 field.
+ * @param {HTMLElement} inputField   - The WC input being replaced.
+ */
+function applyHeight( fieldElement, inputField ) {
+	const height = measureHeight( inputField );
+	if ( height ) {
+		fieldElement.style.height = height;
+		return;
+	}
+
+	if ( typeof ResizeObserver !== 'function' ) {
+		return;
+	}
+
+	const observer = new ResizeObserver( () => {
+		const corrected = measureHeight( inputField );
+		if ( ! corrected ) {
+			return;
+		}
+
+		// Disconnect first: the write below resizes the observed element.
+		observer.disconnect();
+		fieldElement.style.height = corrected;
+	} );
+	observer.observe( fieldElement );
+}
+
+/**
  * Replaces a WC card input with its hosted v6 field, hiding the original.
  *
  * The element v6 returns is ours to size: `style.input` only reaches the text
@@ -51,9 +117,10 @@ export function mountField(
 		`ppcp-sdk-v6-card-field--${ fieldType }`
 	);
 	fieldElement.style.width = '100%';
-	fieldElement.style.height = window.getComputedStyle( inputField ).height;
 
 	inputField.parentNode.appendChild( fieldElement );
+	applyHeight( fieldElement, inputField );
+
 	hide( inputField, true );
 	inputField.hidden = true;
 }

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -24,6 +24,11 @@ import {
 import { hasJQuery } from '../utils/api';
 import { handleError } from '../utils/errorHandler';
 import { isFreeTrialCart } from '../utils/freeTrial';
+import {
+	CARD_DECLINE_MESSAGE,
+	CARD_SAVE_DECLINE_MESSAGE,
+	userFacingError,
+} from '../utils/cardDeclineMessages';
 
 const FIELD_TYPES = [ 'number', 'expiry', 'cvv' ];
 
@@ -230,7 +235,7 @@ export async function initCardFields( config, getTotal = () => undefined ) {
 					return;
 				}
 				if ( saveResult.state !== 'succeeded' ) {
-					throw new Error( 'Card could not be saved.' );
+					throw userFacingError( CARD_SAVE_DECLINE_MESSAGE );
 				}
 
 				await exchangeSetupToken( config, setupTokenId );
@@ -258,7 +263,7 @@ export async function initCardFields( config, getTotal = () => undefined ) {
 			}
 
 			if ( result.state !== 'succeeded' ) {
-				throw new Error( 'Card payment failed.' );
+				throw userFacingError( CARD_DECLINE_MESSAGE );
 			}
 
 			await approveCardOrder( config, orderId );

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
@@ -16,6 +16,10 @@ import { loadSdkV6 } from '../sdkLoader';
 import { postJson } from '../utils/api';
 import { handleError } from '../utils/errorHandler';
 import { navigation } from '../utils/navigation';
+import {
+	CARD_SAVE_DECLINE_MESSAGE,
+	userFacingError,
+} from '../utils/cardDeclineMessages';
 
 const FIELD_TYPES = [ 'number', 'expiry', 'cvv', 'name' ];
 
@@ -120,7 +124,7 @@ export function initCardSaveFields( config ) {
 				return;
 			}
 			if ( result.state !== 'succeeded' ) {
-				throw new Error( 'Card could not be saved.' );
+				throw userFacingError( CARD_SAVE_DECLINE_MESSAGE );
 			}
 
 			await postJson( config.ajax.create_payment_token, {

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -268,6 +268,137 @@ describe( 'initCardFields', () => {
 		expect( numberInput.nextSibling.style.height ).toBe( '45px' );
 	} );
 
+	test( 'leaves no bogus height on the field when the original input has no layout box at mount time, and does not throw without ResizeObserver support', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const numberInput = document.querySelector(
+			'#ppcp-credit-card-gateway-card-number'
+		);
+		numberInput.style.width = '300px';
+		// With no height set, jsdom reports "" rather than a px value, the
+		// same as a real "auto" from display:none.
+
+		const cardSession = makeCardSession();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+
+		await expect(
+			initCardFields( baseConfig() )
+		).resolves.not.toThrow();
+		await flushPromises();
+
+		expect( numberInput.nextSibling.style.height ).toBe( '' );
+	} );
+
+	describe( 'correcting the field height once the input gains a box', () => {
+		let observers;
+
+		function fireObserverFor( target ) {
+			const observer = observers.find( ( o ) => o.target === target );
+			observer.callback();
+		}
+
+		function disconnectMockFor( target ) {
+			return observers.find( ( o ) => o.target === target )
+				.disconnectMock;
+		}
+
+		beforeEach( () => {
+			observers = [];
+			global.ResizeObserver = class {
+				constructor( callback ) {
+					this.callback = callback;
+					this.disconnectMock = jest.fn();
+				}
+				observe( target ) {
+					observers.push( {
+						target,
+						callback: this.callback,
+						disconnectMock: this.disconnectMock,
+					} );
+				}
+				disconnect( ...args ) {
+					this.disconnectMock( ...args );
+				}
+			};
+		} );
+
+		afterEach( () => {
+			delete global.ResizeObserver;
+		} );
+
+		test( 'applies the height and disconnects once the input gains a box', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const numberInput = document.querySelector(
+				'#ppcp-credit-card-gateway-card-number'
+			);
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( baseConfig() );
+			await flushPromises();
+			expect( observers.length ).toBe( 3 );
+
+			numberInput.style.height = '45px';
+			fireObserverFor( numberInput.nextSibling );
+
+			expect( numberInput.nextSibling.style.height ).toBe( '45px' );
+			expect( disconnectMockFor( numberInput.nextSibling ) ).toHaveBeenCalled();
+		} );
+
+		test( 'does not write a height or disconnect when the observer fires while the input is still unmeasurable', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const numberInput = document.querySelector(
+				'#ppcp-credit-card-gateway-card-number'
+			);
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( baseConfig() );
+			await flushPromises();
+
+			fireObserverFor( numberInput.nextSibling );
+
+			expect( numberInput.nextSibling.style.height ).toBe( '' );
+			expect(
+				disconnectMockFor( numberInput.nextSibling )
+			).not.toHaveBeenCalled();
+		} );
+
+		test( 'restores the input\'s own hidden state and !important display after reading through them', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const numberInput = document.querySelector(
+				'#ppcp-credit-card-gateway-card-number'
+			);
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( baseConfig() );
+			await flushPromises();
+			// The real hide() is mocked away in this suite, so its !important
+			// display:none is applied here instead.
+			numberInput.style.setProperty( 'display', 'none', 'important' );
+
+			numberInput.style.height = '45px';
+			fireObserverFor( numberInput.nextSibling );
+
+			expect( numberInput.nextSibling.style.height ).toBe( '45px' );
+			expect( numberInput.hidden ).toBe( true );
+			expect( numberInput.style.getPropertyValue( 'display' ) ).toBe(
+				'none'
+			);
+			expect(
+				numberInput.style.getPropertyPriority( 'display' )
+			).toBe( 'important' );
+		} );
+	} );
+
 	test( 're-attaches to the fresh #payment DOM after WC replaces it on updated_checkout', async () => {
 		buildCheckoutDom( 'ppcp-credit-card-gateway' );
 		const firstSession = makeCardSession();

--- a/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.js
@@ -1,0 +1,50 @@
+/**
+ * Shopper-facing wording for a card session that did not succeed.
+ *
+ * v6 runs 3D Secure client-side, so a rejected card never reaches the PHP
+ * capture gate that produces these messages in v5. The payment wording matches
+ * CardFieldsModule::capture_rejection_message(); change it there first.
+ *
+ * @package
+ */
+
+import { __ } from '@wordpress/i18n';
+
+export const CARD_DECLINE_MESSAGE = __(
+	'This card could not be authorized. Please try a different payment method.',
+	'woocommerce-paypal-payments'
+);
+
+export const CARD_SAVE_DECLINE_MESSAGE = __(
+	'This card could not be authorized. Please try a different card.',
+	'woocommerce-paypal-payments'
+);
+
+/**
+ * The message for a thrown error, keeping internal wording away from shoppers.
+ *
+ * Server errors are marked isUserFacing by the AJAX helper (utils/api.js) and
+ * are already translated; anything else (an SDK error, a bug) falls back.
+ *
+ * @param {Object|Error} error    - The thrown error.
+ * @param {string}       fallback - The message to show for an internal error.
+ * @return {string} The message.
+ */
+export function userFacingMessage( error, fallback ) {
+	return error?.isUserFacing && error.message ? error.message : fallback;
+}
+
+/**
+ * Builds an error whose message the error handler renders verbatim.
+ *
+ * The classic-page handleError() only shows a message it knows is shopper-safe,
+ * so a decline raised on the page must opt in the same way a server error does.
+ *
+ * @param {string} message - The shopper-facing message.
+ * @return {Error} The error.
+ */
+export function userFacingError( message ) {
+	const error = new Error( message );
+	error.isUserFacing = true;
+	return error;
+}

--- a/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.test.js
@@ -1,0 +1,45 @@
+import { userFacingMessage, userFacingError } from './cardDeclineMessages';
+
+describe( 'userFacingMessage()', () => {
+	test( 'returns the fallback when the error is not marked user-facing', () => {
+		const error = new Error( 'PayPal SDK internal failure XYZ' );
+
+		expect( userFacingMessage( error, 'Fallback message.' ) ).toBe(
+			'Fallback message.'
+		);
+	} );
+
+	test( 'returns the error message when it is marked user-facing', () => {
+		const error = new Error( 'Your card was declined by the bank.' );
+		error.isUserFacing = true;
+
+		expect( userFacingMessage( error, 'Fallback message.' ) ).toBe(
+			'Your card was declined by the bank.'
+		);
+	} );
+
+	test( 'returns the fallback when a user-facing error has no message', () => {
+		const error = new Error( '' );
+		error.isUserFacing = true;
+
+		expect( userFacingMessage( error, 'Fallback message.' ) ).toBe(
+			'Fallback message.'
+		);
+	} );
+
+	test( 'returns the fallback for a null error', () => {
+		expect( userFacingMessage( null, 'Fallback message.' ) ).toBe(
+			'Fallback message.'
+		);
+	} );
+} );
+
+describe( 'userFacingError()', () => {
+	test( 'builds an Error carrying the given message and the isUserFacing flag', () => {
+		const error = userFacingError( 'This card could not be authorized.' );
+
+		expect( error ).toBeInstanceOf( Error );
+		expect( error.message ).toBe( 'This card could not be authorized.' );
+		expect( error.isUserFacing ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
*Changelog:* `(none)`

# Description

## 🐛 The problem

A card that fails 3D Secure or is declined leaves the shopper with a developer string ("Card payment failed.") on classic checkout, and with WooCommerce's generic processing error on block checkout. Neither says what went wrong or what to do next.

## 💡 Why it happens

In v5, 3D Secure runs server-side, so a rejection reaches the PHP capture gate and picks up the wording from `CardFieldsModule::capture_rejection_message()`. In v6 it runs in the browser: the rejected session never reaches that gate, and the JS renderers threw internal strings instead.

A decline that does come from `process_payment` is lost on block checkout for a second reason. The Store API clears the gateway's notices, and Blocks ignores the `errorMessage` it returns.

## ✅ The fix

One shared set of shopper-facing strings in `utils/cardDeclineMessages.js`, used by both the classic and the block renderer, matching the v5 payment wording. Errors carry an `isUserFacing` flag, so a server error is shown verbatim while an SDK or internal failure falls back to the friendly wording instead of leaking. On block checkout an `onCheckoutFail` observer puts the gateway's message back.

Two card-field defects found alongside it are fixed in their own commits: fields mounted into the hidden new-card form took the literal `auto` as their height, and block checkout gave the hosted fields plain placeholders instead of the floating labels the rest of the form uses.

## 🧪 How to verify

1. With the v6 advanced card fields enabled, pay on classic checkout with a card that rejects 3D Secure (eg `4868719033482561`). The message names the card and suggests another payment method.
2. Repeat on block checkout.

## 🖼️ Visual proof

**Classic checkout**

| Before | After |
|---|---|
| <img width="1734" height="1203" alt="2026-09-02 - classic-checkout-before" src="https://github.com/user-attachments/assets/0c76507e-e3d8-4e15-bbd1-4978ca91d30b" /> | <img width="1734" height="1203" alt="2026-09-02 - classic-checkout-new" src="https://github.com/user-attachments/assets/dc9c0f67-10db-4cda-9493-3106e731b9e7" /> |

**Block checkout**

| Before | After |
|---|---|
| <img width="1088" height="766" alt="2026-09-02 - block-checkout-before" src="https://github.com/user-attachments/assets/7d513c7d-d142-4431-b76c-12b0d96d9527" /> | <img width="1088" height="771" alt="2026-09-02 - block-checkout-new" src="https://github.com/user-attachments/assets/e1f8ddcd-131d-48b4-9f6a-75b419f45cc5" /> |
