### PR TITLE
fix(googlepay): show the product button on variable products with no preselected attributes

### DIFF
--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -1,5 +1,7 @@
 import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
-import SimulateCart, { isSimulateCartEnabled } from '@ppcp-button/Helper/SimulateCart';
+import SimulateCart, {
+	isSimulateCartEnabled,
+} from '@ppcp-button/Helper/SimulateCart';
 import ErrorHandler from '@ppcp-button/ErrorHandler';
 import UpdateCart from '@ppcp-button/Helper/UpdateCart';
 import BaseHandler from './BaseHandler';
@@ -14,18 +16,32 @@ class SingleProductHandler extends BaseHandler {
 	}
 
 	transactionInfo() {
-		// Simulation is this method's only mechanism for fetching product data;
-		// reject early to avoid a pointless AJAX call.
-		if ( ! isSimulateCartEnabled( this.ppcpConfig ) ) {
-			return Promise.reject( new Error( 'Cart simulation is disabled.' ) );
-		}
-
 		const form = document.querySelector( 'form.cart' );
 		const variationIdInput = form?.querySelector(
 			'input[name="variation_id"]'
 		);
 		if ( variationIdInput && ! parseInt( variationIdInput.value ) ) {
-			return Promise.reject( new Error( 'No variation selected.' ) );
+			/*
+			 * No variation chosen, so there is no product total to price yet.
+			 * Rejecting here left the manager without transaction info and it
+			 * skipped the button entirely, so a variable product with no default
+			 * attributes never offered Google Pay at all - not even once the
+			 * shopper picked one, since nothing re-runs the init on that event.
+			 *
+			 * Fall back to the cart-based figures purely so the button renders.
+			 * ProductButtonGate keeps it disabled until a variation exists, and
+			 * onButtonClick() re-reads this method before opening the sheet, so
+			 * this total is never the one presented to the shopper.
+			 */
+			return super.transactionInfo();
+		}
+
+		// Simulation is this method's only mechanism for fetching product data;
+		// reject early to avoid a pointless AJAX call.
+		if ( ! isSimulateCartEnabled( this.ppcpConfig ) ) {
+			return Promise.reject(
+				new Error( 'Cart simulation is disabled.' )
+			);
 		}
 
 		const errorHandler = new ErrorHandler(

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
@@ -90,9 +90,9 @@ describe( 'SingleProductHandler', () => {
 					null
 				);
 
-				await expect( disabledHandler.transactionInfo() ).rejects.toThrow(
-					'Cart simulation is disabled.'
-				);
+				await expect(
+					disabledHandler.transactionInfo()
+				).rejects.toThrow( 'Cart simulation is disabled.' );
 				expect( mockSimulate ).not.toHaveBeenCalled();
 			} );
 
@@ -113,31 +113,43 @@ describe( 'SingleProductHandler', () => {
 		} );
 
 		describe( 'variation_id guard', () => {
-			test( 'rejects immediately when variation_id is empty', async () => {
-				document.body.innerHTML = `
+			// Falling back rather than rejecting is what lets the button render at
+			// all: the manager skips a button it has no transaction info for, and
+			// nothing re-runs that init when a variation is later chosen, so a
+			// rejection here removed Google Pay from the product for good.
+			// ProductButtonGate keeps the rendered button disabled, and
+			// onButtonClick() re-reads this method before opening the sheet.
+			test.each( [
+				[ 'empty', '' ],
+				[ '"0"', '0' ],
+			] )(
+				'falls back to the cart totals, without simulating, when variation_id is %s',
+				async ( _label, value ) => {
+					document.body.innerHTML = `
 					<form class="cart">
-						<input type="hidden" name="variation_id" value="" />
+						<input type="hidden" name="variation_id" value="${ value }" />
 					</form>
 				`;
 
-				await expect( handler.transactionInfo() ).rejects.toThrow(
-					'No variation selected.'
-				);
-				expect( mockSimulate ).not.toHaveBeenCalled();
-			} );
+					const fallback = Symbol( 'cart transaction info' );
+					const baseTransactionInfo = jest
+						.spyOn(
+							Object.getPrototypeOf(
+								Object.getPrototypeOf( handler )
+							),
+							'transactionInfo'
+						)
+						.mockResolvedValue( fallback );
 
-			test( 'rejects immediately when variation_id is "0"', async () => {
-				document.body.innerHTML = `
-					<form class="cart">
-						<input type="hidden" name="variation_id" value="0" />
-					</form>
-				`;
+					await expect( handler.transactionInfo() ).resolves.toBe(
+						fallback
+					);
+					expect( baseTransactionInfo ).toHaveBeenCalled();
+					expect( mockSimulate ).not.toHaveBeenCalled();
 
-				await expect( handler.transactionInfo() ).rejects.toThrow(
-					'No variation selected.'
-				);
-				expect( mockSimulate ).not.toHaveBeenCalled();
-			} );
+					baseTransactionInfo.mockRestore();
+				}
+			);
 
 			test( 'calls simulate_cart when variation_id is set', async () => {
 				document.body.innerHTML = `
@@ -184,7 +196,9 @@ describe( 'SingleProductHandler', () => {
 
 			test( 'resolves with TransactionInfo built from response data', async () => {
 				const mockTransactionInstance = { totalPrice: '45.00' };
-				TransactionInfo.mockImplementation( () => mockTransactionInstance );
+				TransactionInfo.mockImplementation(
+					() => mockTransactionInstance
+				);
 
 				mockSimulate.mockImplementation( ( onResolve ) =>
 					Promise.resolve(
@@ -199,12 +213,19 @@ describe( 'SingleProductHandler', () => {
 
 				const result = await handler.transactionInfo();
 
-				expect( TransactionInfo ).toHaveBeenCalledWith( 45, 5, 'USD', 'US' );
+				expect( TransactionInfo ).toHaveBeenCalledWith(
+					45,
+					5,
+					'USD',
+					'US'
+				);
 				expect( result ).toBe( mockTransactionInstance );
 			} );
 
 			test( 'propagates rejection from simulate_cart', async () => {
-				const serverError = { message: 'Error adding products to cart.' };
+				const serverError = {
+					message: 'Error adding products to cart.',
+				};
 				mockSimulate.mockRejectedValue( serverError );
 
 				await expect( handler.transactionInfo() ).rejects.toEqual(

--- a/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.js
+++ b/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.js
@@ -1,0 +1,102 @@
+/**
+ * Gates the product-page Google Pay button behind the native add-to-cart state.
+ *
+ * The v5 product bootstrap disables only its own wrapper, and this button's
+ * container is a sibling of it rather than a descendant (SmartButton::button_renderer()
+ * prints both inside .ppc-button-wrapper), so `.ppcp-disabled` never reaches it.
+ * Without this the button would sit enabled next to a disabled "Add to cart",
+ * offering a payment for a variable product with no variation chosen.
+ *
+ * @file
+ */
+
+import {
+	disable,
+	enable,
+	isDisabled,
+} from '@ppcp-button/Helper/ButtonDisabler';
+
+const FORM_SELECTOR = 'form.cart';
+
+// The native submit whose disabled state WooCommerce drives from the variation
+// selection. Its absence means nothing gates the purchase, so the button stays live.
+const ADD_TO_CART_SELECTOR = '.single_add_to_cart_button';
+
+// Attached once per page, however many times init is called.
+let initialized = false;
+
+/**
+ * Resets module state. Test seam only.
+ */
+export function resetProductButtonGate() {
+	initialized = false;
+}
+
+/**
+ * Starts gating the product-page Google Pay button.
+ *
+ * No-ops off the product page and on pages without a classic add-to-cart form,
+ * so it is safe to call unconditionally.
+ *
+ * @param {string} wrapperSelector - Selector of the button's container.
+ * @param {string} context         - The current page context.
+ */
+export function initProductButtonGate( wrapperSelector, context ) {
+	if ( 'product' !== context || initialized || ! wrapperSelector ) {
+		return;
+	}
+
+	const form = document.querySelector( FORM_SELECTOR );
+	if ( ! form ) {
+		return;
+	}
+
+	const shouldEnable = () => {
+		// Re-queried each time: WooCommerce re-renders the button as the
+		// variation selection changes.
+		const button = form.querySelector( ADD_TO_CART_SELECTOR );
+
+		return ! button || ! button.classList.contains( 'disabled' );
+	};
+
+	const sync = () => {
+		const wrapper = document.querySelector( wrapperSelector );
+		if ( ! wrapper ) {
+			return;
+		}
+
+		const enableNow = shouldEnable();
+		const wasDisabled = isDisabled( wrapper );
+
+		// Only act on a transition: disable() binds a fresh mouseup handler each
+		// call, so calling it twice without an intervening enable() would stack
+		// handlers and submit the form more than once.
+		if ( enableNow && wasDisabled ) {
+			enable( wrapper );
+		} else if ( ! enableNow && ! wasDisabled ) {
+			disable( wrapper, form );
+		}
+	};
+
+	initialized = true;
+
+	sync();
+
+	const addToCartButton = form.querySelector( ADD_TO_CART_SELECTOR );
+	if ( addToCartButton ) {
+		new MutationObserver( sync ).observe( form, {
+			subtree: true,
+			attributes: true,
+			attributeFilter: [ 'class' ],
+		} );
+	}
+
+	// Covers quantity changes and the attribute selects.
+	form.addEventListener( 'change', sync );
+
+	if ( window.jQuery ) {
+		// WooCommerce fills variation_id and flips the add-to-cart button only
+		// after these fire, so the change event above can run a beat too early.
+		window.jQuery( form ).on( 'found_variation reset_data', sync );
+	}
+}

--- a/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.test.js
+++ b/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.test.js
@@ -1,0 +1,174 @@
+/* global jest, describe, test, expect, beforeEach, afterEach */
+
+import jQuery from 'jquery';
+
+// isDisabled() is backed by the wrapper's real class list, and disable()/enable()
+// mutate it the same way the real ButtonDisabler's `ppcp-disabled` class does, so
+// the module's own transition guard (isDisabled() vs the new state) is genuinely
+// exercised rather than assumed.
+const getElement = ( selectorOrElement ) =>
+	typeof selectorOrElement === 'string'
+		? document.querySelector( selectorOrElement )
+		: selectorOrElement;
+
+jest.mock( '@ppcp-button/Helper/ButtonDisabler', () => ( {
+	disable: jest.fn( ( selectorOrElement ) => {
+		getElement( selectorOrElement ).classList.add( 'ppcp-disabled' );
+	} ),
+	enable: jest.fn( ( selectorOrElement ) => {
+		getElement( selectorOrElement ).classList.remove( 'ppcp-disabled' );
+	} ),
+	isDisabled: jest.fn( ( selectorOrElement ) =>
+		getElement( selectorOrElement ).classList.contains( 'ppcp-disabled' )
+	),
+} ) );
+
+import { disable, enable } from '@ppcp-button/Helper/ButtonDisabler';
+import {
+	initProductButtonGate,
+	resetProductButtonGate,
+} from './ProductButtonGate';
+
+const WRAPPER_SELECTOR = '#ppc-button-googlepay-container';
+
+function renderPage( {
+	addToCartDisabled = false,
+	withAddToCart = true,
+} = {} ) {
+	document.body.innerHTML = `
+		<div id="ppc-button-googlepay-container"></div>
+		<form class="cart">
+			${
+				withAddToCart
+					? `<button type="submit" class="single_add_to_cart_button${
+							addToCartDisabled ? ' disabled' : ''
+					  }"></button>`
+					: ''
+			}
+		</form>
+	`;
+}
+
+function wrapperIsDisabled() {
+	return document
+		.querySelector( WRAPPER_SELECTOR )
+		.classList.contains( 'ppcp-disabled' );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	document.body.innerHTML = '';
+	resetProductButtonGate();
+	global.jQuery = jQuery;
+} );
+
+afterEach( () => {
+	delete global.jQuery;
+	document.body.innerHTML = '';
+} );
+
+describe( 'initProductButtonGate()', () => {
+	test.each( [ 'checkout', 'cart', undefined ] )(
+		'does nothing when context is %s, even with a disabled add-to-cart button',
+		( context ) => {
+			renderPage( { addToCartDisabled: true } );
+
+			initProductButtonGate( WRAPPER_SELECTOR, context );
+
+			expect( wrapperIsDisabled() ).toBe( false );
+			expect( disable ).not.toHaveBeenCalled();
+		}
+	);
+
+	test( 'does nothing when wrapperSelector is falsy', () => {
+		renderPage( { addToCartDisabled: true } );
+
+		initProductButtonGate( '', 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does nothing when there is no form.cart on the page', () => {
+		document.body.innerHTML = `<div id="ppc-button-googlepay-container"></div>`;
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+		expect( enable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'disables the wrapper on init when the add-to-cart button is disabled', () => {
+		renderPage( { addToCartDisabled: true } );
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( true );
+	} );
+
+	test( 'leaves the wrapper enabled on init when the add-to-cart button is not disabled', () => {
+		renderPage( { addToCartDisabled: false } );
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'leaves the wrapper enabled on init when there is no add-to-cart button at all', () => {
+		renderPage( { withAddToCart: false } );
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'enables the wrapper once the disabled class is removed and the form changes, as when a shopper picks a variation', () => {
+		renderPage( { addToCartDisabled: true } );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		expect( wrapperIsDisabled() ).toBe( true );
+
+		document
+			.querySelector( '.single_add_to_cart_button' )
+			.classList.remove( 'disabled' );
+		document
+			.querySelector( 'form.cart' )
+			.dispatchEvent( new Event( 'change' ) );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+	} );
+
+	test( 'disables the wrapper again once the disabled class returns and the form changes, as when the selection is cleared', () => {
+		renderPage( { addToCartDisabled: false } );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		expect( wrapperIsDisabled() ).toBe( false );
+
+		document
+			.querySelector( '.single_add_to_cart_button' )
+			.classList.add( 'disabled' );
+		document
+			.querySelector( 'form.cart' )
+			.dispatchEvent( new Event( 'change' ) );
+
+		expect( wrapperIsDisabled() ).toBe( true );
+	} );
+
+	test( 'a repeated init call does not double-attach: a single transition still disables only once', () => {
+		renderPage( { addToCartDisabled: false } );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		disable.mockClear();
+
+		document
+			.querySelector( '.single_add_to_cart_button' )
+			.classList.add( 'disabled' );
+		document
+			.querySelector( 'form.cart' )
+			.dispatchEvent( new Event( 'change' ) );
+
+		expect( wrapperIsDisabled() ).toBe( true );
+		expect( disable ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -13,6 +13,7 @@ import GooglepayManager from './GooglepayManager';
 import { setupButtonEvents } from '@ppcp-button/Helper/ButtonRefreshHelper';
 import { CheckoutBootstrap } from './ContextBootstrap/CheckoutBootstrap';
 import moduleStorage from './Helper/GooglePayStorage';
+import { initProductButtonGate } from './Helper/ProductButtonGate';
 
 ( function ( { buttonConfig, ppcpConfig = {} } ) {
 	const context = ppcpConfig.context;
@@ -32,6 +33,8 @@ import moduleStorage from './Helper/GooglePayStorage';
 		setupButtonEvents( function () {
 			manager.reinit();
 		} );
+
+		initProductButtonGate( buttonConfig?.button?.wrapper, context );
 	}
 
 	function bootstrapCheckout() {


### PR DESCRIPTION
### Description

On a classic product page with SDK v5, a variable product whose attributes have no defaults never offered Google Pay. The other express buttons rendered normally.

`SingleProductHandler::transactionInfo()` rejected with `No variation selected.` when `variation_id` was empty. `GooglepayManager` swallows that, ends up with no transaction info, and skips the button (`No transaction info available, skipping button init`). Nothing re-runs that init on a variation change — `setupButtonEvents()` listens for cart, checkout and fragment events, not `found_variation` — so the button stayed missing **even after the shopper picked a variation**. Other product types were unaffected: they resolve a variation up front, or have no `variation_id` input at all.

Two changes:

- The no-variation case now falls back to the cart-based figures so the button renders. `onButtonClick()` re-reads `transactionInfo()` before opening the sheet, so the fallback total is never the one shown to the shopper.
- A new `ProductButtonGate` mirrors the native add-to-cart state onto the button's container through the shared `ButtonDisabler`. This is needed because the v5 product bootstrap disables only its own wrapper, and the Google Pay container is a **sibling** of it rather than a descendant (`SmartButton::button_renderer()` prints both inside `.ppc-button-wrapper`), so `.ppcp-disabled` never reached it. Nothing else gated it either: `GooglepayButton` has no disabled state, and the `ppcp_buttons_enabled_changed` event the bootstrap fires has no listeners anywhere.

The gate is committed before the render change, so no revision in the history offers a live button without a variation.

Verified in the browser, with the disabled state tracking the PayPal buttons exactly:

| | `variation_id` | Google Pay | GPay disabled | PayPal disabled |
|---|---|---|---|---|
| No defaults, on load | 0 | renders (was absent) | yes | yes |
| No defaults, after selecting | 346 | renders | no | no |
| With defaults (control) | 349 | renders | no | no |

A real click while disabled is blocked by `pointer-events: none`: no sheet, no popup.

**Known limitation.** `.ppcp-disabled` dims via `grayscale`, which is close to inert on an already black-and-white button, so the disabled Google Pay button does not *look* disabled the way the greyed PayPal buttons do. It is disabled — the click is blocked — but there is no visual cue. Adding opacity would fix it and may run into Google's button-styling guidelines, so it is left for a design decision rather than guessed at here.

**Not a 4.1.3 regression.** The rejection was added on 2026-06-09 (`e83973ecc`) and shipped in 4.1.2. This blocks the 4.1.3 release ticket but did not originate there.

Two existing tests asserted the rejection this replaces; they now pin the fallback, since the rejection is what removed the button for good. Kept in the same commit as the source change, because a source-only commit would have failed them.

### Steps to Test

Requires SDK v5 (not v6), with Google Pay enabled both as a button and for the Product page location in the Styling tab.

1. Create a variable product with two attributes used for variations, **no default values set**, and at least one priced variation.
2. Open the product page with nothing selected. Google Pay should render below PayPal, Venmo and Pay Later. On `dev/release/4.1.3` it is absent entirely.
3. Click it while the dropdowns still read "Choose an option". Nothing should happen — no Google Pay sheet.
4. Select both attributes. The button becomes active, and clicking it opens the sheet showing the **variation's** price, not a cart total.
5. Regression: set default attributes on the product. Google Pay renders enabled immediately, as before.
6. Regression: a simple product is unchanged.
7. Regression: the cart and checkout pages are unchanged — the gate only runs when the page context is `product`.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: The Google Pay button now appears on variable products that have no preselected attributes, disabled until a variation is chosen.
