### PR TITLE
Resolve this site's own webhook instead of whichever one PayPal lists first (6885)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -277,7 +277,8 @@ return array(
 		return new WebhookSettingsEndpoint(
 			$container->get( 'api.endpoint.webhook' ),
 			$container->get( 'webhook.registrar' ),
-			$container->get( 'webhook.status.simulation' )
+			$container->get( 'webhook.status.simulation' ),
+			$container->get( 'webhook.own-resolver' )
 		);
 	},
 	'settings.rest.pay_later_messaging'                   => static function ( ContainerInterface $container ): PayLaterMessagingEndpoint {

--- a/modules/ppcp-settings/src/Endpoint/WebhookSettingsEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/WebhookSettingsEndpoint.php
@@ -14,6 +14,7 @@ use WP_REST_Response;
 use WP_REST_Server;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 use stdClass;
@@ -53,21 +54,31 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	private WebhookSimulation $webhook_simulation;
 
 	/**
-	 * WebhookSettingsEndpoint constructor.
-	 *
-	 * @param WebhookEndpoint   $webhook_endpoint   A list of subscribed webhooks and a webhook
-	 *                                              endpoint URL.
-	 * @param WebhookRegistrar  $webhook_registrar  A service that allows resubscribing webhooks.
-	 * @param WebhookSimulation $webhook_simulation A service that allows webhook simulations.
+	 * Tells this site's own webhook apart from other sites' webhooks on the same app.
+	 */
+	private OwnWebhookResolver $own_webhook_resolver;
+
+	/**
+	 * @param WebhookEndpoint    $webhook_endpoint     A list of subscribed webhooks and a
+	 *                                                 webhook endpoint URL.
+	 * @param WebhookRegistrar   $webhook_registrar    A service that allows resubscribing
+	 *                                                 webhooks.
+	 * @param WebhookSimulation  $webhook_simulation   A service that allows webhook
+	 *                                                 simulations.
+	 * @param OwnWebhookResolver $own_webhook_resolver Tells this site's own webhook apart
+	 *                                                 from other sites' webhooks on the same
+	 *                                                 app.
 	 */
 	public function __construct(
 		WebhookEndpoint $webhook_endpoint,
 		WebhookRegistrar $webhook_registrar,
-		WebhookSimulation $webhook_simulation
+		WebhookSimulation $webhook_simulation,
+		OwnWebhookResolver $own_webhook_resolver
 	) {
-		$this->webhook_endpoint   = $webhook_endpoint;
-		$this->webhook_registrar  = $webhook_registrar;
-		$this->webhook_simulation = $webhook_simulation;
+		$this->webhook_endpoint     = $webhook_endpoint;
+		$this->webhook_registrar    = $webhook_registrar;
+		$this->webhook_simulation   = $webhook_simulation;
+		$this->own_webhook_resolver = $own_webhook_resolver;
 	}
 
 	/**
@@ -194,15 +205,14 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 
 
 	/**
-	 * Retrieves the Webhooks API response object.
+	 * Retrieves this site's own webhook from the PayPal app
+	 * (it can include webhooks of other sites).
 	 *
 	 * @return Webhook|null The webhook data instance, or null.
 	 */
 	private function get_webhook_data(): ?Webhook {
 		try {
-			$api_response = $this->webhook_endpoint->list();
-
-			return $api_response[0] ?? null;
+			return $this->own_webhook_resolver->find_own( $this->webhook_endpoint->list() );
 		} catch ( Throwable $error ) {
 			return null;
 		}

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookEventStorage;
 
 /**
@@ -147,7 +148,10 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 						'label'          => esc_html__( 'Webhook delivery host', 'woocommerce-paypal-payments' ),
 						'exported_label' => 'Webhook delivery host',
 						'description'    => esc_html__( 'Whether PayPal delivers webhooks to this site or to a different host.', 'woocommerce-paypal-payments' ),
-						'value'          => $this->webhook_delivery_host_status( $this->registered_webhooks( $c, $is_connected ) ),
+						'value'          => $this->webhook_delivery_host_status(
+							$this->registered_webhooks( $c, $is_connected ),
+							$c->get( 'webhook.own-resolver' )
+						),
 					),
 					array(
 						'label'          => esc_html__( 'PayPal Vault enabled', 'woocommerce-paypal-payments' ),
@@ -335,36 +339,37 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 	/**
 	 * Reports whether PayPal's registered webhook points at this site.
 	 *
-	 * Compares each registered webhook's host against this site's host. When they
-	 * differ, webhook events are being delivered elsewhere - typically a staging or dev
-	 * clone connected to the same PayPal account - which the "Webhook status" row above
-	 * cannot detect.
+	 * Asks the resolver which webhooks deliver to this install's incoming endpoint.
+	 * When none of them does, webhook events are going elsewhere.
 	 *
-	 * @param Webhook[] $registered_webhooks The live PayPal-side registered webhooks.
+	 * points_here() rather than is_own() on purpose: the question is where PayPal
+	 * delivers now, so a webhook we once registered under a former domain must not
+	 * excuse a mismatch.
+	 *
+	 * @param Webhook[]          $registered_webhooks The live PayPal-side registered webhooks.
+	 * @param OwnWebhookResolver $resolver            Tells this install's webhook apart from other sites'.
 	 * @return string
 	 */
-	private function webhook_delivery_host_status( array $registered_webhooks ): string {
-		$site_host = $this->normalized_host( home_url() );
-
-		$foreign_hosts = array();
+	private function webhook_delivery_host_status( array $registered_webhooks, OwnWebhookResolver $resolver ): string {
+		$foreign_targets = array();
 		foreach ( $registered_webhooks as $webhook ) {
 			if ( ! $webhook instanceof Webhook ) {
 				continue;
 			}
 
-			$webhook_host = $this->normalized_host( $webhook->url() );
-			if ( '' === $webhook_host ) {
-				continue;
-			}
-
-			if ( $webhook_host === $site_host ) {
+			if ( $resolver->points_here( $webhook ) ) {
 				return $this->bool_to_html( true );
 			}
 
-			$foreign_hosts[ $webhook_host ] = $webhook_host;
+			$webhook_identity = $resolver->identity( $webhook->url() );
+			if ( $webhook_identity === '' ) {
+				continue;
+			}
+
+			$foreign_targets[ $webhook_identity ] = $webhook_identity;
 		}
 
-		if ( array() === $foreign_hosts ) {
+		if ( $foreign_targets === array() ) {
 			return $this->bool_to_html( false );
 		}
 
@@ -372,24 +377,12 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 			'<mark class="error"><span class="dashicons dashicons-warning"></span> %s</mark>',
 			esc_html(
 				sprintf(
-					/* translators: 1: host(s) receiving the webhooks, 2: this site's host. */
+					/* translators: 1: host(s) and path(s) receiving the webhooks, 2: this site's own webhook host and path. */
 					__( 'Delivered to %1$s (this site: %2$s)', 'woocommerce-paypal-payments' ),
-					implode( ', ', $foreign_hosts ),
-					$site_host
+					implode( ', ', $foreign_targets ),
+					$resolver->own_identity()
 				)
 			)
 		);
-	}
-
-	/**
-	 * Extracts the lower-cased host from a URL, or an empty string when it cannot be parsed.
-	 *
-	 * @param string $url The URL to extract the host from.
-	 * @return string
-	 */
-	private function normalized_host( string $url ): string {
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-
-		return is_string( $host ) ? strtolower( $host ) : '';
 	}
 }

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -33,6 +33,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureReversed;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentSaleCompleted;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentSaleRefunded;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\VaultPaymentTokenDeleted;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 return array(
@@ -51,7 +52,13 @@ return array(
 			$last_webhook_storage,
 			$container->get( 'webhook.status.simulation' ),
 			$container->get( 'webhook.orchestration' ),
-			$logger
+			$logger,
+			$container->get( 'webhook.own-resolver' )
+		);
+	},
+	'webhook.own-resolver'                    => static function ( ContainerInterface $container ): OwnWebhookResolver {
+		return new OwnWebhookResolver(
+			$container->get( 'webhook.endpoint.controller' )
 		);
 	},
 	'webhook.orchestration'                   => static function ( ContainerInterface $container ): WebhookOrchestrator {

--- a/modules/ppcp-webhooks/src/OwnWebhookResolver.php
+++ b/modules/ppcp-webhooks/src/OwnWebhookResolver.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+
+/**
+ * Decides which of the webhooks configured on the connected PayPal REST app
+ * belongs to this install.
+ *
+ * Sometimes a REST app can end up with several sites, and PayPal returns every webhook
+ * on the app in creation order.
+ */
+class OwnWebhookResolver {
+
+	private IncomingWebhookEndpoint $incoming_webhook_endpoint;
+
+	public function __construct( IncomingWebhookEndpoint $incoming_webhook_endpoint ) {
+		$this->incoming_webhook_endpoint = $incoming_webhook_endpoint;
+	}
+
+	/**
+	 * Whether the given webhook belongs to this install.
+	 *
+	 * A webhook is considered ours when either:
+	 * - its id matches the one we previously stored (provably ours regardless of the
+	 *   host it currently uses, so a domain migration or NGROK_HOST rotation still
+	 *   recognizes our former webhook instead of leaking it), or
+	 * - its URL identity (host + path) equals this install's incoming endpoint.
+	 *
+	 * @param Webhook $webhook The webhook to check.
+	 */
+	public function is_own( Webhook $webhook ): bool {
+		$stored_id = $this->stored_id();
+		if ( $stored_id !== '' && $webhook->id() === $stored_id ) {
+			return true;
+		}
+
+		return $this->points_here( $webhook );
+	}
+
+	/**
+	 * Whether the given webhook currently delivers to this install.
+	 *
+	 * Unlike is_own(), the stored webhook id is ignored: a webhook we registered
+	 * ourselves but which still points at a former domain does not deliver here.
+	 *
+	 * @param Webhook $webhook The webhook to check.
+	 */
+	public function points_here( Webhook $webhook ): bool {
+		$own_identity = $this->own_identity();
+
+		return $own_identity !== '' && $own_identity === $this->identity( $webhook->url() );
+	}
+
+	/**
+	 * Returns the webhook this install registered, out of the given list.
+	 *
+	 * @param Webhook[] $webhooks The webhooks configured on the PayPal REST app.
+	 */
+	public function find_own( array $webhooks ): ?Webhook {
+		foreach ( $webhooks as $webhook ) {
+			if ( $webhook instanceof Webhook && $this->is_own( $webhook ) ) {
+				return $webhook;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Builds a host+path identity for a webhook URL, used to compare webhooks
+	 * independently of scheme, port, query string or a trailing slash.
+	 *
+	 * The path is included so that same-host installs (e.g. example.com/shop and
+	 * example.com/staging, or subdirectory multisite) are told apart.
+	 *
+	 * @param string $url The webhook URL.
+	 * @return string The lower-cased host followed by the path as-is (paths are case-sensitive),
+	 *                or an empty string when the host cannot be parsed.
+	 */
+	public function identity( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+		$path = is_string( $path ) ? rtrim( $path, '/' ) : '';
+
+		return strtolower( $host ) . $path;
+	}
+
+	/**
+	 * This install's own webhook identity, or an empty string when its URL cannot be parsed.
+	 */
+	public function own_identity(): string {
+		return $this->identity( $this->own_url() );
+	}
+
+	/**
+	 * The webhook URL this install registers with PayPal.
+	 */
+	public function own_url(): string {
+		return $this->incoming_webhook_endpoint->url();
+	}
+
+	/**
+	 * The id of the webhook this install registered, or an empty string.
+	 *
+	 * Read fresh on every call, it can be updated mid-request.
+	 */
+	private function stored_id(): string {
+		return (string) ( ( (array) get_option( WebhookRegistrar::KEY, array() ) )['id'] ?? '' );
+	}
+}

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -6,7 +6,6 @@ namespace WooCommerce\PayPalCommerce\Webhooks;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
@@ -32,6 +31,8 @@ class WebhookRegistrar {
 
 	private LoggerInterface $logger;
 
+	private OwnWebhookResolver $own_webhook_resolver;
+
 	public function __construct(
 		WebhookFactory $webhook_factory,
 		WebhookEndpoint $endpoint,
@@ -39,7 +40,8 @@ class WebhookRegistrar {
 		WebhookEventStorage $last_webhook_event_storage,
 		WebhookSimulation $webhook_simulation,
 		WebhookOrchestrator $webhook_orchestrator,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		OwnWebhookResolver $own_webhook_resolver
 	) {
 
 		$this->webhook_factory            = $webhook_factory;
@@ -49,6 +51,7 @@ class WebhookRegistrar {
 		$this->webhook_simulation         = $webhook_simulation;
 		$this->webhook_orchestrator       = $webhook_orchestrator;
 		$this->logger                     = $logger;
+		$this->own_webhook_resolver       = $own_webhook_resolver;
 	}
 
 	/**
@@ -122,13 +125,10 @@ class WebhookRegistrar {
 	 * the primary site's webhook. See GitHub issue #4604.
 	 */
 	private function do_unregister(): void {
-		$stored_id    = (string) ( ( (array) get_option( self::KEY, array() ) )['id'] ?? '' );
-		$own_identity = $this->webhook_identity( $this->incoming_webhook_endpoint->url() );
-
 		try {
 			$webhooks = $this->endpoint->list();
 			foreach ( $webhooks as $webhook ) {
-				if ( ! $this->is_own_webhook( $webhook, $own_identity, $stored_id ) ) {
+				if ( ! $this->own_webhook_resolver->is_own( $webhook ) ) {
 					$this->logger->warning(
 						"Skipping deletion of webhook {$webhook->id()} ({$webhook->url()}): it belongs to a different site and is not managed by this install."
 					);
@@ -148,53 +148,5 @@ class WebhookRegistrar {
 		delete_option( self::KEY );
 		$this->last_webhook_event_storage->clear();
 		$this->logger->info( 'Webhooks deleted.' );
-	}
-
-	/**
-	 * Whether the given webhook belongs to this site and may be deleted.
-	 *
-	 * A webhook is considered ours when either:
-	 * - its id matches the one we previously stored (provably ours regardless of the
-	 *   host it currently uses, so a domain migration or NGROK_HOST rotation still
-	 *   cleans up our former webhook instead of leaking it), or
-	 * - its URL identity (host + path) equals this install's incoming endpoint. The
-	 *   path is included so that same-host installs (e.g. example.com/shop and
-	 *   example.com/staging, or subdirectory multisite) do not delete each other's
-	 *   webhooks. The host comparison honours the NGROK_HOST development override.
-	 *
-	 * A webhook whose URL cannot be parsed (empty identity) is left in place.
-	 *
-	 * @param Webhook $webhook      The webhook to check.
-	 * @param string  $own_identity This install's incoming endpoint identity (host + path).
-	 * @param string  $stored_id    The id of the webhook this install previously registered.
-	 * @return bool
-	 */
-	private function is_own_webhook( Webhook $webhook, string $own_identity, string $stored_id ): bool {
-		if ( '' !== $stored_id && $webhook->id() === $stored_id ) {
-			return true;
-		}
-
-		$webhook_identity = $this->webhook_identity( $webhook->url() );
-
-		return '' !== $own_identity && $own_identity === $webhook_identity;
-	}
-
-	/**
-	 * Builds a host+path identity for a webhook URL, used to compare webhooks
-	 * independently of scheme, port, query string or a trailing slash.
-	 *
-	 * @param string $url The webhook URL.
-	 * @return string The lower-cased host and path, or an empty string when the host cannot be parsed.
-	 */
-	private function webhook_identity( string $url ): string {
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( ! is_string( $host ) || '' === $host ) {
-			return '';
-		}
-
-		$path = wp_parse_url( $url, PHP_URL_PATH );
-		$path = is_string( $path ) ? rtrim( $path, '/' ) : '';
-
-		return strtolower( $host ) . $path;
 	}
 }

--- a/tests/PHPUnit/Settings/Endpoint/WebhookSettingsEndpointTest.php
+++ b/tests/PHPUnit/Settings/Endpoint/WebhookSettingsEndpointTest.php
@@ -1,0 +1,118 @@
+<?php
+declare( strict_types=1 );
+
+namespace PHPUnit\Settings\Endpoint;
+
+use Mockery;
+use WP_REST_Response;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\WebhookSettingsEndpoint;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Webhooks\IncomingWebhookEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
+use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Settings\Endpoint\WebhookSettingsEndpoint
+ */
+class WebhookSettingsEndpointTest extends TestCase {
+
+	/** @var WebhookEndpoint&Mockery\MockInterface */
+	private $webhook_endpoint;
+
+	/** @var WebhookRegistrar&Mockery\MockInterface */
+	private $webhook_registrar;
+
+	/** @var WebhookSimulation&Mockery\MockInterface */
+	private $webhook_simulation;
+
+	/** @var IncomingWebhookEndpoint&Mockery\MockInterface */
+	private $incoming_webhook_endpoint;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		when( 'rest_ensure_response' )->alias( static fn( $data ) => new WP_REST_Response( $data ) );
+		when( 'wp_parse_url' )->alias( 'parse_url' );
+		when( 'get_option' )->justReturn( [] );
+
+		$this->webhook_endpoint          = Mockery::mock( WebhookEndpoint::class );
+		$this->webhook_registrar         = Mockery::mock( WebhookRegistrar::class );
+		$this->webhook_simulation        = Mockery::mock( WebhookSimulation::class );
+		$this->incoming_webhook_endpoint = Mockery::mock( IncomingWebhookEndpoint::class );
+
+		$this->incoming_webhook_endpoint->shouldReceive( 'url' )
+			->andReturn( 'https://mysite.com/wp-json/paypal/v1/incoming' );
+	}
+
+	private function createEndpoint(): WebhookSettingsEndpoint {
+		return new WebhookSettingsEndpoint(
+			$this->webhook_endpoint,
+			$this->webhook_registrar,
+			$this->webhook_simulation,
+			new OwnWebhookResolver( $this->incoming_webhook_endpoint )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal account with a foreign site's webhook listed FIRST and this
+	 * site's own webhook listed SECOND
+	 * WHEN fetching webhook data
+	 * THEN this site's own webhook URL and lower-cased event names are returned
+	 *
+	 * Regression case for PCP-6885: fetching list()[0] would have surfaced the
+	 * foreign webhook instead of this install's own one.
+	 */
+	public function test_get_webhooks_returns_own_webhook_when_foreign_webhook_is_listed_first(): void {
+		$foreign_webhook = new Webhook( 'https://other-clone.com/wp-json/paypal/v1/incoming', [ (object) [ 'name' => 'PAYMENT.CAPTURE.COMPLETED' ] ], 'FOREIGN' );
+		$own_webhook     = new Webhook(
+			'https://mysite.com/wp-json/paypal/v1/incoming',
+			[ (object) [ 'name' => 'CHECKOUT.ORDER.APPROVED' ] ],
+			'OWN'
+		);
+
+		$this->webhook_endpoint->shouldReceive( 'list' )->andReturn( [ $foreign_webhook, $own_webhook ] );
+
+		$response = $this->createEndpoint()->get_webhooks();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'https://mysite.com/wp-json/paypal/v1/incoming', $data['data']['url'] );
+		$this->assertSame( [ 'checkout.order.approved' ], $data['data']['events'] );
+	}
+
+	/**
+	 * GIVEN a PayPal account whose only registered webhooks belong to other sites
+	 * WHEN fetching webhook data
+	 * THEN a failure response is returned reporting no webhooks were found
+	 */
+	public function test_get_webhooks_reports_failure_when_only_foreign_webhooks_exist(): void {
+		$foreign_webhook = new Webhook( 'https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN' );
+
+		$this->webhook_endpoint->shouldReceive( 'list' )->andReturn( [ $foreign_webhook ] );
+
+		$response = $this->createEndpoint()->get_webhooks();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['success'] );
+		$this->assertSame( 'No webhooks found.', $data['message'] );
+	}
+
+	/**
+	 * GIVEN the PayPal webhook list request fails
+	 * WHEN fetching webhook data
+	 * THEN a failure response is returned instead of erroring out
+	 */
+	public function test_get_webhooks_reports_failure_when_listing_webhooks_throws(): void {
+		$this->webhook_endpoint->shouldReceive( 'list' )->andThrow( new RuntimeException( 'API unavailable' ) );
+
+		$response = $this->createEndpoint()->get_webhooks();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['success'] );
+	}
+}

--- a/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
+++ b/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
@@ -9,6 +9,8 @@ use ReflectionMethod;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Webhooks\IncomingWebhookEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -24,6 +26,7 @@ class StatusReportModuleTest extends TestCase
 		parent::setUp();
 
 		when('wp_parse_url')->alias('parse_url');
+		when('get_option')->justReturn([]);
 
 		if (!defined('MINUTE_IN_SECONDS')) {
 			define('MINUTE_IN_SECONDS', 60);
@@ -32,12 +35,20 @@ class StatusReportModuleTest extends TestCase
 		$this->sut = new StatusReportModule();
 	}
 
-	private function webhook_delivery_host_status(array $registered_webhooks): string
+	private function createResolver(string $own_url = 'https://mysite.com/wp-json/paypal/v1/incoming'): OwnWebhookResolver
+	{
+		$incoming_webhook_endpoint = Mockery::mock(IncomingWebhookEndpoint::class);
+		$incoming_webhook_endpoint->shouldReceive('url')->andReturn($own_url);
+
+		return new OwnWebhookResolver($incoming_webhook_endpoint);
+	}
+
+	private function webhook_delivery_host_status(array $registered_webhooks, ?OwnWebhookResolver $resolver = null): string
 	{
 		$method = new ReflectionMethod(StatusReportModule::class, 'webhook_delivery_host_status');
 		$method->setAccessible(true);
 
-		return $method->invoke($this->sut, $registered_webhooks);
+		return $method->invoke($this->sut, $registered_webhooks, $resolver ?? $this->createResolver());
 	}
 
 	private function registered_webhooks(ContainerInterface $c, bool $is_connected): array
@@ -56,8 +67,6 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_yes_when_a_registered_webhook_matches_this_site(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([
 			new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
 			new Webhook('https://MySite.com/wp-json/paypal/v1/incoming', [], 'OWN'),
@@ -73,14 +82,15 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_reports_foreign_hosts_when_no_registered_webhook_matches_this_site(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([
 			new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
 		]);
 
 		$this->assertStringContainsString('<mark class="error">', $result);
-		$this->assertStringContainsString('Delivered to other-clone.com (this site: mysite.com)', $result);
+		$this->assertStringContainsString(
+			'Delivered to other-clone.com/wp-json/paypal/v1/incoming (this site: mysite.com/wp-json/paypal/v1/incoming)',
+			$result
+		);
 	}
 
 	/**
@@ -91,8 +101,6 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_dash_when_list_contains_only_non_webhook_items(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([new \stdClass(), 'a-string']);
 
 		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
@@ -105,8 +113,6 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_dash_when_webhooks_have_unparseable_hosts(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([
 			new Webhook('not a url', [], 'BROKEN'),
 			new Webhook('', [], 'EMPTY'),
@@ -122,11 +128,33 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_dash_for_empty_webhook_list(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([]);
 
 		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN two sibling installs registered under different subdirectories of the same host
+	 * (e.g. example.com/shop and example.com/staging)
+	 * WHEN determining the webhook delivery host status
+	 * THEN the sibling's webhook is treated as foreign and the row reports the mismatch,
+	 * not a match, since host-only comparison used to conflate the two installs
+	 */
+	public function test_reports_foreign_when_sibling_subdirectory_install_shares_host(): void
+	{
+		$resolver = $this->createResolver('https://example.com/shop/wp-json/paypal/v1/incoming');
+
+		$sibling_webhook = new Webhook('https://example.com/staging/wp-json/paypal/v1/incoming', [], 'SIBLING');
+
+		$result = $this->webhook_delivery_host_status([$sibling_webhook], $resolver);
+
+		$this->assertStringContainsString('<mark class="error">', $result);
+
+		// Host-only reporting rendered this as the nonsensical "example.com (this site: example.com)".
+		$this->assertStringContainsString(
+			'Delivered to example.com/staging/wp-json/paypal/v1/incoming (this site: example.com/shop/wp-json/paypal/v1/incoming)',
+			$result
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/Webhooks/OwnWebhookResolverTest.php
+++ b/tests/PHPUnit/Webhooks/OwnWebhookResolverTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver
+ */
+class OwnWebhookResolverTest extends TestCase
+{
+	/** @var IncomingWebhookEndpoint&Mockery\MockInterface */
+	private $incoming_webhook_endpoint;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		when('wp_parse_url')->alias('parse_url');
+
+		// Default: no webhook was previously stored for this install; individual
+		// tests override this when exercising the stored-id matching path.
+		when('get_option')->justReturn([]);
+
+		$this->incoming_webhook_endpoint = Mockery::mock(IncomingWebhookEndpoint::class);
+	}
+
+	private function createResolver(): OwnWebhookResolver
+	{
+		return new OwnWebhookResolver($this->incoming_webhook_endpoint);
+	}
+
+	/**
+	 * GIVEN webhook URLs that only differ by host case, a trailing slash, a port, a
+	 * query string, or the scheme
+	 * WHEN computing their identity
+	 * THEN all variants normalize to the same identity
+	 *
+	 * @dataProvider identity_normalization_provider
+	 */
+	public function test_identity_normalizes_url_variants(string $url): void
+	{
+		$this->assertSame(
+			'mysite.com/wp-json/paypal/v1/incoming',
+			$this->createResolver()->identity($url)
+		);
+	}
+
+	public function identity_normalization_provider(): array
+	{
+		return [
+			'plain'                => ['https://mysite.com/wp-json/paypal/v1/incoming'],
+			'host case differs'    => ['https://MySite.com/wp-json/paypal/v1/incoming'],
+			'trailing slash'       => ['https://mysite.com/wp-json/paypal/v1/incoming/'],
+			'port is ignored'      => ['https://mysite.com:8080/wp-json/paypal/v1/incoming'],
+			'query string ignored' => ['https://mysite.com/wp-json/paypal/v1/incoming?token=abc'],
+			'scheme is ignored'    => ['http://mysite.com/wp-json/paypal/v1/incoming'],
+		];
+	}
+
+	/**
+	 * GIVEN a URL that cannot be parsed into a host
+	 * WHEN computing its identity
+	 * THEN an empty string is returned
+	 *
+	 * @dataProvider unparseable_url_provider
+	 */
+	public function test_identity_returns_empty_string_for_unparseable_url(string $url): void
+	{
+		$resolver = $this->createResolver();
+
+		$this->assertSame('', $resolver->identity($url));
+	}
+
+	public function unparseable_url_provider(): array
+	{
+		return [
+			'not a valid URL' => ['not-a-valid-url'],
+			'empty string'    => [''],
+		];
+	}
+
+	/**
+	 * GIVEN this install previously stored a webhook id, and the webhook's host has since
+	 * changed (e.g. an NGROK_HOST rotation or domain migration)
+	 * WHEN checking whether a webhook with that stored id belongs to this install
+	 * THEN it is recognized as ours despite the host mismatch
+	 */
+	public function test_is_own_true_when_stored_id_matches_despite_host_change(): void
+	{
+		when('get_option')->justReturn([
+			'id'  => 'STORED_ID',
+			'url' => 'https://old-host.com/wp-json/paypal/v1/incoming',
+		]);
+
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://new-host.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://old-host.com/wp-json/paypal/v1/incoming', [], 'STORED_ID');
+
+		$this->assertTrue($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN no webhook id was previously stored for this install
+	 * WHEN checking whether a webhook whose URL matches this install's incoming endpoint host+path belongs to it
+	 * THEN it is recognized as ours
+	 */
+	public function test_is_own_true_on_url_identity_match_with_no_stored_id(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'SOME_ID');
+
+		$this->assertTrue($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a webhook registered on the same host as this install but under a different path
+	 * (e.g. sibling subdirectory installs)
+	 * WHEN checking whether it belongs to this install
+	 * THEN it is treated as foreign
+	 */
+	public function test_is_own_false_for_same_host_different_path(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://example.com/shop/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://example.com/staging/wp-json/paypal/v1/incoming', [], 'SIBLING');
+
+		$this->assertFalse($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a webhook registered for a completely different host
+	 * WHEN checking whether it belongs to this install
+	 * THEN it is treated as foreign
+	 */
+	public function test_is_own_false_for_foreign_host(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+
+		$this->assertFalse($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a webhook whose URL has no parseable host
+	 * WHEN checking whether it belongs to this install
+	 * THEN it is treated as foreign
+	 */
+	public function test_is_own_false_for_unparseable_webhook_url(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('not-a-valid-url', [], 'BROKEN');
+
+		$this->assertFalse($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a foreign webhook is listed FIRST and this install's own webhook is listed SECOND
+	 * WHEN finding this install's own webhook in the list
+	 * THEN the own webhook is still returned regardless of its position
+	 *
+	 * Regression case for PCP-6885: the previous code took list()[0], so a foreign
+	 * webhook returned first on the PayPal app hid the own webhook entirely.
+	 */
+	public function test_find_own_returns_own_webhook_when_foreign_webhook_is_listed_first(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$foreign_webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+		$own_webhook     = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+
+		$found = $this->createResolver()->find_own([$foreign_webhook, $own_webhook]);
+
+		$this->assertNotNull($found);
+		$this->assertSame('OWN', $found->id());
+	}
+
+	/**
+	 * GIVEN a list of webhooks none of which belong to this install
+	 * WHEN finding this install's own webhook
+	 * THEN null is returned
+	 */
+	public function test_find_own_returns_null_when_no_webhook_matches(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$foreign_webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+
+		$this->assertNull($this->createResolver()->find_own([$foreign_webhook]));
+	}
+
+	/**
+	 * GIVEN no webhooks are registered on PayPal's side
+	 * WHEN finding this install's own webhook
+	 * THEN null is returned
+	 */
+	public function test_find_own_returns_null_for_empty_list(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$this->assertNull($this->createResolver()->find_own([]));
+	}
+
+	/**
+	 * GIVEN a webhook list contaminated with non-Webhook values
+	 * WHEN finding this install's own webhook
+	 * THEN the malformed entries are skipped and the actual own webhook is still found
+	 */
+	public function test_find_own_skips_non_webhook_values(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$own_webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+
+		$found = $this->createResolver()->find_own([new \stdClass(), 'a-string', $own_webhook]);
+
+		$this->assertNotNull($found);
+		$this->assertSame('OWN', $found->id());
+	}
+}

--- a/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
+++ b/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
@@ -74,7 +74,8 @@ class WebhookRegistrarTest extends TestCase
 			$this->last_webhook_event_storage,
 			$this->webhook_simulation,
 			$this->webhook_orchestrator,
-			$this->logger
+			$this->logger,
+			new OwnWebhookResolver($this->incoming_webhook_endpoint)
 		);
 	}
 


### PR DESCRIPTION
## 🐛 The problem

The webhook readback (e.g. in Settings → Payments → PayPal → Troubleshooting) retrieves **whichever webhook PayPal happens to return first**, not this site's. On a PayPal REST app shared with another site, the panel shows a foreign notification URL and subscribed event list, and Resubscribe never corrects it.

## 💡 Why it happens

`WebhookSettingsEndpoint::get_webhook_data()` took `WebhookEndpoint::list()[0]`, and `list()` returns every webhook configured on the connected app in PayPal's creation order. Nothing tied that entry to the webhook this install registered.

This was latent for a long time because registration used to delete *all* webhooks on the app before creating its own, so index 0 was ours by construction. #4609 scoped deregistration to webhooks belonging to the current site and index 0 stopped being guaranteed to be ours.

## ✅ The fix

`OwnWebhookResolver` now answers "is this webhook ours": the id stored in the `ppcp-webhook` option wins, otherwise the host and path of `IncomingWebhookEndpoint::url()`. The settings readback, `WebhookRegistrar` deregistration, and the system status report all go through it.

Note about the status report: it used a **third, divergent** comparison of its own (host only, against `home_url()`), so it mistook sibling subdirectory installs for the same site and warned falsely when `NGROK_HOST` was set.

## 🔍 What to review

- **The fallback is still a heuristic.** With no stored id, ownership is "the webhook whose host and path match ours", not a provable link. The id path covers the normal case.
- **The status row deliberately ignores the stored id**, using `points_here()` rather than `is_own()`: a webhook we registered under a former domain must not excuse a delivery mismatch. Its warning text now prints host and path instead of host alone, because host-only rendered the sibling case as the nonsensical `Delivered to example.com (this site: example.com)`.

## 🧪 Tests

`WebhookSettingsEndpoint` had no coverage at all; it now has some, including the exact regression: a foreign webhook first in the list, ours second. `OwnWebhookResolver` covers identity normalization, the stored-id path across a host change, and sibling subdirectory installs. `WebhookRegistrarTest`'s existing cases pass unchanged, which is the evidence that deregistration behavior did not move.

## 🧪 How to verify

1. `npm run unit-tests && npm run lint`
2. Connect a site, then add a second webhook to the same REST app pointing at another host, created *before* this site's, so PayPal lists it first.
3. Reload Settings → Payments → PayPal → Troubleshooting and confirm the Notification URL is this site's.
4. Re-onboard and confirm the foreign webhook survives while this site's is recreated.
5. In WooCommerce → Status, check the **Webhook delivery host** row: a tick with only our webhook present, a warning naming the foreign target otherwise.