### PR TITLE
Add a BCDC redirect gateway to Block Checkout (6882)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
+++ b/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
@@ -175,6 +175,20 @@ class ExperienceContextBuilder {
 	}
 
 	/**
+	 * Uses the given landing page, ignoring the merchant setting.
+	 *
+	 * @param string $landing_page An ExperienceContext::LANDING_PAGE_* value.
+	 */
+	public function with_landing_page( string $landing_page ): ExperienceContextBuilder {
+		$builder = clone $this;
+
+		$builder->experience_context = $builder->experience_context
+			->with_landing_page( $landing_page );
+
+		return $builder;
+	}
+
+	/**
 	 * Uses the payment method preference from the settings.
 	 */
 	public function with_current_payment_method_preference(): ExperienceContextBuilder {

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -207,10 +207,7 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 
 			// Same reason as the wallets: paypal-guest-payments is only
 			// requested where the card button renders.
-			if (
-				method === FundingSources.CARD &&
-				! config.card_button?.enabled
-			) {
+			if ( method === FundingSources.CARD && ! config.card_button?.row ) {
 				continue;
 			}
 

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.js
@@ -1,11 +1,7 @@
 /**
  * The Basic Card (BCDC) button element, placed in its own gateway row by
- * cardButton/renderCardButton.js.
- *
- * Deliberately not in components/buttonRenderer.js, which draws into the shared
- * express wrapper: keeping the element here makes "the card button never joins
- * the express stack" true by construction rather than by a condition someone
- * can relax.
+ * cardButton/renderCardButton.js. Kept out of components/buttonRenderer.js so it
+ * cannot end up in the shared express wrapper.
  *
  * @package
  */
@@ -19,9 +15,8 @@ export const CARD_BUTTON_CLICK_EVENT = 'bcdc-click';
 /**
  * Builds the button element and its required container, detached.
  *
- * The button checks on connect that its parent is a
- * <paypal-basic-card-container>, so the tree must be assembled before any of it
- * enters the document.
+ * The button checks its parent on connect, so assemble the tree before it enters
+ * the document.
  *
  * @param {Object}  styles         - Style config from the card_button subtree.
  * @param {?string} [buyerCountry] - ISO 3166-1 alpha-2 buyer country.

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.js
@@ -1,7 +1,7 @@
 /**
- * The Basic Card (BCDC) button element, placed in its own gateway row by
- * cardButton/renderCardButton.js. Kept out of components/buttonRenderer.js so it
- * cannot end up in the shared express wrapper.
+ * The Basic Card (BCDC) button element, mounted into its gateway row by
+ * cardButton/renderCardButton.js. Kept separate from that file so the express
+ * placement, dropped from block checkout but not gone for good, can reuse it.
  *
  * @package
  */

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.js
@@ -1,0 +1,59 @@
+/**
+ * The Basic Card (BCDC) button element, placed in its own gateway row by
+ * cardButton/renderCardButton.js.
+ *
+ * Deliberately not in components/buttonRenderer.js, which draws into the shared
+ * express wrapper: keeping the element here makes "the card button never joins
+ * the express stack" true by construction rather than by a condition someone
+ * can relax.
+ *
+ * @package
+ */
+
+/**
+ * The event the SDK's card button dispatches on click. Documented contract; a
+ * plain 'click' listener only works by way of the element's shadow internals.
+ */
+export const CARD_BUTTON_CLICK_EVENT = 'bcdc-click';
+
+/**
+ * Builds the button element and its required container, detached.
+ *
+ * The button checks on connect that its parent is a
+ * <paypal-basic-card-container>, so the tree must be assembled before any of it
+ * enters the document.
+ *
+ * @param {Object}  styles         - Style config from the card_button subtree.
+ * @param {?string} [buyerCountry] - ISO 3166-1 alpha-2 buyer country.
+ * @return {{container: HTMLElement, button: HTMLElement}} The detached pair.
+ */
+export function createCardButtonElements( styles, buyerCountry ) {
+	const container = document.createElement( 'paypal-basic-card-container' );
+	const button = document.createElement( 'paypal-basic-card-button' );
+
+	if ( buyerCountry ) {
+		button.buyerCountry = buyerCountry;
+	}
+
+	if ( styles?.borderRadius ) {
+		button.style.setProperty(
+			'--paypal-button-border-radius',
+			styles.borderRadius
+		);
+	}
+
+	if ( styles?.height ) {
+		button.style.height = styles.height;
+	}
+
+	// The element ships a fixed 225px width, where v5's card button spanned the
+	// checkout column. An outer declaration wins over its own :host rule.
+	if ( styles?.width ) {
+		container.style.width = styles.width;
+		button.style.width = styles.width;
+	}
+
+	container.appendChild( button );
+
+	return { container, button };
+}

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/cardButtonElement.test.js
@@ -1,0 +1,65 @@
+import { createCardButtonElements } from './cardButtonElement';
+
+describe( 'createCardButtonElements()', () => {
+	test( 'builds a detached container/button pair', () => {
+		const { container, button } = createCardButtonElements( {}, null );
+
+		expect( container.tagName ).toBe( 'PAYPAL-BASIC-CARD-CONTAINER' );
+		expect( button.tagName ).toBe( 'PAYPAL-BASIC-CARD-BUTTON' );
+		expect( container.contains( button ) ).toBe( true );
+		expect( container.isConnected ).toBe( false );
+	} );
+
+	test( 'does not set buyerCountry when none is given', () => {
+		const { button } = createCardButtonElements( {}, undefined );
+
+		expect( button.buyerCountry ).toBeUndefined();
+	} );
+
+	test( 'sets buyerCountry as a JS property on the button', () => {
+		const { button } = createCardButtonElements( {}, 'DE' );
+
+		expect( button.buyerCountry ).toBe( 'DE' );
+	} );
+
+	test( 'applies the border radius as the paypal button border-radius custom property', () => {
+		const { button } = createCardButtonElements(
+			{ borderRadius: '4px' },
+			null
+		);
+
+		expect(
+			button.style.getPropertyValue( '--paypal-button-border-radius' )
+		).toBe( '4px' );
+	} );
+
+	test( 'applies height to the button only', () => {
+		const { container, button } = createCardButtonElements(
+			{ height: '55px' },
+			null
+		);
+
+		expect( button.style.height ).toBe( '55px' );
+		expect( container.style.height ).toBe( '' );
+	} );
+
+	test( 'applies width to both the container and the button', () => {
+		const { container, button } = createCardButtonElements(
+			{ width: '225px' },
+			null
+		);
+
+		expect( container.style.width ).toBe( '225px' );
+		expect( button.style.width ).toBe( '225px' );
+	} );
+
+	test( 'applies no styles when none are configured', () => {
+		const { container, button } = createCardButtonElements(
+			undefined,
+			null
+		);
+
+		expect( button.style.length ).toBe( 0 );
+		expect( container.style.length ).toBe( 0 );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.js
@@ -1,9 +1,7 @@
 /**
- * Renders the Basic Card button (BCDC) as its own payment-method row.
- *
- * Kept out of components/buttonRenderer.js, which draws into the shared express
- * wrapper: separate files make "the card button never joins the express stack"
- * true by construction rather than by a condition someone can relax.
+ * Renders the Basic Card button (BCDC) as its own payment-method row, which only
+ * the classic pages have. Block checkout redirects to PayPal's hosted card page
+ * instead; see checkout-block.js.
  *
  * @package
  */
@@ -12,54 +10,10 @@ import { createOrder } from '../endpointsAdapter';
 import { handleError } from '../utils/errorHandler';
 import { FundingSources } from '../utils/fundingSources';
 import { revealMethodGateway } from '../methods/gatewayPlacement';
-
-/**
- * The event the SDK's card button dispatches on click. Documented contract; a
- * plain 'click' listener only works by way of the element's shadow internals.
- */
-const CLICK_EVENT = 'bcdc-click';
-
-/**
- * Builds the button element and its required container, detached.
- *
- * The button checks on connect that its parent is a
- * <paypal-basic-card-container>, so the tree must be assembled before any of it
- * enters the document.
- *
- * @param {Object}  styles         - Style config from the card_button subtree.
- * @param {?string} [buyerCountry] - ISO 3166-1 alpha-2 buyer country.
- * @return {{container: HTMLElement, button: HTMLElement}} The detached pair.
- */
-function createCardButtonElements( styles, buyerCountry ) {
-	const container = document.createElement( 'paypal-basic-card-container' );
-	const button = document.createElement( 'paypal-basic-card-button' );
-
-	if ( buyerCountry ) {
-		button.buyerCountry = buyerCountry;
-	}
-
-	if ( styles?.borderRadius ) {
-		button.style.setProperty(
-			'--paypal-button-border-radius',
-			styles.borderRadius
-		);
-	}
-
-	if ( styles?.height ) {
-		button.style.height = styles.height;
-	}
-
-	// The element ships a fixed 225px width, where v5's card button spanned the
-	// checkout column. An outer declaration wins over its own :host rule.
-	if ( styles?.width ) {
-		container.style.width = styles.width;
-		button.style.width = styles.width;
-	}
-
-	container.appendChild( button );
-
-	return { container, button };
-}
+import {
+	CARD_BUTTON_CLICK_EVENT as CLICK_EVENT,
+	createCardButtonElements,
+} from './cardButtonElement';
 
 /**
  * Renders the card button into its gateway row, if it belongs on this page.
@@ -72,7 +26,9 @@ function createCardButtonElements( styles, buyerCountry ) {
  * @return {Promise<void>} Resolves once the pass is done.
  */
 export async function initCardButton( config, ensureSessions ) {
-	if ( ! config.card_button?.enabled ) {
+	// The row, not `enabled`: availability alone is also true on block checkout,
+	// where there is no gateway row and no wrapper to render into.
+	if ( ! config.card_button?.row ) {
 		return;
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.js
@@ -26,8 +26,6 @@ import {
  * @return {Promise<void>} Resolves once the pass is done.
  */
 export async function initCardButton( config, ensureSessions ) {
-	// The row, not `enabled`: availability alone is also true on block checkout,
-	// where there is no gateway row and no wrapper to render into.
 	if ( ! config.card_button?.row ) {
 		return;
 	}

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.test.js
@@ -19,7 +19,7 @@ const baseConfig = ( overrides = {} ) => ( {
 	page_context: 'checkout',
 	buyer_country: 'US',
 	card_button: {
-		enabled: true,
+		row: true,
 		wrapper: '#card-button-wrapper',
 		payment_method: 'ppcp-card-button-gateway',
 		styles: {},
@@ -37,11 +37,11 @@ beforeEach( () => {
 } );
 
 describe( 'initCardButton', () => {
-	test( 'does nothing when card_button.enabled is false', async () => {
+	test( 'does nothing when card_button.row is false', async () => {
 		const ensureSessions = jest.fn();
 
 		await initCardButton(
-			baseConfig( { card_button: { enabled: false } } ),
+			baseConfig( { card_button: { row: false } } ),
 			ensureSessions
 		);
 

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -212,6 +212,10 @@ if ( config && config.page_context && config.continuation ) {
 	 *                                          supports. Deliberately without
 	 *                                          a default, so a wallet cannot
 	 *                                          inherit PayPal's list.
+	 * @param {string}   [args.label]           - The buyer-facing label, for a
+	 *                                          method whose name is the
+	 *                                          merchant's to set rather than a
+	 *                                          brand.
 	 */
 	const registerExpress = ( {
 		name,
@@ -220,8 +224,9 @@ if ( config && config.page_context && config.continuation ) {
 		content,
 		isDeviceCapable,
 		features,
+		label: labelOverride,
 	} ) => {
-		const label = fundingSourceLabel( fundingSource );
+		const label = labelOverride || fundingSourceLabel( fundingSource );
 
 		registerExpressPaymentMethod( {
 			/*
@@ -242,7 +247,7 @@ if ( config && config.page_context && config.continuation ) {
 			label: createElement( 'div', null, label ),
 			ariaLabel: label,
 			content,
-			edit: createElement( V6EditorPreview, { fundingSource } ),
+			edit: createElement( V6EditorPreview, { fundingSource, label } ),
 			canMakePayment: async ( { cartTotals } = {} ) => {
 				if ( isDeviceCapable && ! isDeviceCapable() ) {
 					return false;
@@ -312,6 +317,34 @@ if ( config && config.page_context && config.continuation ) {
 			features: settings.supported_features,
 		} );
 	}
+}
+
+// BCDC. A plain redirect method here, with no SDK involvement: the v6 guest
+// session renders its card form inline, which needs an express placement that
+// WooCommerce then disables, so "Place order" hands off to PayPal instead.
+// CardButtonGateway already does that - with no approved order in the session it
+// creates one and returns PayPal's hosted checkout URL to redirect to.
+//
+// Skipped in continuation mode, like the card fields.
+if ( config?.card_button?.block_method && ! config.continuation ) {
+	const cardButtonDescription = __(
+		'Pay securely with your credit or debit card. You will be redirected to PayPal to complete your payment.',
+		'woocommerce-paypal-payments'
+	);
+
+	registerPaymentMethod( {
+		name: config.card_button.payment_method,
+		label: createElement( 'div', null, config.card_button.title ),
+		ariaLabel: config.card_button.title,
+		content: createElement( 'div', null, cardButtonDescription ),
+		edit: createElement( 'div', null, cardButtonDescription ),
+		canMakePayment: () => true,
+		supports: {
+			features: gatewayFeatures( config.card_button.supported_features ),
+			// PayPal's hosted card page cannot vault into WooCommerce.
+			showSaveOption: false,
+		},
+	} );
 }
 
 /**

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -340,17 +340,14 @@ if ( config && config.page_context && config.continuation ) {
 	}
 }
 
-// BCDC. A plain redirect method here, with no SDK involvement: the v6 guest
-// session renders its card form inline, which needs an express placement that
-// WooCommerce then disables, so "Place order" hands off to PayPal instead.
-// CardButtonGateway already does that - with no approved order in the session it
-// creates one and returns PayPal's hosted checkout URL to redirect to.
-//
-// Skipped in continuation mode, like the card fields.
+// BCDC, redirecting rather than using the SDK: its card form only renders
+// inline, which needs an express placement that WooCommerce then disables.
+// CardButtonGateway returns PayPal's hosted checkout URL when the session holds
+// no approved order. Skipped in continuation mode, like the card fields.
 if ( config?.card_button?.block_method && ! config.continuation ) {
 	const cardButtonId = config.card_button.payment_method;
-	// Shared with the non-express PayPal row: both send the buyer to PayPal, so
-	// both say so, and a merchant filtering that wording moves them together.
+	// Shared with the non-express PayPal row, so a merchant retitling the button
+	// moves both.
 	const placeOrder = config.place_order || {};
 
 	registerPaymentMethod( {

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -130,6 +130,32 @@ function gatewayFeatures( features ) {
 	return features || [ 'products' ];
 }
 
+/**
+ * Relabels "Place order" while a redirect method is selected.
+ *
+ * The registration's own placeOrderButtonLabel is not honoured on its own by the
+ * Checkout Actions block, which reads the label through this filter instead.
+ * Same belt-and-braces pair as v5.
+ *
+ * @param {string} gatewayId - The method whose selection changes the label.
+ * @param {string} label     - The label to show while it is selected.
+ */
+function registerPlaceOrderLabel( gatewayId, label ) {
+	if ( ! label ) {
+		return;
+	}
+
+	window.wc?.blocksCheckout?.registerCheckoutFilters?.( gatewayId, {
+		placeOrderButtonLabel: ( defaultLabel ) => {
+			const payment = window.wp?.data?.select( 'wc/store/payment' );
+
+			return payment?.getActivePaymentMethod?.() === gatewayId
+				? label
+				: defaultLabel;
+		},
+	} );
+}
+
 if ( config && config.page_context && config.continuation ) {
 	registerPaymentMethod( {
 		name: PAYPAL_GATEWAY_ID,
@@ -327,17 +353,23 @@ if ( config && config.page_context && config.continuation ) {
 //
 // Skipped in continuation mode, like the card fields.
 if ( config?.card_button?.block_method && ! config.continuation ) {
-	const cardButtonDescription = __(
-		'Pay securely with your credit or debit card. You will be redirected to PayPal to complete your payment.',
-		'woocommerce-paypal-payments'
-	);
+	const cardButtonId = config.card_button.payment_method;
+	// Shared with the non-express PayPal row: both send the buyer to PayPal, so
+	// both say so, and a merchant filtering that wording moves them together.
+	const placeOrder = config.place_order || {};
 
 	registerPaymentMethod( {
-		name: config.card_button.payment_method,
+		name: cardButtonId,
 		label: createElement( 'div', null, config.card_button.title ),
 		ariaLabel: config.card_button.title,
-		content: createElement( 'div', null, cardButtonDescription ),
-		edit: createElement( 'div', null, cardButtonDescription ),
+		content: createElement( PayPalPlaceOrderContent, {
+			description: config.card_button.description,
+			placeOrderButtonDescription: placeOrder.description,
+		} ),
+		edit: createElement( PayPalPlaceOrderContent, {
+			description: config.card_button.description,
+		} ),
+		placeOrderButtonLabel: placeOrder.text,
 		canMakePayment: () => true,
 		supports: {
 			features: gatewayFeatures( config.card_button.supported_features ),
@@ -345,6 +377,8 @@ if ( config?.card_button?.block_method && ! config.continuation ) {
 			showSaveOption: false,
 		},
 	} );
+
+	registerPlaceOrderLabel( cardButtonId, placeOrder.text );
 }
 
 /**
@@ -538,24 +572,8 @@ if ( savedPayPalEligible || placeOrderEnabled ) {
 		},
 	} );
 
-	// placeOrderButtonLabel above is not honoured on its own by the Checkout
-	// Actions block, which reads the label through this filter instead. Same
-	// belt-and-braces pair as v5.
 	if ( placeOrderEnabled ) {
-		const placeOrderButtonLabel = ( defaultLabel ) => {
-			const payment = window.wp?.data?.select( 'wc/store/payment' );
-
-			if ( payment?.getActivePaymentMethod?.() !== PAYPAL_GATEWAY_ID ) {
-				return defaultLabel;
-			}
-
-			return config.place_order.text;
-		};
-
-		window.wc?.blocksCheckout?.registerCheckoutFilters?.(
-			PAYPAL_GATEWAY_ID,
-			{ placeOrderButtonLabel }
-		);
+		registerPlaceOrderLabel( PAYPAL_GATEWAY_ID, config.place_order.text );
 	}
 }
 

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -238,10 +238,6 @@ if ( config && config.page_context && config.continuation ) {
 	 *                                          supports. Deliberately without
 	 *                                          a default, so a wallet cannot
 	 *                                          inherit PayPal's list.
-	 * @param {string}   [args.label]           - The buyer-facing label, for a
-	 *                                          method whose name is the
-	 *                                          merchant's to set rather than a
-	 *                                          brand.
 	 */
 	const registerExpress = ( {
 		name,
@@ -250,9 +246,8 @@ if ( config && config.page_context && config.continuation ) {
 		content,
 		isDeviceCapable,
 		features,
-		label: labelOverride,
 	} ) => {
-		const label = labelOverride || fundingSourceLabel( fundingSource );
+		const label = fundingSourceLabel( fundingSource );
 
 		registerExpressPaymentMethod( {
 			/*
@@ -273,7 +268,7 @@ if ( config && config.page_context && config.continuation ) {
 			label: createElement( 'div', null, label ),
 			ariaLabel: label,
 			content,
-			edit: createElement( V6EditorPreview, { fundingSource, label } ),
+			edit: createElement( V6EditorPreview, { fundingSource } ),
 			canMakePayment: async ( { cartTotals } = {} ) => {
 				if ( isDeviceCapable && ! isDeviceCapable() ) {
 					return false;

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -133,9 +133,8 @@ function gatewayFeatures( features ) {
 /**
  * Relabels "Place order" while a redirect method is selected.
  *
- * The registration's own placeOrderButtonLabel is not honoured on its own by the
- * Checkout Actions block, which reads the label through this filter instead.
- * Same belt-and-braces pair as v5.
+ * The registration's own placeOrderButtonLabel is not enough: the Checkout
+ * Actions block reads the label through this filter. Same pair as v5.
  *
  * @param {string} gatewayId - The method whose selection changes the label.
  * @param {string} label     - The label to show while it is selected.

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -99,7 +99,9 @@ async function createInstance( config, context ) {
 		components.push( 'card-fields' );
 	}
 	// The basic card button lives in its own component, not in paypal-payments.
-	if ( config.card_button?.enabled ) {
+	// Only the classic row needs it; on blocks BCDC redirects to PayPal instead
+	// of using the SDK.
+	if ( config.card_button?.row ) {
 		components.push( 'paypal-guest-payments' );
 	}
 	if ( config.fastlane?.enabled ) {

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -98,9 +98,8 @@ async function createInstance( config, context ) {
 	if ( config.card_fields?.enabled ) {
 		components.push( 'card-fields' );
 	}
-	// The basic card button lives in its own component, not in paypal-payments.
-	// Only the classic row needs it; on blocks BCDC redirects to PayPal instead
-	// of using the SDK.
+	// Its own component, not part of paypal-payments, and only the classic row
+	// uses the SDK at all.
 	if ( config.card_button?.row ) {
 		components.push( 'paypal-guest-payments' );
 	}

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
@@ -71,8 +71,8 @@ describe( 'loadSdkV6', () => {
 			],
 		],
 		[
-			'the card button enabled',
-			{ card_button: { enabled: true } },
+			'the card button rendering its classic row',
+			{ card_button: { row: true } },
 			[ 'paypal-payments', 'venmo-payments', 'paypal-guest-payments' ],
 		],
 		[
@@ -130,9 +130,9 @@ describe( 'loadSdkV6', () => {
 		);
 	} );
 
-	test( 'does not request paypal-guest-payments when the card button is explicitly disabled', async () => {
+	test( 'does not request paypal-guest-payments when the card button has no classic row', async () => {
 		await loadSdkV6(
-			baseConfig( { card_button: { enabled: false } } ),
+			baseConfig( { card_button: { row: false } } ),
 			'checkout'
 		);
 

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -337,6 +337,28 @@ describe( 'checkout-block', () => {
 				).toBe( 'Complete order' );
 			} );
 
+			test( 'registers a placeOrderButtonLabel checkout filter for ppcp-gateway that resolves to place_order.text while it is the active payment method', () => {
+				loadCheckoutBlock(
+					baseConfig( {
+						place_order: { enabled: true, text: 'Complete order' },
+					} )
+				);
+				window.wp = {
+					data: {
+						select: () => ( {
+							getActivePaymentMethod: () => 'ppcp-gateway',
+						} ),
+					},
+				};
+
+				const { placeOrderButtonLabel } =
+					checkoutFiltersFor( 'ppcp-gateway' );
+
+				expect( placeOrderButtonLabel( 'Place order' ) ).toBe(
+					'Complete order'
+				);
+			} );
+
 			test( 'does not show saved cards when the vault component is not eligible', () => {
 				loadCheckoutBlock(
 					baseConfig( {

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -539,28 +539,6 @@ describe( 'checkout-block', () => {
 			expect( supports.features ).toEqual( [ 'products' ] );
 		} );
 
-		test( 'disables the save-payment-method option, since a hosted PayPal card page cannot vault into WooCommerce', () => {
-			loadCheckoutBlock(
-				baseConfig( { card_button: cardButtonConfig() } )
-			);
-
-			const { supports } = regularCallFor( 'ppcp-card-button-gateway' );
-
-			expect( supports.showSaveOption ).toBe( false );
-		} );
-
-		test( 'canMakePayment is true unconditionally, with no eligibility check', () => {
-			loadCheckoutBlock(
-				baseConfig( { card_button: cardButtonConfig() } )
-			);
-
-			const { canMakePayment } = regularCallFor(
-				'ppcp-card-button-gateway'
-			);
-
-			expect( canMakePayment() ).toBe( true );
-		} );
-
 		test( 'uses place_order.text as the placeOrderButtonLabel, warning the buyer they are leaving the site', () => {
 			loadCheckoutBlock(
 				baseConfig( {

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -118,7 +118,8 @@ function regularCallsFor( name ) {
  * The single registerPaymentMethod call for one registered name.
  *
  * @param {string} name - The registration name to find.
- * @return {Object} The args object passed to registerPaymentMethod.
+ * @return {Object|undefined} The args object passed to registerPaymentMethod,
+ *                            or undefined when no such call was made.
  */
 function regularCallFor( name ) {
 	return regularCallsFor( name )[ 0 ];
@@ -426,6 +427,118 @@ describe( 'checkout-block', () => {
 			expect( calls[ 0 ].supports.features ).toContain(
 				'ppcp_continuation'
 			);
+		} );
+	} );
+
+	describe( 'BCDC registration', () => {
+		const cardButtonConfig = ( overrides = {} ) => ( {
+			block_method: true,
+			payment_method: 'ppcp-card-button-gateway',
+			title: 'Debit & Credit Cards',
+			supported_features: [ 'products' ],
+			...overrides,
+		} );
+
+		test( 'registers BCDC as a regular method, not an express one, when card_button.block_method is true', () => {
+			loadCheckoutBlock(
+				baseConfig( { card_button: cardButtonConfig() } )
+			);
+
+			expect(
+				regularCallFor( 'ppcp-card-button-gateway' )
+			).toBeDefined();
+			expect( mockRegisterExpressPaymentMethod ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { name: 'ppcp-card-button-gateway' } )
+			);
+		} );
+
+		test( 'does not register BCDC when card_button.block_method is false', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig( { block_method: false } ),
+				} )
+			);
+
+			expect(
+				regularCallFor( 'ppcp-card-button-gateway' )
+			).toBeUndefined();
+		} );
+
+		test( 'does not register BCDC in continuation mode', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig(),
+					continuation: { funding_source: 'paypal' },
+				} )
+			);
+
+			expect(
+				regularCallFor( 'ppcp-card-button-gateway' )
+			).toBeUndefined();
+		} );
+
+		test( 'takes its label and ariaLabel from card_button.title', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig( {
+						title: 'Pay with Card',
+					} ),
+				} )
+			);
+
+			const { ariaLabel } = regularCallFor( 'ppcp-card-button-gateway' );
+
+			expect( ariaLabel ).toBe( 'Pay with Card' );
+		} );
+
+		test( 'declares card_button.supported_features with no ppcp_continuation appended', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig( {
+						supported_features: [ 'products', 'refunds' ],
+					} ),
+				} )
+			);
+
+			const { supports } = regularCallFor( 'ppcp-card-button-gateway' );
+
+			expect( supports.features ).toEqual( [ 'products', 'refunds' ] );
+		} );
+
+		test( 'falls back to the "products" feature when card_button declares none of its own', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig( {
+						supported_features: undefined,
+					} ),
+				} )
+			);
+
+			const { supports } = regularCallFor( 'ppcp-card-button-gateway' );
+
+			expect( supports.features ).toEqual( [ 'products' ] );
+		} );
+
+		test( 'disables the save-payment-method option, since a hosted PayPal card page cannot vault into WooCommerce', () => {
+			loadCheckoutBlock(
+				baseConfig( { card_button: cardButtonConfig() } )
+			);
+
+			const { supports } = regularCallFor( 'ppcp-card-button-gateway' );
+
+			expect( supports.showSaveOption ).toBe( false );
+		} );
+
+		test( 'canMakePayment is true unconditionally, with no eligibility check', () => {
+			loadCheckoutBlock(
+				baseConfig( { card_button: cardButtonConfig() } )
+			);
+
+			const { canMakePayment } = regularCallFor(
+				'ppcp-card-button-gateway'
+			);
+
+			expect( canMakePayment() ).toBe( true );
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -3,6 +3,7 @@ import { checkEligibility } from '../eligibility';
 
 const mockRegisterExpressPaymentMethod = jest.fn();
 const mockRegisterPaymentMethod = jest.fn();
+const mockRegisterCheckoutFilters = jest.fn();
 // virtual: webpack resolves this to the wc.wcBlocksRegistry global, so there is
 // no package under node_modules for Jest to find.
 jest.mock(
@@ -83,6 +84,10 @@ function loadCheckoutBlock( config ) {
 			getSetting: ( key ) =>
 				key === 'paymentMethodData' ? { 'ppcp-sdk-v6': config } : undefined,
 		},
+		blocksCheckout: {
+			registerCheckoutFilters: ( ...args ) =>
+				mockRegisterCheckoutFilters( ...args ),
+		},
 	};
 	jest.isolateModules( () => {
 		require( '../checkout-block.js' );
@@ -125,12 +130,27 @@ function regularCallFor( name ) {
 	return regularCallsFor( name )[ 0 ];
 }
 
+/**
+ * The checkout filters object registered for one gateway id.
+ *
+ * @param {string} gatewayId - The gateway id passed to registerCheckoutFilters.
+ * @return {Object|undefined} The filters object, or undefined when no such
+ *                             call was made.
+ */
+function checkoutFiltersFor( gatewayId ) {
+	const call = mockRegisterCheckoutFilters.mock.calls.find(
+		( [ id ] ) => id === gatewayId
+	);
+	return call ? call[ 1 ] : undefined;
+}
+
 beforeEach( () => {
 	jest.clearAllMocks();
 } );
 
 afterEach( () => {
 	delete window.wc;
+	delete window.wp;
 } );
 
 describe( 'checkout-block', () => {
@@ -539,6 +559,90 @@ describe( 'checkout-block', () => {
 			);
 
 			expect( canMakePayment() ).toBe( true );
+		} );
+
+		test( 'uses place_order.text as the placeOrderButtonLabel, warning the buyer they are leaving the site', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig(),
+					place_order: { text: 'Proceed to PayPal' },
+				} )
+			);
+
+			expect(
+				regularCallFor( 'ppcp-card-button-gateway' )
+					.placeOrderButtonLabel
+			).toBe( 'Proceed to PayPal' );
+		} );
+
+		test( 'registers a placeOrderButtonLabel checkout filter for the card gateway id when place_order.text is set', () => {
+			loadCheckoutBlock(
+				baseConfig( {
+					card_button: cardButtonConfig(),
+					place_order: { text: 'Proceed to PayPal' },
+				} )
+			);
+
+			expect(
+				checkoutFiltersFor( 'ppcp-card-button-gateway' )
+			).toBeDefined();
+		} );
+
+		describe( 'the registered placeOrderButtonLabel filter', () => {
+			beforeEach( () => {
+				loadCheckoutBlock(
+					baseConfig( {
+						card_button: cardButtonConfig(),
+						place_order: { text: 'Proceed to PayPal' },
+					} )
+				);
+			} );
+
+			test( 'returns the configured label while the card gateway is the active payment method', () => {
+				window.wp = {
+					data: {
+						select: () => ( {
+							getActivePaymentMethod: () =>
+								'ppcp-card-button-gateway',
+						} ),
+					},
+				};
+				const { placeOrderButtonLabel } = checkoutFiltersFor(
+					'ppcp-card-button-gateway'
+				);
+
+				expect( placeOrderButtonLabel( 'Place order' ) ).toBe(
+					'Proceed to PayPal'
+				);
+			} );
+
+			test( 'returns the passed-in default label while a different method is active', () => {
+				window.wp = {
+					data: {
+						select: () => ( {
+							getActivePaymentMethod: () => 'ppcp-gateway',
+						} ),
+					},
+				};
+				const { placeOrderButtonLabel } = checkoutFiltersFor(
+					'ppcp-card-button-gateway'
+				);
+
+				expect( placeOrderButtonLabel( 'Place order' ) ).toBe(
+					'Place order'
+				);
+			} );
+		} );
+
+		test( 'registers with no checkout filter and no placeOrderButtonLabel when config.place_order is absent', () => {
+			loadCheckoutBlock(
+				baseConfig( { card_button: cardButtonConfig() } )
+			);
+
+			expect(
+				regularCallFor( 'ppcp-card-button-gateway' )
+			).toBeDefined();
+			expect( mockRegisterCheckoutFilters ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -524,6 +524,19 @@ class SdkV6Manager {
 	}
 
 	/**
+	 * The gateway's own description, empty when the gateway is unavailable.
+	 *
+	 * Left encoded, unlike gateway_title(): the block renders this one through
+	 * PayPalPlaceOrderContent, which sets it as HTML so a merchant can format the
+	 * description, exactly as the non-express PayPal row does with its own.
+	 */
+	private function gateway_description( string $gateway_id ): string {
+		$gateway = $this->gateway( $gateway_id );
+
+		return $gateway ? (string) $gateway->get_description() : '';
+	}
+
+	/**
 	 * The gateway's own supports list, or `array( 'products' )` when the gateway
 	 * is unavailable. The narrowest list hides the method rather than offering
 	 * it on a cart it cannot pay for.
@@ -1278,9 +1291,10 @@ class SdkV6Manager {
 				'payment_method'     => CardButtonGateway::ID,
 				'funding_source'     => 'card',
 				'wrapper'            => '#' . self::CARD_BUTTON_WRAPPER_ID,
-				// Labels the block method; the classic row takes its title from
-				// the gateway itself.
+				// Label and body for the block method; the classic row takes both
+				// from the gateway itself.
 				'title'              => $this->gateway_title( CardButtonGateway::ID ),
+				'description'        => $this->gateway_description( CardButtonGateway::ID ),
 				// This method's own gateway, never PayPal's, for the reason
 				// placement_script_data() gives.
 				'supported_features' => $this->gateway_supports( CardButtonGateway::ID ),

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -490,8 +490,8 @@ class SdkV6Manager {
 	/**
 	 * One available gateway, or null when WooCommerce does not offer it here.
 	 *
-	 * The shared lookup behind gateway_title() and gateway_supports(), so the
-	 * guard that makes both of them null-safe lives in one place.
+	 * The shared lookup behind the gateway_* readers below, so the guard that
+	 * makes them null-safe lives in one place.
 	 */
 	private function gateway( string $gateway_id ): ?WC_Payment_Gateway {
 		$gateway = $this->available_gateways()[ $gateway_id ] ?? null;

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -131,9 +131,8 @@ class SdkV6Manager {
 	private array $placements;
 
 	/**
-	 * Memoizes is_card_button_available(), which the script data asks three times
-	 * over (directly, and through each of the two placement questions) on top of
-	 * the call that prints the classic row.
+	 * Memoizes is_card_button_available(), which the script data asks through
+	 * both placement questions on top of the call that prints the classic row.
 	 *
 	 * @var bool|null
 	 */
@@ -502,9 +501,6 @@ class SdkV6Manager {
 	/**
 	 * The gateway's own user-facing title, empty when the gateway is unavailable.
 	 *
-	 * The buyer-facing label, so it has to be the merchant's own wording for that
-	 * gateway rather than anything derived from the funding source.
-	 *
 	 * Entity-decoded, because get_title() returns the title encoded ("Debit &amp;
 	 * Credit Cards") and the block renders it as text through React, which escapes
 	 * again and would show the entity verbatim - in the method label and in the
@@ -666,11 +662,9 @@ class SdkV6Manager {
 	/**
 	 * Whether the BCDC button may render on this page at all, on either surface.
 	 *
-	 * The single home of the policy, so neither surface restates it: BCDC is
-	 * configured for this context, the cart is one a card payment can settle, and
-	 * WooCommerce still offers the gateway. Asking the gateway list rather than
-	 * re-deriving its policy is what covers the checkout button location being
-	 * off, ACDC outside Mexico, free-trial carts and zero-total carts.
+	 * Asking the gateway list rather than re-deriving its policy is what covers
+	 * the checkout button location being off, ACDC outside Mexico, free-trial
+	 * carts and zero-total carts.
 	 */
 	private function is_card_button_available(): bool {
 		// Checked first, not after the conditions: both placement questions come
@@ -1282,15 +1276,11 @@ class SdkV6Manager {
 				'styles'              => $this->card_field_styles->overrides(),
 			),
 			'card_button'         => array(
-				// The two surfaces: `row` renders the SDK button on classic,
-				// `block_method` registers a redirect method on block checkout.
 				'row'                => $this->is_card_button_row(),
 				'block_method'       => $this->is_card_button_block_method(),
 				'payment_method'     => CardButtonGateway::ID,
 				'funding_source'     => 'card',
 				'wrapper'            => '#' . self::CARD_BUTTON_WRAPPER_ID,
-				// Label and body for the block method; the classic row takes both
-				// from the gateway itself.
 				'title'              => $this->gateway_title( CardButtonGateway::ID ),
 				'description'        => $this->gateway_description( CardButtonGateway::ID ),
 				// This method's own gateway, never PayPal's, for the reason

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -1280,8 +1280,8 @@ class SdkV6Manager {
 				'wrapper'            => '#' . self::CARD_BUTTON_WRAPPER_ID,
 				'title'              => $this->gateway_title( CardButtonGateway::ID ),
 				'description'        => $this->gateway_description( CardButtonGateway::ID ),
-				// This method's own gateway, never PayPal's, for the reason
-				// placement_script_data() gives.
+				// Its own gateway's list, never PayPal's: a borrowed vaulting
+				// list would offer the method on a subscription cart it cannot pay.
 				'supported_features' => $this->gateway_supports( CardButtonGateway::ID ),
 				// No colour: the element is black-only. Width is ours to set
 				// because it ships a fixed 225px, where v5 spanned the column.

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -501,12 +501,9 @@ class SdkV6Manager {
 	/**
 	 * The gateway's own user-facing title, empty when the gateway is unavailable.
 	 *
-	 * Entity-decoded, because get_title() returns the title encoded ("Debit &amp;
-	 * Credit Cards") and the block renders it as text through React, which escapes
-	 * again and would show the entity verbatim - in the method label and in the
-	 * aria-label a screen reader announces. Decoding keeps that escaping in place;
-	 * v5 instead sets the title as HTML, which is not worth copying for a value a
-	 * shop manager can edit.
+	 * Entity-decoded because get_title() returns it encoded ("Debit &amp; Credit
+	 * Cards") and the block renders it as text, which would escape it again. v5
+	 * instead sets it as HTML, not worth copying for a shop-manager-editable value.
 	 */
 	private function gateway_title( string $gateway_id ): string {
 		$gateway = $this->gateway( $gateway_id );

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -641,9 +641,8 @@ class SdkV6Manager {
 	/**
 	 * Whether BCDC is configured for this kind of page.
 	 *
-	 * is_card_button_available() then decides whether it renders at all, and
-	 * is_card_button_row() / is_card_button_block_method() which surface it
-	 * renders on.
+	 * Whether it renders at all is is_card_button_available(); which surface it
+	 * renders on is is_card_button_row() or is_card_button_block_method().
 	 *
 	 * Same context list as its ACDC counterpart, block checkout included.
 	 *

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -673,10 +673,9 @@ class SdkV6Manager {
 	 * off, ACDC outside Mexico, free-trial carts and zero-total carts.
 	 */
 	private function is_card_button_available(): bool {
-		// Checked before the conditions below, not after them: is_card_button_row()
-		// and is_card_button_block_method() both come through here, and the script data
-		// asks all three, so a memo consulted last would still re-run the gateway
-		// settings lookup and both subscription queries on every call.
+		// Checked first, not after the conditions: both placement questions come
+		// through here, so a memo consulted last would still re-run the settings
+		// lookup and the subscription queries on every call.
 		if ( null !== $this->is_card_button_available ) {
 			return $this->is_card_button_available;
 		}

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -506,12 +506,11 @@ class SdkV6Manager {
 	 * gateway rather than anything derived from the funding source.
 	 *
 	 * Entity-decoded, because get_title() returns the title encoded ("Debit &amp;
-	 * Credit Cards") and every consumer renders it as text through React, which
-	 * escapes again and would show the entity verbatim - in the method label, in
-	 * the aria-label a screen reader announces, and in the editor description. v5
-	 * solves the same problem with dangerouslySetInnerHTML, which is not an option
-	 * here: the title is admin-settable, so injecting it as HTML would hand anyone
-	 * who can edit gateway settings a stored-XSS vector.
+	 * Credit Cards") and the block renders it as text through React, which escapes
+	 * again and would show the entity verbatim - in the method label and in the
+	 * aria-label a screen reader announces. Decoding keeps that escaping in place;
+	 * v5 instead sets the title as HTML, which is not worth copying for a value a
+	 * shop manager can edit.
 	 */
 	private function gateway_title( string $gateway_id ): string {
 		$gateway = $this->gateway( $gateway_id );
@@ -526,9 +525,9 @@ class SdkV6Manager {
 	/**
 	 * The gateway's own description, empty when the gateway is unavailable.
 	 *
-	 * Left encoded, unlike gateway_title(): the block renders this one through
-	 * PayPalPlaceOrderContent, which sets it as HTML so a merchant can format the
-	 * description, exactly as the non-express PayPal row does with its own.
+	 * Left encoded, unlike gateway_title(): PayPalPlaceOrderContent sets the
+	 * description as HTML so a merchant can format it, which is how gateway
+	 * descriptions already reach both the classic checkout and the PayPal row.
 	 */
 	private function gateway_description( string $gateway_id ): string {
 		$gateway = $this->gateway( $gateway_id );

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -131,12 +131,13 @@ class SdkV6Manager {
 	private array $placements;
 
 	/**
-	 * Memoizes is_card_button_row(), asked once per request to print the row and
-	 * once to build the script data.
+	 * Memoizes is_card_button_available(), which the script data asks three times
+	 * over (directly, and through each of the two placement questions) on top of
+	 * the call that prints the classic row.
 	 *
 	 * @var bool|null
 	 */
-	private ?bool $is_card_button_row = null;
+	private ?bool $is_card_button_available = null;
 
 	/**
 	 * Memoizes available_gateways(), which every placement asks twice.
@@ -487,6 +488,42 @@ class SdkV6Manager {
 	}
 
 	/**
+	 * One available gateway, or null when WooCommerce does not offer it here.
+	 *
+	 * The shared lookup behind gateway_title() and gateway_supports(), so the
+	 * guard that makes both of them null-safe lives in one place.
+	 */
+	private function gateway( string $gateway_id ): ?WC_Payment_Gateway {
+		$gateway = $this->available_gateways()[ $gateway_id ] ?? null;
+
+		return $gateway instanceof WC_Payment_Gateway ? $gateway : null;
+	}
+
+	/**
+	 * The gateway's own user-facing title, empty when the gateway is unavailable.
+	 *
+	 * The buyer-facing label, so it has to be the merchant's own wording for that
+	 * gateway rather than anything derived from the funding source.
+	 *
+	 * Entity-decoded, because get_title() returns the title encoded ("Debit &amp;
+	 * Credit Cards") and every consumer renders it as text through React, which
+	 * escapes again and would show the entity verbatim - in the method label, in
+	 * the aria-label a screen reader announces, and in the editor description. v5
+	 * solves the same problem with dangerouslySetInnerHTML, which is not an option
+	 * here: the title is admin-settable, so injecting it as HTML would hand anyone
+	 * who can edit gateway settings a stored-XSS vector.
+	 */
+	private function gateway_title( string $gateway_id ): string {
+		$gateway = $this->gateway( $gateway_id );
+
+		if ( ! $gateway ) {
+			return '';
+		}
+
+		return html_entity_decode( (string) $gateway->get_title(), ENT_QUOTES, 'UTF-8' );
+	}
+
+	/**
 	 * The gateway's own supports list, or `array( 'products' )` when the gateway
 	 * is unavailable. The narrowest list hides the method rather than offering
 	 * it on a cart it cannot pay for.
@@ -494,9 +531,9 @@ class SdkV6Manager {
 	 * @return string[]
 	 */
 	private function gateway_supports( string $gateway_id ): array {
-		$gateway = $this->available_gateways()[ $gateway_id ] ?? null;
+		$gateway = $this->gateway( $gateway_id );
 
-		if ( ! $gateway instanceof WC_Payment_Gateway ) {
+		if ( ! $gateway ) {
 			return array( 'products' );
 		}
 
@@ -597,37 +634,46 @@ class SdkV6Manager {
 	}
 
 	/**
-	 * Whether BCDC is configured for this kind of page, not whether the row
-	 * prints here, which is is_card_button_row().
+	 * Whether BCDC is configured for this kind of page.
 	 *
-	 * Narrower than its ACDC counterpart: BCDC has no block checkout support.
+	 * is_card_button_available() then decides whether it renders at all, and
+	 * is_card_button_row() / is_card_button_block_method() which surface it
+	 * renders on.
+	 *
+	 * Same context list as its ACDC counterpart, block checkout included.
 	 *
 	 * @param string|null $location Page context to test; defaults to the current page.
 	 */
 	public function is_card_button_enabled( ?string $location = null ): bool {
 		$location = $location ?? $this->get_page_context();
 
-		return in_array( $location, array( 'checkout', 'pay-now' ), true )
+		return in_array( $location, array( 'checkout', 'checkout-block', 'pay-now' ), true )
 			&& $this->card_payments_configuration->is_bcdc_enabled();
 	}
 
 	/**
-	 * Whether the BCDC button renders as its own payment-method row here.
+	 * Whether the BCDC button may render on this page at all, on either surface.
 	 *
-	 * Asks the gateway list rather than re-deriving its policy, which already
-	 * covers the checkout button location being off, ACDC outside Mexico,
-	 * free-trial carts and zero-total carts.
+	 * The single home of the policy, so neither surface restates it: BCDC is
+	 * configured for this context, the cart is one a card payment can settle, and
+	 * WooCommerce still offers the gateway. Asking the gateway list rather than
+	 * re-deriving its policy is what covers the checkout button location being
+	 * off, ACDC outside Mexico, free-trial carts and zero-total carts.
 	 */
-	private function is_card_button_row(): bool {
-		if ( null !== $this->is_card_button_row ) {
-			return $this->is_card_button_row;
+	private function is_card_button_available(): bool {
+		// Checked before the conditions below, not after them: is_card_button_row()
+		// and is_card_button_block_method() both come through here, and the script data
+		// asks all three, so a memo consulted last would still re-run the gateway
+		// settings lookup and both subscription queries on every call.
+		if ( null !== $this->is_card_button_available ) {
+			return $this->is_card_button_available;
 		}
 
-		if ( ! $this->is_card_button_enabled() || $this->is_block_context() ) {
+		if ( ! $this->is_card_button_enabled() ) {
 			return false;
 		}
 
-		// No row for subscription carts: the v6 guest component has no
+		// Never for subscription carts: the v6 guest component has no
 		// equivalent of the SDK URL vault param v5 uses here, so the button
 		// would take a payment that can never renew. Not a dead end: without a
 		// button "Place order" stays visible, and CardButtonGateway falls back
@@ -638,10 +684,31 @@ class SdkV6Manager {
 			return false;
 		}
 
-		// Memoized only from here on, for the reason is_method_gateway() gives.
-		$this->is_card_button_row = isset( $this->available_gateways()[ CardButtonGateway::ID ] );
+		// Memoized only from here on, for the reason is_method_gateway() gives: a
+		// refusal above can be asked again, since it may have come from a context
+		// that had not resolved yet.
+		$this->is_card_button_available = isset( $this->available_gateways()[ CardButtonGateway::ID ] );
 
-		return $this->is_card_button_row;
+		return $this->is_card_button_available;
+	}
+
+	/**
+	 * Whether the BCDC button renders as its own payment-method row here, which
+	 * only the classic pages have.
+	 */
+	private function is_card_button_row(): bool {
+		return ! $this->is_block_context() && $this->is_card_button_available();
+	}
+
+	/**
+	 * Whether BCDC renders as a WooCommerce Blocks payment method.
+	 *
+	 * A regular method, not an express one: the guest session renders its card
+	 * form inline, and WooCommerce disables the express area once an express
+	 * method starts, leaving that form inert.
+	 */
+	private function is_card_button_block_method(): bool {
+		return $this->is_block_context() && $this->is_card_button_available();
 	}
 
 	/**
@@ -1204,13 +1271,22 @@ class SdkV6Manager {
 				'styles'              => $this->card_field_styles->overrides(),
 			),
 			'card_button'         => array(
-				'enabled'        => $this->is_card_button_row(),
-				'payment_method' => CardButtonGateway::ID,
-				'funding_source' => 'card',
-				'wrapper'        => '#' . self::CARD_BUTTON_WRAPPER_ID,
+				// The two surfaces: `row` renders the SDK button on classic,
+				// `block_method` registers a redirect method on block checkout.
+				'row'                => $this->is_card_button_row(),
+				'block_method'       => $this->is_card_button_block_method(),
+				'payment_method'     => CardButtonGateway::ID,
+				'funding_source'     => 'card',
+				'wrapper'            => '#' . self::CARD_BUTTON_WRAPPER_ID,
+				// Labels the block method; the classic row takes its title from
+				// the gateway itself.
+				'title'              => $this->gateway_title( CardButtonGateway::ID ),
+				// This method's own gateway, never PayPal's, for the reason
+				// placement_script_data() gives.
+				'supported_features' => $this->gateway_supports( CardButtonGateway::ID ),
 				// No colour: the element is black-only. Width is ours to set
 				// because it ships a fixed 225px, where v5 spanned the column.
-				'styles'         => array(
+				'styles'             => array(
 					'borderRadius' => $this->style_mapper->styles_for_context( $page_context ?: 'checkout' )['borderRadius'],
 					'height'       => self::PAYMENT_BUTTON_HEIGHT,
 					'width'        => '100%',

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -329,6 +329,11 @@ class ReturnUrlEndpoint {
 			return $available_gateways[ $payment_method ];
 		}
 
-		return null;
+		// Returning with an approved order puts the checkout in continuation mode,
+		// where DisableGateways offers PayPal alone - so the gateway that sent the
+		// buyer to PayPal is missing from the list above on the way back.
+		$registered_gateways = WC()->payment_gateways->payment_gateways();
+
+		return $registered_gateways[ $payment_method ] ?? null;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -271,8 +271,7 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 
 				return $this->handle_payment_success( $wc_order );
 			} catch ( PayPalOrderMissingException $exc ) {
-				// 'card', so the hosted page opens on the card fields rather than
-				// a PayPal login. See OrderProcessor::create_order().
+				// 'card' also forces the guest card page; see create_order().
 				$order = $this->order_processor->create_order( $wc_order, 'card' );
 
 				return array(

--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -271,8 +272,14 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 
 				return $this->handle_payment_success( $wc_order );
 			} catch ( PayPalOrderMissingException $exc ) {
-				// 'card' also forces the guest card page; see create_order().
-				$order = $this->order_processor->create_order( $wc_order, 'card' );
+				// Guest checkout so the hosted page opens on card fields, not a
+				// login. Do not pass 'card' here: that is the direct-card payment
+				// source, which ignores landing_page.
+				$order = $this->order_processor->create_order(
+					$wc_order,
+					'paypal',
+					ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT
+				);
 
 				return array(
 					'result'   => 'success',

--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -271,7 +271,9 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 
 				return $this->handle_payment_success( $wc_order );
 			} catch ( PayPalOrderMissingException $exc ) {
-				$order = $this->order_processor->create_order( $wc_order );
+				// 'card', so the hosted page opens on the card fields rather than
+				// a PayPal login. See OrderProcessor::create_order().
+				$order = $this->order_processor->create_order( $wc_order, 'card' );
 
 				return array(
 					'result'   => 'success',

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -242,7 +242,19 @@ class OrderProcessor {
 	public function create_order( WC_Order $wc_order, string $funding_source = 'paypal' ): Order {
 		$pu                  = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$shipping_preference = $this->shipping_preference_factory->from_state( $pu, 'checkout' );
-		$order               = $this->order_endpoint->create(
+
+		$experience_context = $this->experience_context_builder
+			->with_default_paypal_config( $shipping_preference, ExperienceContext::USER_ACTION_PAY_NOW );
+
+		// A buyer who chose the card method wants the card fields, not a PayPal
+		// login, so the merchant's landing-page setting does not apply here.
+		if ( 'card' === $funding_source ) {
+			$experience_context = $experience_context->with_landing_page(
+				ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT
+			);
+		}
+
+		$order = $this->order_endpoint->create(
 			array( $pu ),
 			$shipping_preference,
 			$this->payer_factory->from_wc_order( $wc_order ),
@@ -251,9 +263,7 @@ class OrderProcessor {
 			new PaymentSource(
 				$funding_source,
 				(object) array(
-					'experience_context' => $this->experience_context_builder
-						->with_default_paypal_config( $shipping_preference, ExperienceContext::USER_ACTION_PAY_NOW )
-						->build()->to_array(),
+					'experience_context' => $experience_context->build()->to_array(),
 				)
 			)
 		);

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -246,8 +246,8 @@ class OrderProcessor {
 		$experience_context = $this->experience_context_builder
 			->with_default_paypal_config( $shipping_preference, ExperienceContext::USER_ACTION_PAY_NOW );
 
-		// A buyer who chose the card method wants the card fields, not a PayPal
-		// login, so the merchant's landing-page setting does not apply here.
+		// The card buyer wants card fields, not a PayPal login, whatever the
+		// merchant's landing-page setting says.
 		if ( 'card' === $funding_source ) {
 			$experience_context = $experience_context->with_landing_page(
 				ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -234,24 +234,22 @@ class OrderProcessor {
 	/**
 	 * Creates a PayPal order for the given WC order.
 	 *
-	 * @param WC_Order $wc_order The WC order.
-	 * @param string   $funding_source The funding source (e.g. 'paypal', 'venmo').
+	 * @param WC_Order    $wc_order The WC order.
+	 * @param string      $funding_source The funding source (e.g. 'paypal', 'venmo').
+	 * @param string|null $landing_page An ExperienceContext::LANDING_PAGE_* value to
+	 *                                  use instead of the merchant's setting.
 	 * @return Order
 	 * @throws RuntimeException If order creation fails.
 	 */
-	public function create_order( WC_Order $wc_order, string $funding_source = 'paypal' ): Order {
+	public function create_order( WC_Order $wc_order, string $funding_source = 'paypal', ?string $landing_page = null ): Order {
 		$pu                  = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$shipping_preference = $this->shipping_preference_factory->from_state( $pu, 'checkout' );
 
 		$experience_context = $this->experience_context_builder
 			->with_default_paypal_config( $shipping_preference, ExperienceContext::USER_ACTION_PAY_NOW );
 
-		// The card buyer wants card fields, not a PayPal login, whatever the
-		// merchant's landing-page setting says.
-		if ( 'card' === $funding_source ) {
-			$experience_context = $experience_context->with_landing_page(
-				ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT
-			);
+		if ( $landing_page ) {
+			$experience_context = $experience_context->with_landing_page( $landing_page );
 		}
 
 		$order = $this->order_endpoint->create(

--- a/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
@@ -148,11 +148,6 @@ class ExperienceContextBuilderTest extends TestCase
 	}
 
 	/**
-	 * GIVEN a builder
-	 * WHEN with_landing_page() is called
-	 * THEN the original builder instance is left unmodified
-	 */
-	/**
 	 * GIVEN a builder that already applied the merchant's current landing page setting
 	 * WHEN with_landing_page() is called afterwards with an explicit value
 	 * THEN the explicit value overrides the merchant setting

--- a/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
@@ -130,6 +130,59 @@ class ExperienceContextBuilderTest extends TestCase
 	}
 
 	/**
+	 * GIVEN a builder with no landing page set
+	 * WHEN with_landing_page() is called with an explicit value
+	 * THEN the resulting context carries that value, ignoring the merchant setting
+	 */
+	public function testLandingPageSetsExplicitValue()
+	{
+		$this->settings->shouldNotReceive('landing_page_enum');
+
+		$result = $this->sut
+			->with_landing_page(ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT)
+			->build();
+
+		self::assertEquals([
+			'landing_page' => ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT,
+		], $result->to_array());
+	}
+
+	/**
+	 * GIVEN a builder
+	 * WHEN with_landing_page() is called
+	 * THEN the original builder instance is left unmodified
+	 */
+	public function testLandingPageDoesNotMutateOriginalBuilder()
+	{
+		$this->sut
+			->with_landing_page(ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT)
+			->build();
+
+		self::assertEmpty($this->sut->build()->to_array());
+	}
+
+	/**
+	 * GIVEN a builder that already applied the merchant's current landing page setting
+	 * WHEN with_landing_page() is called afterwards with an explicit value
+	 * THEN the explicit value overrides the merchant setting
+	 */
+	public function testLandingPageOverridesCurrentLandingPage()
+	{
+		$this->settings
+			->expects('landing_page_enum')
+			->andReturn(ExperienceContext::LANDING_PAGE_LOGIN);
+
+		$result = $this->sut
+			->with_current_landing_page()
+			->with_landing_page(ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT)
+			->build();
+
+		self::assertEquals([
+			'landing_page' => ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT,
+		], $result->to_array());
+	}
+
+	/**
 	 * @dataProvider paymentMethodPreferenceDataProvider
 	 */
 	public function testCurrentPaymentMethodPreference( $value, $expected)

--- a/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
@@ -152,15 +152,6 @@ class ExperienceContextBuilderTest extends TestCase
 	 * WHEN with_landing_page() is called
 	 * THEN the original builder instance is left unmodified
 	 */
-	public function testLandingPageDoesNotMutateOriginalBuilder()
-	{
-		$this->sut
-			->with_landing_page(ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT)
-			->build();
-
-		self::assertEmpty($this->sut->build()->to_array());
-	}
-
 	/**
 	 * GIVEN a builder that already applied the merchant's current landing page setting
 	 * WHEN with_landing_page() is called afterwards with an explicit value

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -1840,13 +1840,17 @@ class SdkV6ManagerTest extends TestCase
      * AND both degrade to '' and ['products'] respectively when the gateway is
      *     unavailable, offering the button on no more carts than a registered
      *     gateway would
+     * AND card_button.description carries that gateway's own description,
+     *     unchanged (not entity-decoded, unlike the title), degrading to ''
+     *     when the gateway is unavailable
      *
      * @dataProvider card_button_title_and_features_provider
      */
     public function testScriptDataCardButtonTitleAndSupportedFeaturesReflectOwnGateway(
         bool $gateway_available,
         string $expected_title,
-        array $expected_supported_features
+        array $expected_supported_features,
+        string $expected_description
     ): void {
         $this->stubScriptDataBaseline('checkout', 'checkout');
         $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
@@ -1855,6 +1859,7 @@ class SdkV6ManagerTest extends TestCase
         if ($gateway_available) {
             $gateway = Mockery::mock('WC_Payment_Gateway');
             $gateway->shouldReceive('get_title')->andReturn('Debit or Credit Card');
+            $gateway->shouldReceive('get_description')->andReturn('Pay with your <strong>debit</strong> or credit card.');
             $gateway->supports = ['products', 'refunds'];
             $gateways[CardButtonGateway::ID] = $gateway;
         }
@@ -1866,16 +1871,17 @@ class SdkV6ManagerTest extends TestCase
 
         $this->assertSame($expected_title, $data['card_button']['title']);
         $this->assertSame($expected_supported_features, $data['card_button']['supported_features']);
+        $this->assertSame($expected_description, $data['card_button']['description']);
     }
 
     public function card_button_title_and_features_provider(): array
     {
         return [
             'gateway available carries its own title and supports list' => [
-                true, 'Debit or Credit Card', ['products', 'refunds'],
+                true, 'Debit or Credit Card', ['products', 'refunds'], 'Pay with your <strong>debit</strong> or credit card.',
             ],
             'gateway unavailable degrades to an empty title and products-only supports' => [
-                false, '', ['products'],
+                false, '', ['products'], '',
             ],
         ];
     }
@@ -1909,6 +1915,7 @@ class SdkV6ManagerTest extends TestCase
 
         $gateway = Mockery::mock('WC_Payment_Gateway');
         $gateway->shouldReceive('get_title')->andReturn($encoded_title);
+        $gateway->shouldReceive('get_description')->andReturn('');
         $gateway->supports = ['products'];
 
         when('WC')->justReturn($this->create_wc_stub([CardButtonGateway::ID => $gateway]));

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -1668,7 +1668,8 @@ class SdkV6ManagerTest extends TestCase
      * GIVEN a page context and a BCDC (Basic Credit and Debit Cards) setting
      * WHEN checking whether the v6 Basic Card button is enabled for that location
      * THEN the result depends on both the page context and the BCDC setting
-     * AND checkout-block is never eligible, since BCDC has no block checkout support
+     * AND checkout-block is eligible too, since BCDC now offers a block-checkout
+     *     payment method alongside its classic payment-method row
      *
      * @dataProvider card_button_enablement_provider
      */
@@ -1689,7 +1690,8 @@ class SdkV6ManagerTest extends TestCase
             'classic checkout with BCDC disabled does not render the card button' => ['checkout', false, false],
             'pay-now with BCDC enabled renders the card button' => ['pay-now', true, true],
             'pay-now with BCDC disabled does not render the card button' => ['pay-now', false, false],
-            'checkout-block is never eligible, even with BCDC enabled' => ['checkout-block', true, false],
+            'checkout-block with BCDC enabled is eligible for the block payment method' => ['checkout-block', true, true],
+            'checkout-block with BCDC disabled is not eligible' => ['checkout-block', false, false],
             'product page is never eligible for the card button' => ['product', true, false],
             'cart page is never eligible for the card button' => ['cart', true, false],
         ];
@@ -1699,9 +1701,11 @@ class SdkV6ManagerTest extends TestCase
      * GIVEN BCDC configured for checkout/pay-now, with every smart-button
      *       location and ACDC turned off
      * WHEN checking whether the v6 SDK should load on the current page
-     * THEN the SDK loads on checkout and pay-now purely because BCDC is enabled there
-     * AND it does not load on product, cart or checkout-block, since BCDC has no
-     *     block checkout support and settings alone never enable it elsewhere
+     * THEN the SDK loads on checkout, pay-now and checkout-block purely because
+     *      BCDC is enabled there, now that the button offers a block-checkout
+     *      payment method alongside its classic row
+     * AND it does not load on product or cart, since settings alone never
+     *     enable it there
      *
      * @dataProvider should_load_for_card_button_provider
      */
@@ -1725,24 +1729,26 @@ class SdkV6ManagerTest extends TestCase
             'checkout with BCDC disabled does not load for the card button' => ['checkout', false, false],
             'product page never loads for the card button' => ['product', true, false],
             'cart page never loads for the card button' => ['cart', true, false],
-            'checkout-block never loads for the card button (no block support)' => ['checkout-block', true, false],
+            'checkout-block with BCDC enabled loads the SDK for the block payment method' => ['checkout-block', true, true],
         ];
     }
 
     /**
-     * GIVEN a checkout page where BCDC is enabled for the settings-only gate
+     * GIVEN a classic checkout page where BCDC is enabled for the settings-only gate
      * WHEN the SDK bootstrap data is generated
-     * THEN card_button.enabled is true only when the CardButtonGateway is also
-     *      among WooCommerce's available payment gateways
+     * THEN card_button.row is true only when the CardButtonGateway is also among
+     *      WooCommerce's available payment gateways
      * AND it is false whenever the gateway is unavailable — the same signal
      *     WooCommerce gives for ACDC-active-outside-Mexico, a free-trial cart,
      *     or a zero-total cart, since each of those removes the gateway itself
      * AND it is false for a cart containing a subscription, since BCDC is
      *     withheld there regardless of gateway availability
+     * AND card_button.block_method is always false here, since the classic page
+     *     has no block-checkout payment method to render
      *
      * @dataProvider card_button_row_provider
      */
-    public function testScriptDataCardButtonEnabled(bool $cart_contains_subscription, bool $gateway_available, bool $expected): void
+    public function testScriptDataCardButtonRowReflectsAvailabilityOnClassicCheckout(bool $cart_contains_subscription, bool $gateway_available, bool $expected): void
     {
         $this->context->shouldReceive('context')->andReturn('checkout');
         $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
@@ -1768,7 +1774,8 @@ class SdkV6ManagerTest extends TestCase
         $testee = $this->createTestee();
         $data   = $testee->script_data();
 
-        $this->assertSame($expected, $data['card_button']['enabled']);
+        $this->assertSame($expected, $data['card_button']['row']);
+        $this->assertFalse($data['card_button']['block_method']);
     }
 
     public function card_button_row_provider(): array
@@ -1777,6 +1784,156 @@ class SdkV6ManagerTest extends TestCase
             'gateway available and no subscription renders the row' => [false, true, true],
             'gateway unavailable never renders the row (ACDC-active, free trial, or zero-total cart)' => [false, false, false],
             'subscription cart withholds the row even though the gateway is available' => [true, true, false],
+        ];
+    }
+
+    /**
+     * GIVEN a WooCommerce Blocks checkout page where BCDC is enabled for the
+     *       settings-only gate
+     * WHEN the SDK bootstrap data is generated
+     * THEN card_button.block_method is true only when the CardButtonGateway is
+     *      also among WooCommerce's available payment gateways
+     * AND it is false for a cart containing a subscription, since the shared
+     *     availability policy withholds BCDC there regardless of the surface
+     * AND card_button.row is always false here, since Blocks has no gateway
+     *     row for the button to occupy
+     *
+     * @dataProvider card_button_row_provider
+     */
+    public function testScriptDataCardButtonBlockMethodReflectsAvailabilityOnBlockCheckout(bool $cart_contains_subscription, bool $gateway_available, bool $expected): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout-block');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
+
+        when('WC')->justReturn($this->create_wc_stub($gateway_available ? [CardButtonGateway::ID => true] : []));
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame($expected, $data['card_button']['block_method']);
+        $this->assertFalse($data['card_button']['row']);
+    }
+
+    /**
+     * GIVEN the CardButtonGateway is available, exposing its own title and
+     *       supports list
+     * WHEN the SDK bootstrap data is generated
+     * THEN card_button.title carries that gateway's own user-facing title
+     * AND card_button.supported_features carries that gateway's own supports
+     *     list, never a borrowed one
+     * AND both degrade to '' and ['products'] respectively when the gateway is
+     *     unavailable, offering the button on no more carts than a registered
+     *     gateway would
+     *
+     * @dataProvider card_button_title_and_features_provider
+     */
+    public function testScriptDataCardButtonTitleAndSupportedFeaturesReflectOwnGateway(
+        bool $gateway_available,
+        string $expected_title,
+        array $expected_supported_features
+    ): void {
+        $this->stubScriptDataBaseline('checkout', 'checkout');
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+
+        $gateways = [];
+        if ($gateway_available) {
+            $gateway = Mockery::mock('WC_Payment_Gateway');
+            $gateway->shouldReceive('get_title')->andReturn('Debit or Credit Card');
+            $gateway->supports = ['products', 'refunds'];
+            $gateways[CardButtonGateway::ID] = $gateway;
+        }
+
+        when('WC')->justReturn($this->create_wc_stub($gateways));
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame($expected_title, $data['card_button']['title']);
+        $this->assertSame($expected_supported_features, $data['card_button']['supported_features']);
+    }
+
+    public function card_button_title_and_features_provider(): array
+    {
+        return [
+            'gateway available carries its own title and supports list' => [
+                true, 'Debit or Credit Card', ['products', 'refunds'],
+            ],
+            'gateway unavailable degrades to an empty title and products-only supports' => [
+                false, '', ['products'],
+            ],
+        ];
+    }
+
+    /**
+     * GIVEN block checkout with BCDC enabled and the CardButtonGateway available
+     * AND the gateway's title is HTML-entity-encoded, the way
+     *     WC_Payment_Gateway::get_title() returns it on a real store (e.g.
+     *     "Debit &amp; Credit Cards")
+     * WHEN the SDK bootstrap data is generated
+     * THEN card_button.title is HTML-entity-decoded, since Blocks renders this
+     *      value as plain text in the block payment method's label, aria-label
+     *      and editor description — an undecoded title would display a literal
+     *      "&amp;" and be read aloud as "ampersand" by a screen reader
+     *
+     * @dataProvider card_button_title_entity_decoding_provider
+     */
+    public function testScriptDataCardButtonTitleIsEntityDecodedOnBlockCheckout(string $encoded_title, string $expected_title): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout-block');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
+
+        $gateway = Mockery::mock('WC_Payment_Gateway');
+        $gateway->shouldReceive('get_title')->andReturn($encoded_title);
+        $gateway->supports = ['products'];
+
+        when('WC')->justReturn($this->create_wc_stub([CardButtonGateway::ID => $gateway]));
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame($expected_title, $data['card_button']['title']);
+    }
+
+    public function card_button_title_entity_decoding_provider(): array
+    {
+        return [
+            'ampersand entity decodes to a literal ampersand' => [
+                'Debit &amp; Credit Cards', 'Debit & Credit Cards',
+            ],
+            'apostrophe entity decodes under ENT_QUOTES' => [
+                "Merchant&#039;s Card", "Merchant's Card",
+            ],
         ];
     }
 

--- a/tests/integration/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/integration/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -6,10 +6,13 @@ namespace WooCommerce\PayPalCommerce\Tests\Integration\WcGateway\Processor;
 
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Tests\Integration\IntegrationMockedTestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\PayPalOrderMissingException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -237,5 +240,71 @@ class OrderProcessorTest extends IntegrationMockedTestCase
 
 		$wcOrder = wc_get_order($wcOrder->get_id());
 		$this->assertEquals($originalStatus, $wcOrder->get_status());
+	}
+
+	/**
+	 * GIVEN a buyer paying with the card funding source
+	 * WHEN a PayPal order is created for their WooCommerce order
+	 * THEN the experience context forces the guest checkout landing page, regardless of the merchant's setting
+	 */
+	public function testCreateOrderForCardFundingSourceForcesGuestCheckoutLandingPage(): void
+	{
+		$capturedPaymentSource = $this->captureCreatedPaymentSource('card');
+
+		$this->assertSame(
+			ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT,
+			$capturedPaymentSource->properties()->experience_context['landing_page']
+		);
+	}
+
+	/**
+	 * GIVEN a buyer paying with the default PayPal funding source
+	 * WHEN a PayPal order is created for their WooCommerce order
+	 * THEN the experience context uses the merchant's configured landing page instead of being forced
+	 */
+	public function testCreateOrderForDefaultFundingSourceUsesMerchantLandingPageSetting(): void
+	{
+		$capturedPaymentSource = $this->captureCreatedPaymentSource('paypal');
+
+		$this->assertSame(
+			ExperienceContext::LANDING_PAGE_LOGIN,
+			$capturedPaymentSource->properties()->experience_context['landing_page']
+		);
+	}
+
+	/**
+	 * Creates a PayPal order via OrderProcessor::create_order() for the given funding source
+	 * and returns the PaymentSource that was passed to OrderEndpoint::create().
+	 */
+	private function captureCreatedPaymentSource(string $fundingSource): PaymentSource
+	{
+		$capturedPaymentSource = null;
+
+		$mockOrderEndpoint = \Mockery::mock(OrderEndpoint::class);
+		$mockOrderEndpoint->shouldReceive('create')
+			->andReturnUsing(function (...$args) use (&$capturedPaymentSource) {
+				$capturedPaymentSource = $args[5];
+				return \Mockery::mock(Order::class)->shouldIgnoreMissing();
+			});
+
+		$settingsProvider = \Mockery::mock(SettingsProvider::class)->shouldIgnoreMissing();
+		$settingsProvider->shouldReceive('landing_page_enum')->andReturn(ExperienceContext::LANDING_PAGE_LOGIN);
+
+		$container = $this->setupTestContainer($mockOrderEndpoint, [
+			'settings.settings-provider' => fn() => $settingsProvider,
+		]);
+
+		$wcOrder = $this->getConfiguredOrder(
+			$this->customer_id,
+			'ppcp-gateway',
+			['simple'],
+			[],
+			false
+		);
+
+		$orderProcessor = $container->get('wcgateway.order-processor');
+		$orderProcessor->create_order($wcOrder, $fundingSource);
+
+		return $capturedPaymentSource;
 	}
 }

--- a/tests/integration/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/integration/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -243,13 +243,13 @@ class OrderProcessorTest extends IntegrationMockedTestCase
 	}
 
 	/**
-	 * GIVEN a buyer paying with the card funding source
-	 * WHEN a PayPal order is created for their WooCommerce order
-	 * THEN the experience context forces the guest checkout landing page, regardless of the merchant's setting
+	 * GIVEN a merchant configured to use the login landing page
+	 * WHEN a PayPal order is created with an explicit landing page argument
+	 * THEN the experience context uses the explicit landing page, overriding the merchant's setting
 	 */
-	public function testCreateOrderForCardFundingSourceForcesGuestCheckoutLandingPage(): void
+	public function testCreateOrderUsesExplicitLandingPageOverMerchantSetting(): void
 	{
-		$capturedPaymentSource = $this->captureCreatedPaymentSource('card');
+		$capturedPaymentSource = $this->captureCreatedPaymentSource('paypal', ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT);
 
 		$this->assertSame(
 			ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT,
@@ -258,11 +258,13 @@ class OrderProcessorTest extends IntegrationMockedTestCase
 	}
 
 	/**
-	 * GIVEN a buyer paying with the default PayPal funding source
-	 * WHEN a PayPal order is created for their WooCommerce order
-	 * THEN the experience context uses the merchant's configured landing page instead of being forced
+	 * GIVEN a merchant configured to use the login landing page
+	 * WHEN a PayPal order is created without an explicit landing page argument
+	 * THEN the experience context falls back to the merchant's configured landing page
+	 * AND the payment source is created under the 'paypal' key, not 'card', so PayPal
+	 *     routes it as a redirect flow instead of direct card processing
 	 */
-	public function testCreateOrderForDefaultFundingSourceUsesMerchantLandingPageSetting(): void
+	public function testCreateOrderUsesMerchantLandingPageSettingWhenNoneGiven(): void
 	{
 		$capturedPaymentSource = $this->captureCreatedPaymentSource('paypal');
 
@@ -270,13 +272,14 @@ class OrderProcessorTest extends IntegrationMockedTestCase
 			ExperienceContext::LANDING_PAGE_LOGIN,
 			$capturedPaymentSource->properties()->experience_context['landing_page']
 		);
+		$this->assertSame('paypal', $capturedPaymentSource->name());
 	}
 
 	/**
 	 * Creates a PayPal order via OrderProcessor::create_order() for the given funding source
-	 * and returns the PaymentSource that was passed to OrderEndpoint::create().
+	 * and landing page, and returns the PaymentSource that was passed to OrderEndpoint::create().
 	 */
-	private function captureCreatedPaymentSource(string $fundingSource): PaymentSource
+	private function captureCreatedPaymentSource(string $fundingSource, ?string $landingPage = null): PaymentSource
 	{
 		$capturedPaymentSource = null;
 
@@ -303,7 +306,7 @@ class OrderProcessorTest extends IntegrationMockedTestCase
 		);
 
 		$orderProcessor = $container->get('wcgateway.order-processor');
-		$orderProcessor->create_order($wcOrder, $fundingSource);
+		$orderProcessor->create_order($wcOrder, $fundingSource, $landingPage);
 
 		return $capturedPaymentSource;
 	}


### PR DESCRIPTION
### Description

The BCDC button has been removed from Block Checkout (express button section) under SDK v6, leaving merchants with BCDC and no ACDC with no card option there at all. This adds the redirect gateway to replace it: a "Debit & Credit Cards" row whose "Proceed to PayPal" button sends the buyer to PayPal's hosted **guest card** page.

Also resolves reports that BCDC does not appear on block checkout, though not its account-specific 403 from find-eligible-methods.

Includes an adjacent fix in `ReturnUrlEndpoint`: it resolved the order's gateway from available gateways, but continuation mode leaves only PayPal available, so any non-PayPal gateway that sent the buyer there failed with "Payment gateway is unavailable" on return. Now falls back to registered gateways (affects AXO too), and is untested because the method is private behind a caller that ends in `exit()`.

### Screenshots

| Before - BCDC Missing | After - BCDC as a regular gateway |
| :--- | :--- |
|<img width="747" height="844" alt="bcdc_missing" src="https://github.com/user-attachments/assets/71ae935f-f958-4190-a7e8-ab3377baa8d2" />|<img width="745" height="901" alt="fixed_bcdc" src="https://github.com/user-attachments/assets/d2a07839-0579-4998-bb7d-89f6f25bbca8" />|

### Steps to Test

Requires the v6 SDK flag, BCDC enabled, ACDC disabled. **Use a private window** - PayPal shows the login screen to buyers it recognises from cookies, whatever the landing page says.

1. Set the PayPal landing page to **"Login page"** - the setting this gateway must override.
2. As a guest, add a product and open the **block** checkout. Express Checkout shows PayPal only, no card button.
3. Select **Debit & Credit Cards** - the order button reads **Proceed to PayPal**.
4. Click it. PayPal shows **card fields**, with the billing address pre-filled from checkout.
5. Complete payment. You land on order-received; the order is `processing` with payment method **Debit & Credit Cards** (`ppcp-card-button-gateway`), not PayPal.
6. Repeat with the **PayPal** method - it must still show the **login** screen, proving the override is scoped to cards.
7. Regression, classic checkout: the "Debit & Credit Cards" row still renders PayPal's card button inline.
8. Regression, block cart: no card option appears.