### PR TITLE
"No saved PayPal account" error on Place Order / express button for free-trial subscription checkout  (6880)

### DIFF
--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -409,15 +409,27 @@ const placeOrderEnabled =
  * coupon applied on the checkout is taken into account. Mirrors v5's
  * paypalPaymentMethodAllowed().
  *
+ * A free-trial ($0) subscription is the exception: it cannot be paid through
+ * this row. The "Place order" flow redirects to a PayPal order that cannot be
+ * created for a zero total, and PayPal can only vault a payment method without a
+ * purchase through an approval the buyer opens from a button. So the row is
+ * withheld and the express "Pay with PayPal" button (which runs that save flow)
+ * is offered instead. Read live, so a coupon that zeroes or un-zeroes the cart
+ * after render is honoured.
+ *
  * @param {Object} [cartTotals] - The canMakePayment cart totals.
  * @return {boolean} Whether the row may show.
  */
 function regularRowAllowedForCart( cartTotals ) {
+	const amount = amountFromCartTotals( cartTotals ) || config.amount;
+
+	if ( isFreeTrialCart( config, amount ) ) {
+		return false;
+	}
+
 	if ( config.has_subscriptions ) {
 		return true;
 	}
-
-	const amount = amountFromCartTotals( cartTotals ) || config.amount;
 
 	return parseFloat( amount ) > 0;
 }
@@ -489,7 +501,9 @@ if ( savedPayPalEligible || placeOrderEnabled ) {
 	} else {
 		rowProps = {
 			// The row exists because a saved token does, so it is always
-			// available; a new PayPal payment uses the express button.
+			// available; a new PayPal payment uses the express button. A saved
+			// token completes a free-trial order too (the gateway attaches it),
+			// so this variant carries no broken redirect to withhold.
 			content: createElement( SavedTokenNote ),
 			canMakePayment: () => true,
 		};

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -350,26 +350,47 @@ describe( 'checkout-block', () => {
 					totalPrice: '4900',
 					expected: true,
 				},
-			] )( '$name', ( { hasSubscriptions, totalPrice, expected } ) => {
-				loadCheckoutBlock(
-					baseConfig( {
-						place_order: { enabled: true, text: 'Complete order' },
-						has_subscriptions: hasSubscriptions,
-						amount: '10.00',
-					} )
-				);
+				{
+					name: 'a free-trial subscription cart at a $0 live total is not allowed: it is vaulted through the express button instead',
+					hasSubscriptions: true,
+					totalPrice: '0',
+					cartNeedsVaulting: true,
+					expected: false,
+				},
+			] )(
+				'$name',
+				( {
+					hasSubscriptions,
+					totalPrice,
+					cartNeedsVaulting,
+					expected,
+				} ) => {
+					loadCheckoutBlock(
+						baseConfig( {
+							place_order: {
+								enabled: true,
+								text: 'Complete order',
+							},
+							has_subscriptions: hasSubscriptions,
+							cart_needs_vaulting: cartNeedsVaulting,
+							amount: '10.00',
+						} )
+					);
 
-				const { canMakePayment } = regularCallFor( 'ppcp-gateway' );
+					const { canMakePayment } = regularCallFor(
+						'ppcp-gateway'
+					);
 
-				expect(
-					canMakePayment( {
-						cartTotals: {
-							total_price: totalPrice,
-							currency_minor_unit: 2,
-						},
-					} )
-				).toBe( expected );
-			} );
+					expect(
+						canMakePayment( {
+							cartTotals: {
+								total_price: totalPrice,
+								currency_minor_unit: 2,
+							},
+						} )
+					).toBe( expected );
+				}
+			);
 		} );
 
 		describe( 'when only the saved-PayPal vault row is eligible', () => {


### PR DESCRIPTION
On Block Checkout (SDK v6) with WC Subscriptions in vaulting mode, checking out a free-trial ($0) subscription via the "Proceed to PayPal" row failed with "No saved PayPal account." and created a Failed order for both guest and logged-in customers. The row runs a server-side redirect that creates a PayPal order, but a $0 free-trial can't create an order; PayPal can only vault a payment method without a purchase through an approval the buyer opens from a button, which that row never does.                                                               
                                                                                                                                                                                             
This PR hides the non-express PayPal "Place order" row for free-trial carts, so the only PayPal path is the express "Pay with PayPal" button, which runs the vault "save without purchase" flow correctly. Implemented as a single guard in `regularRowAllowedForCart()` (`checkout-block.js`): it returns false when `isFreeTrialCart()` is `true`, read from the live cart total so a coupon that zeroes/un-zeroes the cart flips the row accordingly. The saved-token row (returning buyers) stays available since it completes free-trial orders fine.