### PR TITLE
fix(sdk-v6): match v5 button sizing on block pages and in the mini cart

### DIFF
--- a/modules/ppcp-sdk-v6/resources/css/checkout-block.scss
+++ b/modules/ppcp-sdk-v6/resources/css/checkout-block.scss
@@ -1,0 +1,19 @@
+// Widths for the express buttons on block pages.
+//
+// The v6 button Web Components are inline-block boxes of a fixed 225px, which
+// fits neither layout WooCommerce Blocks gives them: they under-fill the cart
+// block's column and overflow the checkout block's grid cell, clipping the
+// label. The wallets size themselves through the SDK and need nothing here.
+//
+// gateway.scss carries the same rule for the classic stack and the mini cart.
+// This file exists because SdkV6Manager::enqueue() deliberately skips block
+// pages, so their assets ship from V6PaymentMethod instead.
+
+.wc-block-components-express-payment__event-buttons {
+	paypal-button,
+	venmo-button,
+	paypal-pay-later-button {
+		display: block;
+		width: 100%;
+	}
+}

--- a/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.js
+++ b/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.js
@@ -21,3 +21,18 @@ export function buttonStyle( styles ) {
 		borderRadius: styles.borderRadius,
 	};
 }
+
+/**
+ * The button height for a context.
+ *
+ * The flat `button_height` is the page context's. The mini cart carries its
+ * own, shorter one, and it renders on pages whose own context is something
+ * else entirely, so the context has to be asked for by name.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} context - The page context.
+ * @return {string|undefined} The CSS length, or undefined when neither is set.
+ */
+export function buttonHeight( config, context ) {
+	return config.button_styles?.[ context ]?.height || config.button_height;
+}

