### PR TITLE
fix(sdk-v6): keep Pay Later messaging on one stack on home and shop

### DIFF
--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -573,6 +573,24 @@ class SdkV6Manager {
 			return true;
 		}
 
+		// Home and shop, where v5 places a Pay Later message and v6 has no
+		// message hook of its own yet. Whether v5 rendered there came down to the
+		// unrelated mini-cart setting: with the mini-cart on, the fallback below
+		// claimed the page and v5 went dark; with it off, v5 stayed and drew the
+		// banner. Claim the page either way, so one stack owns messaging
+		// everywhere rather than v6 and v5 splitting it per page. The message is
+		// withheld until v6 can draw it itself, at which point should_load_messages()
+		// above claims the page first and this branch stops being reached.
+		//
+		// Scoped to the empty page context so the block and page-context
+		// locations keep deciding without consulting messaging, as
+		// testShouldLoadOnCurrentPageInBlockContextsIsUnaffectedByMessagingEligibility
+		// pins.
+		$message_location = $page_location ? '' : $this->context->location();
+		if ( $message_location && $this->settings_status->is_pay_later_messaging_enabled_for_location( $message_location ) ) {
+			return true;
+		}
+
 		// Sitewide, because the mini-cart can appear on any page as either the
 		// classic "Cart" widget or the block Mini-Cart, and is_active_widget()
 		// only detects the classic one. boot.js renders into the mini-cart

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -888,6 +888,8 @@ class SdkV6ManagerTest extends TestCase
         $this->context->shouldReceive('location')->andReturn($location);
         $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
         $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        // Off, so the hand-over to v5 is not what vetoes the claim here.
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')->andReturn(false);
         $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(true);
 
         $testee = $this->createTestee();
@@ -954,6 +956,10 @@ class SdkV6ManagerTest extends TestCase
         $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
             ->with('custom_placement')
             ->andReturn(true);
+        // Off for the page's own location, so the hand-over to v5 does not apply.
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->with($location)
+            ->andReturn(false);
         // No block present, so has_paylater_block() resolves false and
         // messages_settings_location() falls back to the empty location, not
         // 'custom_placement' - the eligibility lookup below reflects that.
@@ -968,6 +974,56 @@ class SdkV6ManagerTest extends TestCase
         $testee = $this->createTestee();
 
         $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN no v6 page context (home or shop), the mini-cart smart-button location
+     *       disabled so nothing else would claim the page, and v5 Pay Later messaging
+     *       enabled for the resolved page location
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN it loads, claiming the page so the v5 stack stands down there — v6 owns
+     *      messaging wherever it is active, and withholds the message on home and shop
+     *      until it has a hook of its own rather than letting v5 draw it
+     * AND with messaging disabled for that same location nothing claims the page, so it
+     *     does not load — the claim is made only where v5 would otherwise have drawn a
+     *     banner
+     *
+     * @dataProvider homeShopMessagingClaimProvider
+     */
+    public function testShouldLoadOnCurrentPageClaimsHomeAndShopWhereV5WouldOtherwiseRenderAMessage(
+        string $location,
+        bool $messaging_enabled,
+        bool $expected
+    ): void {
+        $this->context->shouldReceive('context')->andReturn('');
+        $this->context->shouldReceive('location')->andReturn($location);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        // Off, so the sitewide fallback cannot claim the page and the messaging
+        // decision below is the only thing that can.
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
+            ->andReturn(false);
+        // Catch-all so an incidental call for 'custom_placement' (reachable through
+        // messages_settings_location()'s has_paylater_block() check) does not throw.
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->andReturn(false)
+            ->byDefault();
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->with($location)
+            ->andReturn($messaging_enabled);
+
+        $testee = $this->createTestee();
+
+        $this->assertSame($expected, $testee->should_load_on_current_page());
+    }
+
+    public function homeShopMessagingClaimProvider(): array
+    {
+        return [
+            'home page is claimed when v5 has a message there' => ['home', true, true],
+            'shop page is claimed when v5 has a message there' => ['shop', true, true],
+            'home page is left alone when v5 has no message'   => ['home', false, false],
+            'shop page is left alone when v5 has no message'   => ['shop', false, false],
+        ];
     }
 
     /**


### PR DESCRIPTION
### Description

On home and shop, whether the Pay Later banner appeared came down to the **mini-cart button** — a setting with nothing to do with messaging. With the mini-cart enabled, the sitewide fallback in `SdkV6Manager::resolve_should_load()` claimed the page and the v5 stack was swapped for `DisabledSmartButton`, so the banner vanished. With it disabled, v5 stayed and drew the banner. Same site, same v6, opposite results — that inconsistency is the actual defect behind the report, rather than the banner being visible as such.

v6 has no message hook for home or shop (`messages_render_hook()` handles checkout, cart, product and pay-now only), so it cannot render one there yet.

Per the discussion on this: v6 owns messaging wherever it is active, rather than splitting it with v5 per page. These pages are now claimed whenever v5 would have had a message for them, so the banner is withheld consistently instead of depending on an unrelated toggle. **Stored configuration is untouched**, so the message returns once v6 renders these locations as text (planned for 4.1.4).

Scoped to an empty page context, so the block and page-context locations keep deciding without consulting messaging eligibility — an invariant `testShouldLoadOnCurrentPageInBlockContextsIsUnaffectedByMessagingEligibility` already pins.

**Impact.** No signature or hook changes. Behaviour change: with v6 active, a merchant who had Pay Later messaging configured for home/shop no longer sees it on those pages. That was already the case whenever the mini-cart button was enabled; this makes it consistent. Everything else is untouched — the classic and block checkout, cart, product and pay-now messaging all decide exactly as before, and the mini-cart itself is unaffected.

Not tested under multisite.

### Steps to Test

Requires the v6 SDK active and Pay Later messaging enabled for Home and Shop (on a site upgraded from v5 the settings migration carries those over; on a fresh site Home defaults to off).

1. Set the **mini-cart** button to **disabled** in the Styling tab — this is the combination that leaked the banner.
2. Visit the home page and the shop page. No Pay Later banner should appear. On `dev/release/4.1.3` the banner renders on both.
3. Enable the mini-cart button and revisit both pages. Still no banner — the point of the change is that the two settings now agree.
4. Regression: confirm Pay Later messaging still renders where v6 supports it — classic checkout, cart and product pages.
5. Regression: confirm the mini-cart button itself still renders and pays.
6. Regression: with the v6 SDK disabled, confirm the v5 banner still renders on home and shop as before.

Note the v6 client-token endpoint is rate limited — repeated page loads return 429 and the buttons stop rendering entirely, which looks like a failure but is not.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: Pay Later messaging on the home and shop pages no longer appears or disappears depending on the mini-cart button setting when the v6 SDK is active.
