### PR TITLE
fix(wc-gateway): keep the gateway a shopper chose after a failed PayPal attempt

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use WC_Order;
+use WC_Session;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
@@ -999,11 +1000,38 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				if ( $order->get_payment_method() === CreditCardGateway::ID ) {
 					return;
 				}
+				if ( ! $this->shopper_is_paying_with_ppcp() ) {
+					return;
+				}
 				$order->set_payment_method( PayPalGateway::ID );
 			},
 			10,
 			1
 		);
+	}
+
+	/**
+	 * Whether the shopper's session still says they are paying with one of our gateways.
+	 *
+	 * The order meta the caller checks outlives the attempt that wrote it, so on its own
+	 * it cannot tell a payment in flight from one the shopper abandoned before choosing
+	 * another gateway. Asking the session narrows the override to the first case: a
+	 * shopper who has since selected another gateway keeps that choice, and so does every
+	 * context with no shopper session at all - the admin order screen, cron, webhooks.
+	 */
+	private function shopper_is_paying_with_ppcp(): bool {
+		if ( ! function_exists( 'WC' ) ) {
+			return false;
+		}
+
+		$session = WC()->session;
+		if ( ! $session instanceof WC_Session ) {
+			return false;
+		}
+
+		$chosen = $session->get( 'chosen_payment_method' );
+
+		return is_string( $chosen ) && 0 === strpos( $chosen, 'ppcp-' );
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/WCGatewayModuleTest.php
+++ b/tests/PHPUnit/WcGateway/WCGatewayModuleTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use ReflectionMethod;
+use WC_Session;
+use WooCommerce\PayPalCommerce\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+class WCGatewayModuleTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * GIVEN the shopper's session still has a PCP gateway id chosen
+	 * WHEN shopper_is_paying_with_ppcp is called
+	 * THEN it returns true
+	 *
+	 * @dataProvider ppcp_chosen_payment_method_provider
+	 */
+	public function testReturnsTrueForPpcpChosenPaymentMethod(string $chosen_payment_method): void
+	{
+		$this->stub_wc_session_with_chosen_payment_method($chosen_payment_method);
+
+		$this->assertTrue($this->invoke_shopper_is_paying_with_ppcp());
+	}
+
+	public function ppcp_chosen_payment_method_provider(): array
+	{
+		return [
+			'main PayPal gateway' => ['ppcp-gateway'],
+			'credit card gateway' => ['ppcp-credit-card-gateway'],
+		];
+	}
+
+	/**
+	 * GIVEN the shopper's session says they chose Direct Bank Transfer after a failed PayPal attempt
+	 * WHEN shopper_is_paying_with_ppcp is called
+	 * THEN it returns false, so the order's payment method is not forced back to PayPal
+	 */
+	public function testReturnsFalseWhenShopperChoseNonPpcpGateway(): void
+	{
+		$this->stub_wc_session_with_chosen_payment_method('bacs');
+
+		$this->assertFalse($this->invoke_shopper_is_paying_with_ppcp());
+	}
+
+	/**
+	 * GIVEN WC()->session holds a value that is not a chosen payment method string
+	 * WHEN shopper_is_paying_with_ppcp is called
+	 * THEN it returns false
+	 *
+	 * @dataProvider non_ppcp_session_value_provider
+	 */
+	public function testReturnsFalseForNonPpcpSessionValue($chosen_payment_method): void
+	{
+		$this->stub_wc_session_with_chosen_payment_method($chosen_payment_method);
+
+		$this->assertFalse($this->invoke_shopper_is_paying_with_ppcp());
+	}
+
+	public function non_ppcp_session_value_provider(): array
+	{
+		return [
+			'empty string'    => [''],
+			'non-string array' => [['unexpected']],
+			'non-string null' => [null],
+		];
+	}
+
+	/**
+	 * GIVEN there is no shopper session, e.g. on the admin order screen, in cron, or in a webhook
+	 * WHEN shopper_is_paying_with_ppcp is called
+	 * THEN it returns false without touching the session
+	 */
+	public function testReturnsFalseWhenWcSessionIsMissing(): void
+	{
+		$woocommerce = Mockery::mock(\WooCommerce::class);
+		$woocommerce->session = null;
+		when('WC')->justReturn($woocommerce);
+
+		$this->assertFalse($this->invoke_shopper_is_paying_with_ppcp());
+	}
+
+	/**
+	 * @param mixed $chosen_payment_method
+	 */
+	private function stub_wc_session_with_chosen_payment_method($chosen_payment_method): void
+	{
+		$session = Mockery::mock(WC_Session::class);
+		$session->shouldReceive('get')
+			->with('chosen_payment_method')
+			->andReturn($chosen_payment_method);
+
+		$woocommerce = Mockery::mock(\WooCommerce::class);
+		$woocommerce->session = $session;
+
+		when('WC')->justReturn($woocommerce);
+	}
+
+	private function invoke_shopper_is_paying_with_ppcp(): bool
+	{
+		$module = new WCGatewayModule();
+
+		$method = new ReflectionMethod($module, 'shopper_is_paying_with_ppcp');
+		$method->setAccessible(true);
+
+		return $method->invoke($module);
+	}
+}