--- a/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.test.js
@@ -1,0 +1,59 @@
+import { buttonHeight } from './buttonStyle';
+
+const config = ( overrides = {} ) => ( {
+	...overrides,
+} );
+
+describe( 'buttonHeight()', () => {
+	test( 'returns the per-context height even when a different flat button_height is also set', () => {
+		const result = buttonHeight(
+			config( {
+				button_height: '48px',
+				button_styles: { 'mini-cart': { height: '35px' } },
+			} ),
+			'mini-cart'
+		);
+
+		expect( result ).toBe( '35px' );
+	} );
+
+	test( 'falls back to the flat button_height when the context has no entry in button_styles', () => {
+		const result = buttonHeight(
+			config( {
+				button_height: '48px',
+				button_styles: { cart: { height: '40px' } },
+			} ),
+			'checkout'
+		);
+
+		expect( result ).toBe( '48px' );
+	} );
+
+	test( 'falls back to the flat button_height when button_styles is absent entirely', () => {
+		const result = buttonHeight(
+			config( { button_height: '48px' } ),
+			'mini-cart'
+		);
+
+		expect( result ).toBe( '48px' );
+	} );
+
+	test( 'returns undefined when neither button_styles nor button_height is set', () => {
+		const result = buttonHeight( config(), 'mini-cart' );
+
+		expect( result ).toBeUndefined();
+	} );
+
+	test( 'resolves two different contexts in the same config to their own heights', () => {
+		const conf = config( {
+			button_height: '48px',
+			button_styles: {
+				'mini-cart': { height: '35px' },
+				product: { height: '55px' },
+			},
+		} );
+
+		expect( buttonHeight( conf, 'mini-cart' ) ).toBe( '35px' );
+		expect( buttonHeight( conf, 'product' ) ).toBe( '55px' );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -24,7 +24,7 @@ import { APPLE_PAY_VERSION, buildApplePayRequest } from './applePayRequest';
 import { watchSheetTotal } from './applePaySheetTotal';
 import { applePayFailure, attachShippingHandlers } from './applePayShipping';
 import { recordDomainValidation } from './applePayValidation';
-import { buttonStyle } from '../methods/buttonStyle';
+import { buttonHeight, buttonStyle } from '../methods/buttonStyle';
 import {
 	applePayPayer,
 	applePayShippingAddress,
@@ -330,7 +330,11 @@ export async function renderApplePay( {
 	}
 
 	container.appendChild(
-		createButton( styles, overrides.height || config.button_height, pay )
+		createButton(
+			styles,
+			overrides.height || buttonHeight( config, context ),
+			pay
+		)
 	);
 }
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
@@ -22,7 +22,7 @@ import {
 	buildReadyToPayRequest,
 } from './googlePayRequest';
 import { buildPaymentDataCallbacks } from './googlePayShipping';
-import { buttonStyle } from '../methods/buttonStyle';
+import { buttonHeight, buttonStyle } from '../methods/buttonStyle';
 import {
 	googlePayPayer,
 	googlePayShippingAddress,
@@ -73,7 +73,8 @@ export async function renderGooglePay( {
 	const settings = methodConfig( config, method );
 
 	const container = document.createElement( 'div' );
-	container.style.height = overrides.height || config.button_height;
+	container.style.height =
+		overrides.height || buttonHeight( config, context );
 	wrapper.appendChild( container );
 
 	// Independent: fetching PayPal's config does not need Google's global,

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -63,6 +63,14 @@ class SdkV6Manager {
 	 */
 	public const PAYMENT_BUTTON_HEIGHT = '48px';
 
+	/**
+	 * The button height in the mini cart, which is narrower than a page column
+	 * and so carries a shorter button. Matches the v5 default for the location
+	 * (see SmartButton::script_data(), which sends 35 there and 48 for the
+	 * block contexts).
+	 */
+	public const MINI_CART_BUTTON_HEIGHT = '35px';
+
 	// The pay-for-order page has no pre-payment hook, so the message renders
 	// after the submit button and is relocated by SdkV6Module.
 	public const PAY_ORDER_MESSAGE_HOOK = 'woocommerce_pay_order_before_submit';
@@ -938,7 +946,7 @@ class SdkV6Manager {
 
 	/**
 	 * The button styles for one context, carrying the height every button in
-	 * the express stack shares.
+	 * that context's express stack shares.
 	 *
 	 * @param string $context The page context.
 	 * @return array{colorClass: string, borderRadius: string, height: string}
@@ -946,8 +954,17 @@ class SdkV6Manager {
 	private function button_styles( string $context ): array {
 		return array_merge(
 			$this->style_mapper->styles_for_context( $context ),
-			array( 'height' => self::PAYMENT_BUTTON_HEIGHT )
+			array( 'height' => $this->button_height( $context ) )
 		);
+	}
+
+	/**
+	 * The button height for a context.
+	 */
+	private function button_height( string $context ): string {
+		return 'mini-cart' === $context
+			? self::MINI_CART_BUTTON_HEIGHT
+			: self::PAYMENT_BUTTON_HEIGHT;
 	}
 
 	/**

--- a/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
+++ b/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
@@ -83,6 +83,7 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 	 * @return void
 	 */
 	public function initialize() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 	}
 
 	public function is_active() {
@@ -111,6 +112,34 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 		);
 
 		return array( $handle );
+	}
+
+	/**
+	 * Enqueues the styles for the express buttons on block pages.
+	 *
+	 * Block pages bypass SdkV6Manager::enqueue(), which serves the classic
+	 * pages only, so their styles are registered here instead.
+	 */
+	public function enqueue_style(): void {
+		if ( ! $this->is_active() ) {
+			return;
+		}
+
+		$style_url = $this->asset_getter->get_asset_url( 'checkout-block.css' );
+		if ( ! $style_url ) {
+			return;
+		}
+
+		$handle = 'wc-ppcp-sdk-v6-blocks-style';
+
+		wp_register_style(
+			$handle,
+			$style_url,
+			array(),
+			$this->version
+		);
+
+		wp_enqueue_style( $handle );
 	}
 
 	public function get_payment_method_data(): array {

--- a/modules/ppcp-sdk-v6/src/Helper/ButtonStyleMapper.php
+++ b/modules/ppcp-sdk-v6/src/Helper/ButtonStyleMapper.php
@@ -42,9 +42,9 @@ class ButtonStyleMapper {
 	 * Returns v6-compatible styles for a given context.
 	 *
 	 * Color and shape come from the styling DTOs, the same source the v5
-	 * SmartButton reads. There is no height: the styling DTOs have no
-	 * height field (the legacy button_*_height keys are unmaintained
-	 * fossils that current v5 no longer honors either).
+	 * SmartButton reads. There is no height, because the styling DTOs have no
+	 * height field; SdkV6Manager::button_height() supplies one per context
+	 * instead, matching the per-location defaults v5 sends.
 	 *
 	 * @param string $context The page context (product, cart, checkout, mini-cart).
 	 * @return array{colorClass: string, borderRadius: string}

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -1831,6 +1831,29 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
+     * GIVEN a checkout page where the mini-cart smart button location is also enabled
+     * WHEN the SDK bootstrap data is generated
+     * THEN button_styles carries a shorter height for the mini-cart entry, since the
+     *      mini-cart column is narrower than a page column and a full-height button
+     *      there renders oversized
+     * AND the checkout page's own entry keeps the full page-width button height, so the
+     *     two heights differ within the same payload rather than both falling back to
+     *     one hardcoded value
+     */
+    public function testScriptDataButtonStylesMiniCartHeightDiffersFromPageContext(): void
+    {
+        $this->stub_common_script_data_dependencies();
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
+            ->with('mini-cart')->andReturn(true);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(SdkV6Manager::PAYMENT_BUTTON_HEIGHT, $data['button_styles']['checkout']['height']);
+        $this->assertSame(SdkV6Manager::MINI_CART_BUTTON_HEIGHT, $data['button_styles']['mini-cart']['height']);
+    }
+
+    /**
      * GIVEN the BCDC row is eligible to print (checkout, BCDC enabled, the
      *       gateway available, no subscription in the cart)
      * WHEN the card button wrapper is rendered

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ const modulesAssets = {
 		'js/checkout-block.js',
 		'js/boot-add-payment-method.js',
 		'css/gateway.scss',
+		'css/checkout-block.scss',
 	],
 	'ppcp-settings': [ 'js/index.js', 'css/styles.scss' ],
 	'ppcp-wc-gateway': [


### PR DESCRIPTION
### Description

Two v6 button-sizing differences against v5, measured in the browser rather than eyeballed.

**Width, on block pages.** The v6 button Web Components are inline-block boxes of a fixed 225px, which fits neither layout WooCommerce Blocks gives them: they under-filled the cart block's column (421px) and overflowed the checkout block's grid cell (177px), clipping the label - "Pay with venmo" was cut off mid-wordmark. `gateway.scss` already corrects this for the classic stack and the mini cart, but its selectors are the classic wrapper ids and `SdkV6Manager::enqueue()` returns early for block pages, so they loaded no v6 styles at all. Block pages now get a stylesheet of their own, registered from `V6PaymentMethod`. The wallets size themselves through the SDK and needed nothing.

**Height, in the mini cart.** Every context received the same `PAYMENT_BUTTON_HEIGHT` ('48px'), so mini-cart buttons rendered around 40% taller than v5's in a dropdown far narrower than a page column. v5 sends a height per location - 35 for the mini cart, 48 for the block contexts (`SmartButton::script_data()`). The height is now resolved per context to match; the block contexts are unchanged, since 48px was already their value. The wallets separately read the flat `button_height`, which is the *page* context's - wrong for the mini cart, which renders on pages whose own context is something else - so they now read the per-context value with the flat one as fallback.

Measured before/after, at a 1600px viewport:

| Surface | Before | After |
|---|---|---|
| Cart block | 225px wide in a 421px column | 421 x 48 |
| Checkout block | 225px in a 177px cell, label clipped | 177 x 48 |
| Mini cart | 192 x 48 | 192 x 35 (matches v5) |

**Two judgement calls worth review.**

Heights are constants rather than settings reads. Matching v5 exactly would mean reading `button_mini-cart_height` with its 25-55 clamp, but the styling DTOs have no height field and the settings UI cannot set one, so those legacy keys are frozen at the migrated defaults - which are exactly 35 and 48. Constants give identical behaviour without reviving a dependency on keys nothing maintains. A merchant who hand-edited the legacy value would no longer see it honoured under v6.

This also corrects a claim in `ButtonStyleMapper` that those keys "are unmaintained fossils that current v5 no longer honors either". v5 reads them at both call sites above, and that belief is the likely reason a single height ended up hardcoded.

The card button was checked and deliberately left alone: it emits its own fixed 48px, but `is_card_button_row()` excludes block contexts and it renders as a gateway row on checkout/pay-now, never in the mini-cart stack.

No public signature changes. `V6PaymentMethod::enqueue_style()` is a new public method (a hook callback) on a concrete class.

Not tested under multisite.

### Steps to Test

Requires the v6 SDK active, with a block cart and block checkout page. A block theme is not needed - the Cart and Checkout blocks are what matter, and a classic theme can use them.

1. Enable the express buttons for the cart, express checkout and mini cart locations in the Styling tab.
2. Add a product to the cart, then open the **cart block**. PayPal, Venmo and Pay Later should span the full column, matching the Google Pay button and "Proceed to Checkout". On `dev/develop` they are roughly half the column width.
3. Open the **block checkout**. All express buttons should be equal width in the row, and "Pay with venmo" should read in full. On `dev/develop` the wordmark is clipped.
4. Hover the header cart on a page that shows the **mini cart** (e.g. the shop page or home page - WooCommerce hides the mini cart on the cart and checkout pages). The buttons should be 35px tall, noticeably shorter than before and matching v5.
5. Regression: turn the v6 SDK off and confirm the classic pages and mini cart are unchanged.
6. Regression: with v6 on, confirm the classic checkout express stack and the card button row are unchanged.

Note the v6 client-token endpoint is rate limited. Repeated page loads return 429 and the buttons then stop rendering entirely, which looks like a failure but is not - wait it out or clear the `_transient_ppcp_sdk_v6_rl_*` transients.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: Express buttons now size to their container on block cart and checkout pages, and the mini cart's buttons match their previous height.
