### PR TITLE
Fix ACDC payment failure when part of the order is paid with store credit (6798)

### DIFF
--- a/docs/extra-discount-filters.md
+++ b/docs/extra-discount-filters.md
@@ -82,7 +82,5 @@ add_filter(
   integration is needed for that plugin.
 - Account Funds for WooCommerce (`woocommerce-account-funds`) is handled automatically via
   `WcAccountFundsCompat` across the same three paths. No manual integration is needed.
-- Reporting the amount matters beyond the charged total. `AmountFactory` reconciles any gap between
-  the WC total and the summed breakdown by adjusting the tax line, which was sized for
-  inclusive-tax rounding. An unreported discount pushes that adjustment negative, and PayPal
-  rejects the Level 2 card data with `CANNOT_BE_NEGATIVE` on `tax_total`.
+- An unreported discount is not only a wrong total. `AmountFactory` reconciles the gap through the
+  tax line, so it can surface as `CANNOT_BE_NEGATIVE` on `tax_total` in the Level 2 card data.

--- a/docs/extra-discount-filters.md
+++ b/docs/extra-discount-filters.md
@@ -80,3 +80,9 @@ add_filter(
   `WcGiftCardsCompat` for the classic cart/checkout, express button shipping callback, and order
   paths. No manual
   integration is needed for that plugin.
+- Account Funds for WooCommerce (`woocommerce-account-funds`) is handled automatically via
+  `WcAccountFundsCompat` across the same three paths. No manual integration is needed.
+- Reporting the amount matters beyond the charged total. `AmountFactory` reconciles any gap between
+  the WC total and the summed breakdown by adjusting the tax line, which was sized for
+  inclusive-tax rounding. An unreported discount pushes that adjustment negative, and PayPal
+  rejects the Level 2 card data with `CANNOT_BE_NEGATIVE` on `tax_total`.

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -69,6 +69,10 @@ class CompatModule implements ServiceModule, ExecutableModule {
 			( new WcGiftCardsCompat( $context ) )->register();
 		}
 
+		if ( class_exists( '\Kestrel\Account_Funds\Cart' ) ) {
+			( new WcAccountFundsCompat() )->register();
+		}
+
 		$this->migrate_pay_later_settings( $c );
 		$this->migrate_smart_button_settings( $c );
 		$this->migrate_three_d_secure_setting();

--- a/modules/ppcp-compat/src/WcAccountFundsCompat.php
+++ b/modules/ppcp-compat/src/WcAccountFundsCompat.php
@@ -10,22 +10,15 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Compat;
 
 /**
- * Provides Account Funds (store credit) compatibility.
- *
- * The plugin applies store credit directly via WC_Cart::set_total() and
- * WC_Order::set_total(), bypassing the standard coupon/fee getters. Unreported, the
- * credit surfaces as the gap between the WC total and the summed breakdown, which
- * AmountFactory folds into the tax line - producing a negative tax_total that PayPal
- * rejects with CANNOT_BE_NEGATIVE once Level 2 card data is sent.
+ * Reports Account Funds store credit, which the plugin applies through
+ * WC_Cart::set_total() and WC_Order::set_total() rather than a coupon or fee. Left
+ * unreported it lands in the tax line, and PayPal rejects a negative tax_total.
  */
 class WcAccountFundsCompat {
 
 	private const CART_CLASS = '\Kestrel\Account_Funds\Cart';
 
-	/**
-	 * Order meta carrying the credit applied to a partially covered order. Written on
-	 * order creation, before payment processing, and by the plugin's pre-4.0 path too.
-	 */
+	// Written on order creation, before payment processing, and by the pre-4.0 path too.
 	private const ORDER_META = '_funds_used';
 
 	public function register(): void {
@@ -69,9 +62,8 @@ class WcAccountFundsCompat {
 	}
 
 	/**
-	 * Gated on partial use, which is what makes the plugin reduce the cart total.
-	 * Fully covered carts are paid through the plugin's own gateway and never reach
-	 * a PayPal amount, but the getter would still report a balance for them.
+	 * Gated on partial use, which is what makes the plugin reduce the cart total. The
+	 * getter reports a balance for fully covered carts too, which PayPal never sees.
 	 */
 	private function applied_cart_credit(): float {
 		$cart_class = self::CART_CLASS;

--- a/modules/ppcp-compat/src/WcAccountFundsCompat.php
+++ b/modules/ppcp-compat/src/WcAccountFundsCompat.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Compatibility layer for the Account Funds for WooCommerce plugin.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+/**
+ * Provides Account Funds (store credit) compatibility.
+ *
+ * The plugin applies store credit directly via WC_Cart::set_total() and
+ * WC_Order::set_total(), bypassing the standard coupon/fee getters. Unreported, the
+ * credit surfaces as the gap between the WC total and the summed breakdown, which
+ * AmountFactory folds into the tax line - producing a negative tax_total that PayPal
+ * rejects with CANNOT_BE_NEGATIVE once Level 2 card data is sent.
+ *
+ * Both readers mirror the exact condition under which the plugin reduces the total,
+ * so the reported discount can never exceed the reduction it accounts for.
+ */
+class WcAccountFundsCompat {
+
+	/**
+	 * The plugin's cart helper, holding the credit applied to the session cart.
+	 */
+	private const CART_CLASS = '\Kestrel\Account_Funds\Cart';
+
+	/**
+	 * Order meta carrying the credit applied to a partially covered order. Written on
+	 * order creation, before payment processing, and by the plugin's pre-4.0 path too.
+	 */
+	private const ORDER_META = '_funds_used';
+
+	public function register(): void {
+		add_filter(
+			'woocommerce_paypal_payments_cart_extra_discount',
+			array( $this, 'cart_extra_discount' ),
+			10,
+			2
+		);
+		add_filter(
+			'woocommerce_paypal_payments_order_extra_discount',
+			array( $this, 'order_extra_discount' ),
+			10,
+			2
+		);
+		add_filter(
+			'woocommerce_paypal_payments_store_api_cart_extra_discount',
+			array( $this, 'store_api_cart_extra_discount' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Adds the store credit applied to the cart to whatever other hooks reported.
+	 */
+	public function cart_extra_discount( float $extra, \WC_Cart $cart ): float {
+		return $extra + $this->applied_cart_credit();
+	}
+
+	/**
+	 * Same for the Store API, which works in minor units on both sides of the sum.
+	 */
+	public function store_api_cart_extra_discount( int $extra ): int {
+		$credit = $this->applied_cart_credit();
+
+		if ( $credit <= 0.0 ) {
+			return $extra;
+		}
+
+		return $extra + (int) round( $credit * 10 ** wc_get_price_decimals() );
+	}
+
+	/**
+	 * Adds the store credit applied to the order to whatever other hooks reported.
+	 *
+	 * Read from order meta rather than the cart: the cart session is gone on the
+	 * pay-for-order page, and a stored order keeps the amount it was reduced by.
+	 */
+	public function order_extra_discount( float $extra, \WC_Order $order ): float {
+		return $extra + max( 0.0, (float) $order->get_meta( self::ORDER_META ) );
+	}
+
+	/**
+	 * The credit applied to the current cart, or 0.0 when none is.
+	 *
+	 * Gated on partial use, which is what makes the plugin reduce the cart total.
+	 * Fully covered carts are paid through the plugin's own gateway and never reach
+	 * a PayPal amount, but the getter would still report a balance for them.
+	 */
+	private function applied_cart_credit(): float {
+		$cart_class = self::CART_CLASS;
+
+		if ( ! class_exists( $cart_class ) || ! $cart_class::is_using_account_funds_partially() ) {
+			return 0.0;
+		}
+
+		return max( 0.0, (float) $cart_class::get_applied_account_funds_amount() );
+	}
+}

--- a/modules/ppcp-compat/src/WcAccountFundsCompat.php
+++ b/modules/ppcp-compat/src/WcAccountFundsCompat.php
@@ -17,15 +17,9 @@ namespace WooCommerce\PayPalCommerce\Compat;
  * credit surfaces as the gap between the WC total and the summed breakdown, which
  * AmountFactory folds into the tax line - producing a negative tax_total that PayPal
  * rejects with CANNOT_BE_NEGATIVE once Level 2 card data is sent.
- *
- * Both readers mirror the exact condition under which the plugin reduces the total,
- * so the reported discount can never exceed the reduction it accounts for.
  */
 class WcAccountFundsCompat {
 
-	/**
-	 * The plugin's cart helper, holding the credit applied to the session cart.
-	 */
 	private const CART_CLASS = '\Kestrel\Account_Funds\Cart';
 
 	/**
@@ -55,9 +49,6 @@ class WcAccountFundsCompat {
 		);
 	}
 
-	/**
-	 * Adds the store credit applied to the cart to whatever other hooks reported.
-	 */
 	public function cart_extra_discount( float $extra, \WC_Cart $cart ): float {
 		return $extra + $this->applied_cart_credit();
 	}
@@ -66,18 +57,10 @@ class WcAccountFundsCompat {
 	 * Same for the Store API, which works in minor units on both sides of the sum.
 	 */
 	public function store_api_cart_extra_discount( int $extra ): int {
-		$credit = $this->applied_cart_credit();
-
-		if ( $credit <= 0.0 ) {
-			return $extra;
-		}
-
-		return $extra + (int) round( $credit * 10 ** wc_get_price_decimals() );
+		return $extra + (int) round( $this->applied_cart_credit() * 10 ** wc_get_price_decimals() );
 	}
 
 	/**
-	 * Adds the store credit applied to the order to whatever other hooks reported.
-	 *
 	 * Read from order meta rather than the cart: the cart session is gone on the
 	 * pay-for-order page, and a stored order keeps the amount it was reduced by.
 	 */
@@ -86,8 +69,6 @@ class WcAccountFundsCompat {
 	}
 
 	/**
-	 * The credit applied to the current cart, or 0.0 when none is.
-	 *
 	 * Gated on partial use, which is what makes the plugin reduce the cart total.
 	 * Fully covered carts are paid through the plugin's own gateway and never reach
 	 * a PayPal amount, but the getter would still report a balance for them.

--- a/tests/PHPUnit/Compat/Fixtures/KestrelAccountFundsCartStub.php
+++ b/tests/PHPUnit/Compat/Fixtures/KestrelAccountFundsCartStub.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Stub for the third-party Kestrel\Account_Funds\Cart class.
+ *
+ * Loaded on demand (never at file-parse time) so tests can also exercise the
+ * genuine "plugin not installed" path via class_exists().
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace Kestrel\Account_Funds;
+
+if ( ! class_exists( Cart::class ) ) {
+	class Cart {
+
+		/**
+		 * @var bool
+		 */
+		public static $is_using_partially = false;
+
+		/**
+		 * @var float
+		 */
+		public static $applied_amount = 0.0;
+
+		public static function reset(): void {
+			self::$is_using_partially = false;
+			self::$applied_amount     = 0.0;
+		}
+
+		public static function is_using_account_funds_partially(): bool {
+			return self::$is_using_partially;
+		}
+
+		public static function get_applied_account_funds_amount(): float {
+			return self::$applied_amount;
+		}
+	}
+}

--- a/tests/PHPUnit/Compat/WcAccountFundsCompatTest.php
+++ b/tests/PHPUnit/Compat/WcAccountFundsCompatTest.php
@@ -88,12 +88,15 @@ class WcAccountFundsCompatTest extends TestCase {
 	}
 
 	/**
-	 * GIVEN a cart that Account Funds is not partially covering
+	 * GIVEN the plugin reports a balance while not partially covering the cart, so the
+	 *   cart total was never reduced
 	 * WHEN store_api_cart_extra_discount() runs
-	 * THEN the extra discount in minor units is returned untouched
+	 * THEN the extra discount in minor units is returned untouched, the block checkout
+	 *   counterpart of the classic guard below
 	 */
-	public function test_store_api_cart_extra_discount_unchanged_when_no_credit_applies(): void {
-		$this->stub_kestrel_cart( false, 0.0 );
+	public function test_store_api_cart_extra_discount_unchanged_when_cart_total_was_not_reduced(): void {
+		$this->stub_kestrel_cart( false, 25.0 );
+		when( 'wc_get_price_decimals' )->justReturn( 2 );
 
 		$result = $this->testee->store_api_cart_extra_discount( 100 );
 
@@ -110,6 +113,22 @@ class WcAccountFundsCompatTest extends TestCase {
 	 */
 	public function test_cart_extra_discount_ignores_credit_when_cart_total_was_not_reduced(): void {
 		$this->stub_kestrel_cart( false, 25.0 );
+
+		$cart = Mockery::mock( \WC_Cart::class );
+
+		$result = $this->testee->cart_extra_discount( 2.0, $cart );
+
+		$this->assertSame( 2.0, $result );
+	}
+
+	/**
+	 * GIVEN the plugin reports a negative applied amount
+	 * WHEN cart_extra_discount() runs
+	 * THEN it is clamped to zero rather than inflating what other hooks reported, which
+	 *   the factory's own clamp on the summed value would not catch
+	 */
+	public function test_cart_extra_discount_clamps_a_negative_applied_amount(): void {
+		$this->stub_kestrel_cart( true, -5.0 );
 
 		$cart = Mockery::mock( \WC_Cart::class );
 

--- a/tests/PHPUnit/Compat/WcAccountFundsCompatTest.php
+++ b/tests/PHPUnit/Compat/WcAccountFundsCompatTest.php
@@ -1,0 +1,172 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+use Kestrel\Account_Funds\Cart as KestrelAccountFundsCart;
+use Mockery;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Filters\expectAdded;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Compat\WcAccountFundsCompat
+ */
+class WcAccountFundsCompatTest extends TestCase {
+
+	private $testee;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->testee = new WcAccountFundsCompat();
+	}
+
+	/**
+	 * Loads the Kestrel\Account_Funds\Cart stub on demand and resets its static state,
+	 * so tests exercising the "plugin present" path stay isolated from one another.
+	 */
+	private function stub_kestrel_cart( bool $is_using_partially, float $applied_amount ): void {
+		require_once __DIR__ . '/Fixtures/KestrelAccountFundsCartStub.php';
+
+		KestrelAccountFundsCart::reset();
+		KestrelAccountFundsCart::$is_using_partially = $is_using_partially;
+		KestrelAccountFundsCart::$applied_amount     = $applied_amount;
+	}
+
+	/**
+	 * GIVEN an order that Account Funds partially paid via a direct set_total() call,
+	 *   recorded as order meta
+	 * WHEN order_extra_discount() runs
+	 * THEN the credit is added to the extra discount so the breakdown accounts for it
+	 */
+	public function test_order_extra_discount_reports_credit_used_on_order(): void {
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_meta' )->with( '_funds_used' )->andReturn( '12.50' );
+
+		$result = $this->testee->order_extra_discount( 10.0, $order );
+
+		$this->assertSame( 22.5, $result );
+	}
+
+	/**
+	 * GIVEN an order without a usable store-credit amount recorded against it
+	 * WHEN order_extra_discount() runs
+	 * THEN the extra discount accumulated by other hooks is returned unchanged
+	 *
+	 * @dataProvider data_no_reportable_order_credit
+	 */
+	public function test_order_extra_discount_unchanged_when_no_reportable_credit( $meta_value ): void {
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_meta' )->with( '_funds_used' )->andReturn( $meta_value );
+
+		$result = $this->testee->order_extra_discount( 10.0, $order );
+
+		$this->assertSame( 10.0, $result );
+	}
+
+	public function data_no_reportable_order_credit(): array {
+		return array(
+			'meta absent, WordPress returns empty string' => array( '' ),
+			'negative credit is clamped to zero'           => array( '-5.00' ),
+		);
+	}
+
+	/**
+	 * GIVEN a cart partially paid with store credit
+	 * WHEN store_api_cart_extra_discount() runs
+	 * THEN the credit is converted from a float to minor units and added to the extra
+	 *   discount reported to the Store API
+	 */
+	public function test_store_api_cart_extra_discount_converts_credit_to_minor_units(): void {
+		$this->stub_kestrel_cart( true, 12.50 );
+		when( 'wc_get_price_decimals' )->justReturn( 2 );
+
+		$result = $this->testee->store_api_cart_extra_discount( 100 );
+
+		$this->assertSame( 1350, $result );
+	}
+
+	/**
+	 * GIVEN a cart that Account Funds is not partially covering
+	 * WHEN store_api_cart_extra_discount() runs
+	 * THEN the extra discount in minor units is returned untouched
+	 */
+	public function test_store_api_cart_extra_discount_unchanged_when_no_credit_applies(): void {
+		$this->stub_kestrel_cart( false, 0.0 );
+
+		$result = $this->testee->store_api_cart_extra_discount( 100 );
+
+		$this->assertSame( 100, $result );
+	}
+
+	/**
+	 * GIVEN the plugin reports an applied balance while not partially covering the cart,
+	 *   which is what its getter returns once its own gateway is selected and the cart
+	 *   total was therefore never reduced
+	 * WHEN cart_extra_discount() runs
+	 * THEN nothing is reported, since a discount the cart total does not carry would
+	 *   undercharge the buyer
+	 */
+	public function test_cart_extra_discount_ignores_credit_when_cart_total_was_not_reduced(): void {
+		$this->stub_kestrel_cart( false, 25.0 );
+
+		$cart = Mockery::mock( \WC_Cart::class );
+
+		$result = $this->testee->cart_extra_discount( 2.0, $cart );
+
+		$this->assertSame( 2.0, $result );
+	}
+
+	/**
+	 * GIVEN the Account Funds plugin is not installed, so its cart helper class
+	 *   never exists
+	 * WHEN cart_extra_discount() runs
+	 * THEN no credit is reported and the extra discount is returned unchanged
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_cart_extra_discount_reports_no_credit_when_kestrel_class_absent(): void {
+		$this->assertFalse(
+			class_exists( '\Kestrel\Account_Funds\Cart', false ),
+			'Precondition: the Kestrel stub must not have been loaded in this process.'
+		);
+
+		$cart = Mockery::mock( \WC_Cart::class );
+
+		$result = $this->testee->cart_extra_discount( 5.0, $cart );
+
+		$this->assertSame( 5.0, $result );
+	}
+
+	/**
+	 * GIVEN a cart partially paid with store credit
+	 * WHEN cart_extra_discount() runs
+	 * THEN the applied credit is added to the extra discount accumulated by other hooks
+	 */
+	public function test_cart_extra_discount_adds_applied_credit_when_plugin_present(): void {
+		$this->stub_kestrel_cart( true, 7.5 );
+
+		$cart = Mockery::mock( \WC_Cart::class );
+
+		$result = $this->testee->cart_extra_discount( 2.0, $cart );
+
+		$this->assertSame( 9.5, $result );
+	}
+
+	/**
+	 * GIVEN the compat class is being wired up
+	 * WHEN register() runs
+	 * THEN all three extra-discount filters used to balance the breakdown are attached
+	 */
+	public function test_register_attaches_all_three_extra_discount_filters(): void {
+		expectAdded( 'woocommerce_paypal_payments_cart_extra_discount' )->once();
+		expectAdded( 'woocommerce_paypal_payments_order_extra_discount' )->once();
+		expectAdded( 'woocommerce_paypal_payments_store_api_cart_extra_discount' )->once();
+
+		$this->testee->register();
+
+		$this->addToAssertionCount( 1 );
+	}
+}


### PR DESCRIPTION
### Description

Account Funds applies store credit with `set_total()`, so it never reaches `get_total_discount()`. `AmountFactory` pushes the unreported gap into the tax line, driving it negative, and PayPal rejects the Level 2 card data with `CANNOT_BE_NEGATIVE` on `tax_total`.

Adds `WcAccountFundsCompat` to report the credit through the existing extra-discount filters, same pattern as `WcGiftCardsCompat`.

Related: #4690 catches the same symptom from any source, but only when tax would go negative (complementary, no shared files)

### Steps to Test

Requires store country US, currency USD, ACDC enabled, vaulting off, Level 2/3 processing on, and Account Funds active. Without all of these the bug cannot occur.

1. Give a test customer 200.00 store credit
2. Add a product costing more than that, for example 399.98
3. On the classic checkout, apply the credit so part of the total is still charged
4. Pay with Debit & Credit Cards using a sandbox card
5. Check the newest `woocommerce-paypal-payments` log under WooCommerce > Status > Logs

On `dev/develop` the order fails with `CANNOT_BE_NEGATIVE`. On this branch it completes, with the credit as `discount` and the real tax as `tax_total`.