### PR DESCRIPTION
### Description

A `woocommerce_before_order_object_save` hook in `WCGatewayModule` forces an order's payment method back to `ppcp-gateway` whenever the order carries the `_ppcp_paypal_order_id` meta. That meta is written as soon as a PayPal order is associated with the WC order and outlives the attempt, so it cannot tell a payment in flight from one the shopper abandoned before choosing another gateway.

A shopper whose PayPal, card or wallet attempt failed **after** the order was created, and who then retried with Direct Bank Transfer, had that choice reverted on the next save. Only the slug is rewritten (`WC_Order::set_payment_method()` sets the title only when passed a gateway object), so the order ends up with `payment_method = ppcp-gateway` alongside `payment_method_title = "Direct bank transfer"`. `WC_Gateway_BACS::email_instructions()` gates on the slug, so the customer's on-hold email arrives with **no bank details and no instructions** and they have nothing to pay against. The reporter saw two such orders in three weeks on a live store, at €636 and €480.

Reproduced on a clean install, and confirmed fixed:

| | before | after |
|---|---|---|
| Order after a failed PayPal attempt, shopper picks BACS | `payment_method = ppcp-gateway` | `bacs` |
| BACS on-hold email for that order | 0 bytes, no IBAN | 629 bytes, IBAN + instructions |
| Plain BACS order (control) | `bacs`, 629 bytes | unchanged |

**Wider than the title.** Every local APM gateway (iDEAL, Blik, EPS, Bancontact, P24, Trustly, MyBank, Multibanco, OXXO, PWC) writes the same meta, so an abandoned APM attempt reverted the same way, and to `ppcp-gateway` rather than the method actually tried.

The override is now narrowed to the case it was written for: the shopper's session still naming one of our gateways. `ApproveOrderEndpoint` locks `chosen_payment_method` to PayPal for the block express flow this hook protects (added by the same commit that added the hook), so that flow is unaffected. A shopper who has since selected another gateway keeps it, and so does every context with no shopper session at all: the admin order screen, cron and webhooks.

**What was not reproduced.** The hook was added for a concurrent Store API cart request racing the express checkout POST and resetting `_payment_method`. That race needs genuine concurrency and I could not reproduce it, so the fix preserving it is argued from the code and verified for the session states the guard reads, rather than demonstrated end to end. That is the part worth reviewing hardest.

Two approaches were tried and rejected on the way, in case they come up in review. Scoping to `woocommerce_rest_checkout_process_payment_with_context` cannot work, because the racing save happens in a separate PHP process where a checkout-request flag is not visible. Scoping to draft orders cannot work either, because `DraftOrderTrait::is_valid_draft_order()` also accepts the pending and failed orders being retried, which is exactly the reported order.

No signature or hook changes. Not tested under multisite.

### Steps to Test

Requires Direct Bank Transfer enabled with a bank account configured, plus PayPal Payments.

1. Place an order and let a PayPal, card or Google Pay attempt fail **after** the WC order is created, so the order carries `_ppcp_paypal_order_id`. A card declined by the sandbox works.
2. Retry on the same order and select **Direct Bank Transfer**.
3. Inspect the order. `payment_method` should be `bacs`, matching the title. On `dev/develop` it is `ppcp-gateway`.
4. Check the customer on-hold email. It should contain the bank details and the BACS instructions. On `dev/develop` both are missing.
5. Regression: a plain BACS order with no prior PayPal attempt behaves as before.
6. Regression: express PayPal on the block checkout still records PayPal as the payment method on the order and on the order edit screen, including when another PCP gateway is sorted first under WooCommerce → Settings → Payments.
7. Regression: editing and saving such an order in wp-admin no longer rewrites its payment method.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: An order no longer reverts to the PayPal gateway when the customer switches to another payment method after a failed PayPal attempt, which stopped Direct Bank Transfer on-hold emails from including the bank details.
