### PR TITLE
Fix negative tax_total when a discount is not reported by WooCommerce (6762)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -216,13 +216,23 @@ class AmountFactory {
 		} else {
 			$wc_total              = (float) $order->get_total();
 			$wc_total_cents        = (int) round( $wc_total * 100 );
+			$discount_cents        = (int) round( $discount_value * 100 );
 			$component_total_cents = (int) round( $item_total_val * 100 )
 				+ (int) round( $shipping_val * 100 )
 				+ (int) round( $taxes_val * 100 )
-				- (int) round( $discount_value * 100 );
-			$taxes_cents           = (int) round( $taxes_val * 100 ) + ( $wc_total_cents - $component_total_cents );
-			$taxes                 = new Money( $taxes_cents / 100, $currency );
-			$total                 = new Money( $wc_total, $currency );
+				- $discount_cents;
+			$delta_cents           = $wc_total_cents - $component_total_cents;
+			$taxes_cents           = (int) round( $taxes_val * 100 ) + $delta_cents;
+
+			// Deeper than the tax means an unreported discount, not rounding. Book it
+			// as one: PayPal rejects a negative tax_total on Level 2 card data.
+			if ( $taxes_cents < 0 ) {
+				$taxes_cents = (int) round( $taxes_val * 100 );
+				$discount    = new Money( ( $discount_cents - $delta_cents ) / 100, $currency );
+			}
+
+			$taxes = new Money( $taxes_cents / 100, $currency );
+			$total = new Money( $wc_total, $currency );
 		}
 
 		$breakdown = new AmountBreakdown(

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -224,11 +224,17 @@ class AmountFactory {
 			$delta_cents           = $wc_total_cents - $component_total_cents;
 			$taxes_cents           = (int) round( $taxes_val * 100 ) + $delta_cents;
 
-			// Deeper than the tax means an unreported discount, not rounding. Book it
-			// as one: PayPal rejects a negative tax_total on Level 2 card data.
+			// Deeper than the tax means an unreported discount, not rounding. Book it as
+			// one: PayPal rejects a negative tax_total on Level 2 card data.
 			if ( $taxes_cents < 0 ) {
-				$taxes_cents = (int) round( $taxes_val * 100 );
-				$discount    = new Money( ( $discount_cents - $delta_cents ) / 100, $currency );
+				$taxes_cents = max( 0, (int) round( $taxes_val * 100 ) );
+				$discount    = new Money(
+					( (int) round( $item_total_val * 100 )
+						+ (int) round( $shipping_val * 100 )
+						+ $taxes_cents
+						- $wc_total_cents ) / 100,
+					$currency
+				);
 			}
 
 			$taxes = new Money( $taxes_cents / 100, $currency );

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -515,6 +515,92 @@ class AmountFactoryTest extends TestCase
 	}
 
 	/**
+	 * A plain order with no fees, on the non-free-trial path, carrying only the totals
+	 * the tax reconciliation reads.
+	 */
+	private function orderWithTotals(
+		float $subtotal,
+		float $tax,
+		float $shipping,
+		float $discount,
+		float $total
+	): \WC_Order {
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
+		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
+		$order->shouldReceive( 'get_total' )->andReturn( $total );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+
+		return $order;
+	}
+
+	/**
+	 * An unreported discount (a plugin calling set_total() directly, or an order read
+	 * before get_total_discount() populates) used to push the whole gap into tax and
+	 * drive it negative, which PayPal rejects on Level 2 card data.
+	 *
+	 * @dataProvider dataUnreportedDiscountCases
+	 */
+	public function testFromWcOrderRestoresTaxAndBooksUnreportedDiscount(
+		float $subtotal,
+		float $tax,
+		float $shipping,
+		float $reported_discount,
+		float $wc_total,
+		string $expected_tax,
+		string $expected_discount
+	): void {
+		$order = $this->orderWithTotals( $subtotal, $tax, $shipping, $reported_discount, $wc_total );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( $expected_tax, $breakdown->tax_total()->value_str() );
+		$this->assertSame( $expected_discount, $breakdown->discount()->value_str() );
+
+		$sum = (float) $breakdown->item_total()->value_str()
+			+ (float) $breakdown->shipping()->value_str()
+			+ (float) $breakdown->tax_total()->value_str()
+			- (float) $breakdown->discount()->value_str();
+		$this->assertSame(
+			number_format( $wc_total, 2, '.', '' ),
+			number_format( $sum, 2, '.', '' )
+		);
+	}
+
+	public function dataUnreportedDiscountCases(): array
+	{
+		return [
+			// Rows 1 and 2 must produce the same split: reported or not, the breakdown
+			// PayPal receives is identical.
+			'unreported_discount_smaller_than_tax'      => [ 100.0, 19.0, 0.0, 0.0, 69.0, '19.00', '50.00' ],
+			'reported_discount_matches_unreported_case' => [ 100.0, 19.0, 0.0, 50.0, 69.0, '19.00', '50.00' ],
+			'zero_tax_whole_item_total_discounted'      => [ 45.01, 0.0, 0.0, 0.0, 0.01, '0.00', '45.00' ],
+		];
+	}
+
+	/**
+	 * Guards the behaviour that predates the fallback.
+	 */
+	public function testFromWcOrderSmallRoundingDeltaStaysInTaxNotDiscount(): void
+	{
+		// 16.54 is one cent under the component sum of 16.55.
+		$order = $this->orderWithTotals( 13.90, 2.65, 0.0, 0.0, 16.54 );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( '2.64', $breakdown->tax_total()->value_str() );
+		$this->assertNull( $breakdown->discount() );
+	}
+
+	/**
 	 * A manually created order with a negative fee
 	 * must not be undercharged on the PayPal side. The negative fee is surfaced as
 	 * a discount AND filtered out of the items sent to PayPal, so it must not also

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -462,17 +462,7 @@ class AmountFactoryTest extends TestCase
 		float $discount,
 		float $wc_total
 	): void {
-		$order = Mockery::mock( \WC_Order::class );
-		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
-		$order->shouldReceive( 'get_total_fees' )->andReturn( $fees );
-		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
-		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
-		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
-		$order->shouldReceive( 'get_total' )->andReturn( $wc_total );
-		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
-		$order->shouldReceive( 'get_meta' )->andReturn( null );
-		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
-		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+		$order = $this->orderWithTotals( $subtotal, $tax, $shipping, $discount, $wc_total, $fees );
 
 		$result    = $this->testee->from_wc_order( $order );
 		$breakdown = $result->breakdown();
@@ -515,19 +505,20 @@ class AmountFactoryTest extends TestCase
 	}
 
 	/**
-	 * A plain order with no fees, on the non-free-trial path, carrying only the totals
-	 * the tax reconciliation reads.
+	 * An order on the non-free-trial path, carrying only the totals the tax
+	 * reconciliation reads.
 	 */
 	private function orderWithTotals(
 		float $subtotal,
 		float $tax,
 		float $shipping,
 		float $discount,
-		float $total
+		float $total,
+		float $fees = 0.0
 	): \WC_Order {
 		$order = Mockery::mock( \WC_Order::class );
 		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
-		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( $fees );
 		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
 		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
 		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
@@ -541,9 +532,8 @@ class AmountFactoryTest extends TestCase
 	}
 
 	/**
-	 * An unreported discount (a plugin calling set_total() directly, or an order read
-	 * before get_total_discount() populates) used to push the whole gap into tax and
-	 * drive it negative, which PayPal rejects on Level 2 card data.
+	 * An unreported discount (set_total() called directly, or an order read before
+	 * get_total_discount() populates) used to push the whole gap into tax.
 	 *
 	 * @dataProvider dataUnreportedDiscountCases
 	 */
@@ -577,11 +567,12 @@ class AmountFactoryTest extends TestCase
 	public function dataUnreportedDiscountCases(): array
 	{
 		return [
-			// Rows 1 and 2 must produce the same split: reported or not, the breakdown
-			// PayPal receives is identical.
+			// Rows 1 and 2 must produce the same split, reported or not.
 			'unreported_discount_smaller_than_tax'      => [ 100.0, 19.0, 0.0, 0.0, 69.0, '19.00', '50.00' ],
 			'reported_discount_matches_unreported_case' => [ 100.0, 19.0, 0.0, 50.0, 69.0, '19.00', '50.00' ],
 			'zero_tax_whole_item_total_discounted'      => [ 45.01, 0.0, 0.0, 0.0, 0.01, '0.00', '45.00' ],
+			// A negative fee can make WC report negative tax.
+			'negative_wc_tax_is_floored_at_zero'       => [ 100.0, -5.0, 0.0, 0.0, 60.0, '0.00', '40.00' ],
 		];
 	}
 
@@ -590,7 +581,7 @@ class AmountFactoryTest extends TestCase
 	 */
 	public function testFromWcOrderSmallRoundingDeltaStaysInTaxNotDiscount(): void
 	{
-		// 16.54 is one cent under the component sum of 16.55.
+		// The delta_minus_one case above, asserted on the split rather than the invariant.
 		$order = $this->orderWithTotals( 13.90, 2.65, 0.0, 0.0, 16.54 );
 
 		$result    = $this->testee->from_wc_order( $order );


### PR DESCRIPTION
### Description

`AmountFactory` treats `get_total()` as authoritative and pushes any gap between it and the summed breakdown into the tax line. That was sized for 1 cent inclusive-tax rounding. When a discount is not reported by the standard getters, a plugin calling `set_total()` directly or an order read before `get_total_discount()` populates, the whole discount lands there and drives tax negative. PayPal then rejects the Level 2 card data with `CANNOT_BE_NEGATIVE` on `tax_total`.

Now, when the gap is deeper than the tax, the gap is booked as a discount and the tax is kept, floored at zero. The floor matters because a negative fee can make WooCommerce report negative tax on its own, which would otherwise be passed straight through. Both values stay non-negative and the breakdown still sums to the total.

Only `from_wc_order()` is affected. Both cart methods derive the total from components, so they were never exposed.

Related: #4689 fixes the Account Funds case at the source (complementary, no shared files). 

### Steps to Test

Requires store country US, currency USD, ACDC enabled, and Level 2/3 processing on, otherwise the Level 2 data is never built.

The simplest deterministic trigger is the Account Funds scenario from #4689, since a draft-order read is not reproducible on demand:

1. With Account Funds active, give a test customer 200.00 store credit
2. Add a product costing more than that, for example 399.98
3. On the classic checkout, apply the credit so part of the total is still charged
4. Pay with Debit & Credit Cards using a sandbox card
5. Check the newest `woocommerce-paypal-payments` log under WooCommerce > Status > Logs

On `dev/develop` the request carries a negative `level_2.tax_total` and PayPal rejects it. On this branch the tax is the real amount and the gap appears as `discount`.