### PR TITLE
Add snapshot mechanism to rebuild shipping line items (6763)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -68,6 +68,7 @@ use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PayUponInvoice\Pay
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PayUponInvoice\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PWCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\RefundFeesUpdater;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
@@ -683,6 +684,12 @@ return array(
 		return new FeesUpdater(
 			$container->get( 'api.endpoint.orders' ),
 			$container->get( 'api.factory.capture' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
+		);
+	},
+
+	'wcgateway.helper.resumed-order-shipping-restorer'     => static function ( ContainerInterface $container ): ResumedOrderShippingRestorer {
+		return new ResumedOrderShippingRestorer(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Helper/ResumedOrderShippingRestorer.php
+++ b/modules/ppcp-wc-gateway/src/Helper/ResumedOrderShippingRestorer.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Restores the shipping line items WooCommerce drops when it resumes a failed order.
+ *
+ *
+ * This helper snapshots the shipping items while they still exist and re-adds them after
+ * the rebuild, only when the divergence actually happened.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use Psr\Log\LoggerInterface;
+use Throwable;
+use WC_Order;
+use WC_Order_Item_Shipping;
+
+/**
+ * ResumedOrderShippingRestorer class.
+ */
+class ResumedOrderShippingRestorer {
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * The shipping line items captured before the rebuild, keyed by order ID.
+	 *
+	 * Lives for the duration of the request only: the snapshot is taken and consumed
+	 * within a single checkout submission.
+	 *
+	 * @var array<int, array<int, array<string, mixed>>>
+	 */
+	private $snapshots = array();
+
+	/**
+	 * ResumedOrderShippingRestorer constructor.
+	 *
+	 * @param LoggerInterface $logger The logger.
+	 */
+	public function __construct( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Records the shipping line items of an order that is about to be rebuilt.
+	 *
+	 * Hooked to `woocommerce_resume_order`, which fires immediately before
+	 * WC_Order::remove_order_items() deletes them.
+	 *
+	 * @param int $order_id The ID of the order being resumed.
+	 * @return void
+	 */
+	public function snapshot( int $order_id ): void {
+		try {
+			if ( $order_id <= 0 ) {
+				return;
+			}
+
+			$wc_order = wc_get_order( $order_id );
+			if ( ! $wc_order instanceof WC_Order ) {
+				return;
+			}
+
+			$items = array();
+
+			foreach ( $wc_order->get_shipping_methods() as $item ) {
+				if ( ! $item instanceof WC_Order_Item_Shipping ) {
+					continue;
+				}
+
+				$items[] = array(
+					'method_title' => $item->get_method_title(),
+					'method_id'    => $item->get_method_id(),
+					'instance_id'  => $item->get_instance_id(),
+					'total'        => $item->get_total(),
+					'total_tax'    => $item->get_total_tax(),
+					'taxes'        => $item->get_taxes(),
+					'tax_status'   => $item->get_tax_status(),
+					'meta'         => $this->meta_of( $item ),
+				);
+			}
+
+			if ( ! $items ) {
+				return;
+			}
+
+			$this->snapshots[ $order_id ] = $items;
+		} catch ( Throwable $exception ) {
+			unset( $this->snapshots[ $order_id ] );
+
+			$this->logger->error(
+				sprintf(
+					'Could not snapshot the shipping line items of resumed order %1$d: %2$s',
+					$order_id,
+					$exception->getMessage()
+				)
+			);
+		}
+	}
+
+	/**
+	 * Re-adds the snapshotted shipping line items when the rebuild dropped them.
+	 *
+	 * Restoration is best-effort: a failure is logged and swallowed so that checkout and
+	 * payment proceed exactly as they do today.
+	 *
+	 * @param int $order_id The ID of the processed order.
+	 * @return void
+	 */
+	public function restore( int $order_id ): void {
+		$shipping_total = '';
+
+		try {
+			if ( ! isset( $this->snapshots[ $order_id ] ) ) {
+				return;
+			}
+
+			$wc_order = wc_get_order( $order_id );
+			if ( ! $wc_order instanceof WC_Order ) {
+				unset( $this->snapshots[ $order_id ] );
+
+				return;
+			}
+
+			$shipping_total = (string) $wc_order->get_shipping_total();
+			if ( (float) $shipping_total <= 0.0 ) {
+				return;
+			}
+
+			if ( $wc_order->get_shipping_methods() ) {
+				return;
+			}
+
+			foreach ( $this->snapshots[ $order_id ] as $item_data ) {
+				$wc_order->add_item( $this->item_from( $item_data ) );
+			}
+
+			/**
+			 * Only the line items are persisted. The order's shipping total and grand total
+			 * were already correct and must stay byte-identical, so no total is recalculated
+			 * here: the amount sent to PayPal is unaffected by the restoration.
+			 */
+			$wc_order->save();
+
+			unset( $this->snapshots[ $order_id ] );
+		} catch ( Throwable $exception ) {
+			$this->logger->error(
+				sprintf(
+					'Could not restore the shipping line item of resumed order %1$d, which has a shipping total of %2$s and no shipping line item backing it: %3$s',
+					$order_id,
+					'' !== $shipping_total ? $shipping_total : 'unknown',
+					$exception->getMessage()
+				)
+			);
+		}
+	}
+
+	/**
+	 * Builds a fresh shipping line item from snapshotted data.
+	 *
+	 * A new item is built rather than the original object being reused, because the
+	 * original row was deleted by WC_Order::remove_order_items() and its ID no longer
+	 * exists in the database.
+	 *
+	 * @param array<string, mixed> $item_data The snapshotted item data.
+	 * @return WC_Order_Item_Shipping
+	 */
+	private function item_from( array $item_data ): WC_Order_Item_Shipping {
+		$item = new WC_Order_Item_Shipping();
+
+		$item->set_method_title( (string) ( $item_data['method_title'] ?? '' ) );
+		$item->set_method_id( (string) ( $item_data['method_id'] ?? '' ) );
+		$item->set_instance_id( (string) ( $item_data['instance_id'] ?? '' ) );
+		$item->set_total( (string) ( $item_data['total'] ?? '0' ) );
+
+		/**
+		 * WC_Order_Item_Shipping::set_total_tax() is protected; set_taxes() derives the
+		 * total tax from the same rate breakdown the original item carried. The snapshotted
+		 * tax status needs no counterpart, since WC_Order_Item::get_tax_status() is fixed.
+		 */
+		$taxes = $item_data['taxes'] ?? array();
+		$item->set_taxes( is_array( $taxes ) ? $taxes : array() );
+
+		$meta = $item_data['meta'] ?? array();
+		if ( is_array( $meta ) ) {
+			foreach ( $meta as $meta_entry ) {
+				$item->add_meta_data( (string) $meta_entry['key'], $meta_entry['value'], true );
+			}
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Extracts the item meta as plain key/value pairs.
+	 *
+	 * The WC_Meta_Data objects themselves carry IDs of rows that are about to be deleted,
+	 * so only the values are kept.
+	 *
+	 * @param WC_Order_Item_Shipping $item The shipping line item.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function meta_of( WC_Order_Item_Shipping $item ): array {
+		$meta = array();
+
+		foreach ( $item->get_meta_data() as $meta_data ) {
+			$data = $meta_data->get_data();
+
+			if ( ! isset( $data['key'] ) || '' === (string) $data['key'] ) {
+				continue;
+			}
+
+			$meta[] = array(
+				'key'   => (string) $data['key'],
+				'value' => $data['value'] ?? '',
+			);
+		}
+
+		return $meta;
+	}
+}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -47,6 +47,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\InstallmentsProductStatus;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PayUponInvoice\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PWCProductStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\GatewayWithoutPayPalAdminNotice;
@@ -92,6 +93,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		$this->register_block_express_payment_method_handler( $c );
 		$this->register_columns( $c );
 		$this->register_checkout_paypal_address_preset( $c );
+		$this->register_resumed_order_shipping_restorer( $c );
 		$this->register_wc_tasks( $c );
 		$this->register_woo_inbox_notes( $c );
 		$this->register_void_button( $c );
@@ -777,6 +779,42 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			},
 			10,
 			2
+		);
+	}
+
+	/**
+	 * Registers the restorer that keeps the shipping line item of a resumed order.
+	 *
+	 * WooCommerce wipes and rebuilds a resumed order's line items; the rebuild can leave a
+	 * non-zero shipping total with no shipping line item behind it. The restorer snapshots
+	 * the items before they are wiped and puts them back when that happens.
+	 *
+	 * @param ContainerInterface $container The container.
+	 * @return void
+	 */
+	private function register_resumed_order_shipping_restorer( ContainerInterface $container ): void {
+		add_action(
+			'woocommerce_resume_order',
+			static function ( $order_id ) use ( $container ): void {
+				$restorer = $container->get( 'wcgateway.helper.resumed-order-shipping-restorer' );
+				assert( $restorer instanceof ResumedOrderShippingRestorer );
+
+				$restorer->snapshot( (int) $order_id );
+			},
+			10,
+			1
+		);
+
+		add_action(
+			'woocommerce_checkout_order_processed',
+			static function ( $order_id ) use ( $container ): void {
+				$restorer = $container->get( 'wcgateway.helper.resumed-order-shipping-restorer' );
+				assert( $restorer instanceof ResumedOrderShippingRestorer );
+
+				$restorer->restore( (int) $order_id );
+			},
+			10,
+			1
 		);
 	}
 

--- a/tests/integration/PHPUnit/Checkout/ResumedOrderShippingRestorerTest.php
+++ b/tests/integration/PHPUnit/Checkout/ResumedOrderShippingRestorerTest.php
@@ -1,0 +1,744 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Checkout;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WC_Order;
+use WC_Shipping_Zone;
+use WC_Shipping_Zones;
+use WC_Tax;
+use WC_Cache_Helper;
+use WooCommerce\PayPalCommerce\Tests\Integration\IntegrationMockedTestCase;
+
+/**
+ * Integration tests for ResumedOrderShippingRestorer.
+ *
+ * Reproduces the "shipping line lost on Advanced Card Processing retry" bug:
+ * WC_Checkout::create_order() resumes a failed order, wipes its line items,
+ * and rebuilds it. set_data_from_cart() restores the shipping TOTAL
+ * unconditionally, while create_order_shipping_lines() only restores the
+ * shipping LINE ITEM when the previously chosen rate still resolves in the
+ * freshly recalculated shipping packages. When it does not, the order is
+ * left with a non-zero shipping total and zero shipping line items.
+ */
+class ResumedOrderShippingRestorerTest extends IntegrationMockedTestCase
+{
+    /**
+     * @var int[]
+     */
+    private $created_order_ids = [];
+
+    /**
+     * @var array<int, array{zone_id: int, instance_id: int}>
+     */
+    private $created_zones = [];
+
+    /**
+     * @var int[]
+     */
+    private $tax_rate_ids = [];
+
+    /**
+     * @var callable|null
+     */
+    private $throwing_filter;
+
+    /**
+     * @var callable|null
+     */
+    private $flag_callback;
+
+    /**
+     * Baseline values of the global WooCommerce tax options, captured in setUp()
+     * and restored verbatim in tearDown() so this class never leaks tax
+     * configuration into tests that run after it in the same process.
+     *
+     * @var string|false
+     */
+    private $original_calc_taxes;
+
+    /**
+     * @var string|false
+     */
+    private $original_tax_based_on;
+
+    /**
+     * @var string|false
+     */
+    private $original_prices_include_tax;
+
+    /**
+     * Baseline customer address, captured in setUp() and restored verbatim in
+     * tearDown(). fill_cart_and_calculate() overwrites these fields (and persists
+     * them via WC_Customer::save()) to drive shipping-zone matching, and nothing
+     * else in the flow ever puts them back.
+     *
+     * @var array<string, string>
+     */
+    private $original_customer_address = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->original_calc_taxes = get_option('woocommerce_calc_taxes');
+        $this->original_tax_based_on = get_option('woocommerce_tax_based_on');
+        $this->original_prices_include_tax = get_option('woocommerce_prices_include_tax');
+
+        $customer = $this->customer();
+        $this->original_customer_address = [
+            'shipping_country' => $customer->get_shipping_country(),
+            'shipping_state' => $customer->get_shipping_state(),
+            'shipping_city' => $customer->get_shipping_city(),
+            'shipping_postcode' => $customer->get_shipping_postcode(),
+            'billing_country' => $customer->get_billing_country(),
+            'billing_state' => $customer->get_billing_state(),
+            'billing_city' => $customer->get_billing_city(),
+            'billing_postcode' => $customer->get_billing_postcode(),
+        ];
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->throwing_filter) {
+            remove_filter('woocommerce_order_get_items', $this->throwing_filter, 10);
+            $this->throwing_filter = null;
+        }
+
+        if ($this->flag_callback) {
+            remove_action('woocommerce_checkout_order_processed', $this->flag_callback, PHP_INT_MAX);
+            $this->flag_callback = null;
+        }
+
+        foreach ($this->created_order_ids as $order_id) {
+            $order = wc_get_order($order_id);
+            if ($order instanceof WC_Order) {
+                $order->delete(true);
+            }
+        }
+        $this->created_order_ids = [];
+
+        foreach ($this->created_zones as $zone) {
+            delete_option('woocommerce_flat_rate_' . $zone['instance_id'] . '_settings');
+            WC_Shipping_Zones::delete_zone($zone['zone_id']);
+        }
+        $this->created_zones = [];
+
+        // WC_Shipping_Zones::delete_zone() does not itself bump the shipping transient
+        // version, so cached packages/rates resolved from a zone created by this class
+        // would otherwise survive into the next test.
+        WC_Cache_Helper::get_transient_version('shipping', true);
+
+        foreach ($this->tax_rate_ids as $tax_rate_id) {
+            WC_Tax::_delete_tax_rate($tax_rate_id);
+        }
+        $this->tax_rate_ids = [];
+
+        // Bump the tax transient version so cached tax-rate lookups from this
+        // class's inserted/deleted rates don't leak into later tests.
+        WC_Cache_Helper::get_transient_version('taxes', true);
+
+        update_option('woocommerce_calc_taxes', $this->original_calc_taxes);
+        update_option('woocommerce_tax_based_on', $this->original_tax_based_on);
+        update_option('woocommerce_prices_include_tax', $this->original_prices_include_tax);
+
+        // Restore the customer address fill_cart_and_calculate() overwrote and
+        // persisted, so a later test's shipping-zone matching never depends on
+        // whatever address this class last left behind.
+        if ($this->original_customer_address) {
+            $customer = $this->customer();
+            $customer->set_shipping_country($this->original_customer_address['shipping_country']);
+            $customer->set_shipping_state($this->original_customer_address['shipping_state']);
+            $customer->set_shipping_city($this->original_customer_address['shipping_city']);
+            $customer->set_shipping_postcode($this->original_customer_address['shipping_postcode']);
+            $customer->set_billing_country($this->original_customer_address['billing_country']);
+            $customer->set_billing_state($this->original_customer_address['billing_state']);
+            $customer->set_billing_city($this->original_customer_address['billing_city']);
+            $customer->set_billing_postcode($this->original_customer_address['billing_postcode']);
+            $customer->save();
+        }
+
+        WC()->session->set('order_awaiting_payment', 0);
+        WC()->session->set('chosen_shipping_methods', []);
+
+        // WC_Shipping::calculate_shipping_for_package() caches resolved rates in the
+        // session under 'shipping_for_package_<n>', keyed by a package hash. That
+        // session is backed by the woocommerce_sessions DB table (WC_Session_Handler),
+        // so stale entries survive across processes; clear them explicitly rather than
+        // relying solely on the shipping transient bump above.
+        if (method_exists(WC()->session, 'get_session_data')) {
+            foreach (array_keys(WC()->session->get_session_data()) as $session_key) {
+                if (0 === strpos($session_key, 'shipping_for_package_')) {
+                    WC()->session->set($session_key, null);
+                }
+            }
+        }
+
+        $this->cart()->empty_cart();
+
+        parent::tearDown();
+    }
+
+    /**
+     * GIVEN a checkout order with one taxable flat-rate shipping line item
+     * WHEN woocommerce_resume_order fires for that order and it is later rebuilt
+     * THEN the restorer's recorded snapshot reproduces the item's method_title,
+     *      method_id, instance_id, total, total_tax, taxes and tax_status exactly
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_snapshots_all_shipping_item_fields_when_resume_order_fires(): void
+    {
+        $this->bootstrapModule();
+
+        $zone = $this->create_shipping_zone_with_flat_rate('18.45', 'taxable');
+        $this->enable_taxes_for_country('US');
+        $this->fill_cart_and_calculate($zone['rate_key']);
+
+        $order_id = $this->create_initial_order();
+
+        $initial_order = wc_get_order($order_id);
+        $initial_items = $initial_order->get_shipping_methods();
+        $this->assertCount(1, $initial_items, 'Precondition: the freshly created order must carry one shipping line.');
+
+        $original_item = current($initial_items);
+        $this->assertGreaterThan(
+            0.0,
+            (float) $original_item->get_total_tax(),
+            'Precondition: the shipping line must be taxed for this assertion to be meaningful.'
+        );
+
+        $expected_method_title = $original_item->get_method_title();
+        $expected_method_id = $original_item->get_method_id();
+        $expected_instance_id = $original_item->get_instance_id();
+        $expected_total = $original_item->get_total();
+        $expected_total_tax = $original_item->get_total_tax();
+        $expected_taxes = $original_item->get_taxes();
+        $expected_tax_status = $original_item->get_tax_status();
+
+        $this->resume_with_missing_rate($order_id);
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        $restored_order = wc_get_order($order_id);
+        $restored_items = $restored_order->get_shipping_methods();
+        $this->assertCount(1, $restored_items);
+
+        $restored_item = current($restored_items);
+        $this->assertSame($expected_method_title, $restored_item->get_method_title());
+        $this->assertSame($expected_method_id, $restored_item->get_method_id());
+        $this->assertSame($expected_instance_id, $restored_item->get_instance_id());
+        $this->assertSame($expected_total, $restored_item->get_total());
+        $this->assertSame($expected_total_tax, $restored_item->get_total_tax());
+        $this->assertSame($expected_taxes, $restored_item->get_taxes());
+        $this->assertSame($expected_tax_status, $restored_item->get_tax_status());
+    }
+
+    /**
+     * GIVEN a resumed order whose rebuild leaves a shipping total of 18.45 with no shipping line items
+     * WHEN woocommerce_checkout_order_processed fires
+     * THEN a shipping line matching the snapshotted method_title, method_id, instance_id and total
+     *      is added to the order and persisted
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_restores_the_shipping_line_when_rebuild_leaves_a_total_without_items(): void
+    {
+        $this->bootstrapModule();
+
+        $zone = $this->create_shipping_zone_with_flat_rate('18.45');
+        $this->fill_cart_and_calculate($zone['rate_key']);
+
+        $order_id = $this->create_initial_order();
+
+        $initial_order = wc_get_order($order_id);
+        $initial_items = $initial_order->get_shipping_methods();
+        $this->assertCount(1, $initial_items, 'Precondition: the initial order must carry the shipping line.');
+
+        $original_item = current($initial_items);
+        $expected_method_title = $original_item->get_method_title();
+        $expected_method_id = $original_item->get_method_id();
+        $expected_instance_id = $original_item->get_instance_id();
+        $expected_total = $original_item->get_total();
+
+        $this->resume_with_missing_rate($order_id);
+
+        $bug_state_order = wc_get_order($order_id);
+        $this->assertCount(
+            0,
+            $bug_state_order->get_shipping_methods(),
+            'The bug must be reproduced: rebuild must leave no shipping line items.'
+        );
+        $this->assertEqualsWithDelta(
+            18.45,
+            (float) $bug_state_order->get_shipping_total(),
+            0.001,
+            'The bug must be reproduced: shipping total must remain the non-zero cart total.'
+        );
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        $restored_order = wc_get_order($order_id);
+        $restored_items = $restored_order->get_shipping_methods();
+        $this->assertCount(1, $restored_items);
+
+        $restored_item = current($restored_items);
+        $this->assertSame($expected_method_title, $restored_item->get_method_title());
+        $this->assertSame($expected_method_id, $restored_item->get_method_id());
+        $this->assertSame($expected_instance_id, $restored_item->get_instance_id());
+        $this->assertSame($expected_total, $restored_item->get_total());
+    }
+
+    /**
+     * GIVEN a resumed order whose rebuild already restored a shipping line item itself
+     * WHEN woocommerce_checkout_order_processed fires
+     * THEN the restorer adds nothing and the order's shipping item count is unchanged
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_adds_nothing_when_the_rebuilt_order_already_has_shipping_items(): void
+    {
+        $this->bootstrapModule();
+
+        $zone = $this->create_shipping_zone_with_flat_rate('9.99');
+        $this->fill_cart_and_calculate($zone['rate_key']);
+
+        $order_id = $this->create_initial_order();
+
+        $this->resume_with_existing_rate($order_id);
+
+        $pre_hook_order = wc_get_order($order_id);
+        $pre_hook_items = $pre_hook_order->get_shipping_methods();
+        $this->assertCount(
+            1,
+            $pre_hook_items,
+            'Precondition: core must have restored the shipping line itself since the chosen rate still resolves.'
+        );
+        $pre_hook_item_id = current($pre_hook_items)->get_id();
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        $post_hook_order = wc_get_order($order_id);
+        $post_hook_items = $post_hook_order->get_shipping_methods();
+
+        $this->assertCount(1, $post_hook_items, 'The restorer must not add a duplicate shipping line.');
+        $this->assertSame($pre_hook_item_id, current($post_hook_items)->get_id());
+    }
+
+    /**
+     * GIVEN a resumed order whose rebuilt shipping total is 0.00 and has no shipping line items
+     * WHEN woocommerce_checkout_order_processed fires
+     * THEN the restorer adds nothing
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_adds_nothing_when_the_rebuilt_shipping_total_is_zero(): void
+    {
+        $this->bootstrapModule();
+
+        $zone = $this->create_shipping_zone_with_flat_rate('0.00');
+        $this->fill_cart_and_calculate($zone['rate_key']);
+
+        $order_id = $this->create_initial_order();
+
+        $this->resume_with_missing_rate($order_id);
+
+        $pre_hook_order = wc_get_order($order_id);
+        $this->assertCount(
+            0,
+            $pre_hook_order->get_shipping_methods(),
+            'Precondition: rebuild must leave no shipping line items.'
+        );
+        $this->assertSame(
+            '0.00',
+            wc_format_decimal($pre_hook_order->get_shipping_total(), 2),
+            'Precondition: the rebuilt shipping total must be zero.'
+        );
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        $post_hook_order = wc_get_order($order_id);
+        $this->assertCount(0, $post_hook_order->get_shipping_methods());
+    }
+
+    /**
+     * GIVEN an order that was created without woocommerce_resume_order ever firing for it
+     * WHEN woocommerce_checkout_order_processed fires
+     * THEN the restorer holds no snapshot for that order and leaves it untouched
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_takes_no_action_when_no_resume_order_fired(): void
+    {
+        $this->bootstrapModule();
+
+        $order = new WC_Order();
+        $order->set_customer_id($this->customer_id);
+        $order->set_status('pending');
+        $order->set_shipping_total('12.34');
+        $order->save();
+
+        $order_id = $order->get_id();
+        $this->created_order_ids[] = $order_id;
+
+        $this->assertCount(
+            0,
+            wc_get_order($order_id)->get_shipping_methods(),
+            'Precondition: the synthetic order must have no shipping line items.'
+        );
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        $untouched_order = wc_get_order($order_id);
+        $this->assertCount(0, $untouched_order->get_shipping_methods());
+        $this->assertSame('12.34', $untouched_order->get_shipping_total());
+    }
+
+    /**
+     * GIVEN the restore step fails while it inspects/rebuilds the order's shipping items
+     * WHEN woocommerce_checkout_order_processed fires
+     * THEN the exception is caught, an error naming the order id is logged, and execution
+     *      continues past the do_action so process_payment can still run
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_logs_and_swallows_a_failure_while_persisting_the_restored_item(): void
+    {
+        $captured_order_id = 0;
+
+        $logger = Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
+        $logger->shouldReceive('error')
+            ->atLeast()->once()
+            ->withArgs(static function (...$args) use (&$captured_order_id) {
+                $message = $args[0] ?? '';
+                return is_string($message)
+                    && $captured_order_id > 0
+                    && false !== strpos($message, (string) $captured_order_id);
+            });
+
+        // The logger is replaced as an EXTENSION, not as a service: ppcp-wc-gateway's own
+        // extensions.php rebuilds 'woocommerce.logger.woocommerce' from scratch and discards
+        // whatever the service returned, so a plain service override never reaches the code
+        // under test. This module is registered last, so its extension wins.
+        $this->bootstrapModule([], [
+            'woocommerce.logger.woocommerce' => function () use ($logger) {
+                return $logger;
+            },
+        ]);
+
+        $zone = $this->create_shipping_zone_with_flat_rate('18.45');
+        $this->fill_cart_and_calculate($zone['rate_key']);
+
+        $order_id = $this->create_initial_order();
+        $captured_order_id = $order_id;
+
+        $this->resume_with_missing_rate($order_id);
+
+        // Real WC_Order::save() swallows its own exceptions internally and never
+        // propagates them to the caller, so the failure is injected via the real
+        // 'woocommerce_order_get_items' filter (fired from WC_Abstract_Order::get_items(),
+        // which get_shipping_methods() calls as part of the restorer's own guard check).
+        $this->throwing_filter = static function ($items, $order_arg, $types) use ($order_id) {
+            if ((int) $order_arg->get_id() === $order_id && in_array('shipping', (array) $types, true)) {
+                throw new \RuntimeException('Simulated failure while restoring the shipping item.');
+            }
+            return $items;
+        };
+        add_filter('woocommerce_order_get_items', $this->throwing_filter, 10, 3);
+
+        $flag_reached = false;
+        $this->flag_callback = static function () use (&$flag_reached) {
+            $flag_reached = true;
+        };
+        add_action('woocommerce_checkout_order_processed', $this->flag_callback, PHP_INT_MAX, 0);
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        remove_filter('woocommerce_order_get_items', $this->throwing_filter, 10);
+        $this->throwing_filter = null;
+
+        $this->assertTrue(
+            $flag_reached,
+            'Execution must continue past woocommerce_checkout_order_processed despite the persistence failure.'
+        );
+
+        $post_hook_order = wc_get_order($order_id);
+        $this->assertCount(
+            0,
+            $post_hook_order->get_shipping_methods(),
+            'No shipping line should persist since the restore attempt failed.'
+        );
+    }
+
+    /**
+     * GIVEN a resumed order that the restorer successfully repairs
+     * WHEN the restoration completes
+     * THEN get_shipping_total() and get_total() are byte-identical to their pre-restoration
+     *      values, so the amount sent to PayPal is unaffected
+     *
+     * @test
+     * @group integration
+     * @group checkout
+     * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\ResumedOrderShippingRestorer
+     */
+    public function it_leaves_shipping_total_and_order_total_byte_identical_after_restoring(): void
+    {
+        $this->bootstrapModule();
+
+        $zone = $this->create_shipping_zone_with_flat_rate('18.45');
+        $this->fill_cart_and_calculate($zone['rate_key']);
+
+        $order_id = $this->create_initial_order();
+
+        $this->resume_with_missing_rate($order_id);
+
+        $pre_restore_order = wc_get_order($order_id);
+        $this->assertCount(
+            0,
+            $pre_restore_order->get_shipping_methods(),
+            'Precondition: rebuild must leave no shipping line items.'
+        );
+
+        // Pin the order total to a value that recalculating from the line items could not
+        // reproduce. Without this the assertion below is satisfied by coincidence: a restorer
+        // that wrongly called calculate_totals() would arrive at the same numbers anyway, so
+        // the test could not tell the two apart. The shipping total is left as the real
+        // rebuilt value, so only the grand total carries the sentinel.
+        $pre_restore_order->set_total('999.99');
+        $pre_restore_order->save();
+
+        $pre_restore_order = wc_get_order($order_id);
+        $expected_shipping_total = $pre_restore_order->get_shipping_total();
+        $expected_total = $pre_restore_order->get_total();
+        $this->assertSame(
+            '999.99',
+            $expected_total,
+            'Precondition: the sentinel total must have persisted.'
+        );
+
+        do_action('woocommerce_checkout_order_processed', $order_id, $this->posted_data(), wc_get_order($order_id));
+
+        $restored_order = wc_get_order($order_id);
+        $this->assertCount(
+            1,
+            $restored_order->get_shipping_methods(),
+            'Precondition for a meaningful comparison: restoration must have actually happened.'
+        );
+
+        $this->assertSame($expected_shipping_total, $restored_order->get_shipping_total());
+        $this->assertSame(
+            $expected_total,
+            $restored_order->get_total(),
+            'The restorer must not recalculate the order total.'
+        );
+    }
+
+    /**
+     * Creates a real WC_Shipping_Zone with a flat_rate shipping method instance.
+     *
+     * @return array{zone_id: int, instance_id: int, rate_key: string}
+     */
+    private function create_shipping_zone_with_flat_rate(string $cost, string $tax_status = 'none'): array
+    {
+        $zone = new WC_Shipping_Zone();
+        $zone->set_zone_name('PCP Test Zone ' . uniqid());
+        $zone->set_zone_order(0);
+        $zone->save();
+        $zone->set_locations([['code' => 'US', 'type' => 'country']]);
+        $zone->save();
+
+        $instance_id = $zone->add_shipping_method('flat_rate');
+
+        update_option(
+            'woocommerce_flat_rate_' . $instance_id . '_settings',
+            [
+                'title' => 'Flat rate',
+                'tax_status' => $tax_status,
+                'cost' => $cost,
+            ]
+        );
+
+        WC_Cache_Helper::get_transient_version('shipping', true);
+
+        $this->created_zones[] = [
+            'zone_id' => $zone->get_id(),
+            'instance_id' => $instance_id,
+        ];
+
+        return [
+            'zone_id' => $zone->get_id(),
+            'instance_id' => $instance_id,
+            'rate_key' => 'flat_rate:' . $instance_id,
+        ];
+    }
+
+    /**
+     * Adds the "simple" preset product to the cart and calculates totals with the
+     * given rate chosen, so the cart caches a non-zero shipping total.
+     */
+    private function fill_cart_and_calculate(string $rate_key): void
+    {
+        $this->cart()->empty_cart();
+
+        $product_id = wc_get_product_id_by_sku('DUMMY_SIMPLE_SKU_01');
+        $this->cart()->add_to_cart($product_id, 1);
+
+        $this->customer()->set_shipping_country('US');
+        $this->customer()->set_shipping_state('CA');
+        $this->customer()->set_shipping_city('Los Angeles');
+        $this->customer()->set_shipping_postcode('90001');
+        $this->customer()->set_billing_country('US');
+        $this->customer()->set_billing_state('CA');
+        $this->customer()->set_billing_city('Los Angeles');
+        $this->customer()->set_billing_postcode('90001');
+        $this->customer()->save();
+
+        WC()->session->set('chosen_shipping_methods', [$rate_key]);
+
+        $this->cart()->calculate_totals();
+    }
+
+    /**
+     * Enables tax calculation and inserts a real tax rate that also applies to shipping.
+     */
+    private function enable_taxes_for_country(string $country): void
+    {
+        update_option('woocommerce_calc_taxes', 'yes');
+        update_option('woocommerce_tax_based_on', 'shipping');
+        update_option('woocommerce_prices_include_tax', 'no');
+
+        // tax_rate_compound and tax_rate_shipping are integer columns. WC_Tax::prepare_tax_rate()
+        // only reformats keys that have a matching format_<key>() method, and there is no
+        // format_tax_rate_shipping()/format_tax_rate_compound() in WC_Tax, so a string like
+        // 'yes' goes straight into $wpdb->insert() and MySQL silently coerces it to 0. Passing
+        // real integers here is required for the shipping flag to actually persist as on.
+        $this->tax_rate_ids[] = WC_Tax::_insert_tax_rate([
+            'tax_rate_country' => $country,
+            'tax_rate_state' => '',
+            'tax_rate' => '10.0000',
+            'tax_rate_name' => 'PCP Test Tax',
+            'tax_rate_priority' => '1',
+            'tax_rate_compound' => 0,
+            'tax_rate_shipping' => 1,
+            'tax_rate_order' => '1',
+            'tax_rate_class' => '',
+        ]);
+    }
+
+    /**
+     * The $data array handed to WC_Checkout::create_order(), modelled on
+     * WC_Checkout::get_posted_data().
+     *
+     * @return array<string, mixed>
+     */
+    private function posted_data(): array
+    {
+        return [
+            'terms' => 1,
+            'payment_method' => 'ppcp-credit-card-gateway',
+            'order_comments' => '',
+            'shipping_method' => '',
+            'billing_first_name' => 'John',
+            'billing_last_name' => 'Doe',
+            'billing_address_1' => '123 Main St',
+            'billing_city' => 'Los Angeles',
+            'billing_state' => 'CA',
+            'billing_postcode' => '90001',
+            'billing_country' => 'US',
+            'billing_email' => 'customer1@example.com',
+            'billing_phone' => '1234567890',
+            'shipping_first_name' => 'John',
+            'shipping_last_name' => 'Doe',
+            'shipping_address_1' => '123 Main St',
+            'shipping_city' => 'Los Angeles',
+            'shipping_state' => 'CA',
+            'shipping_postcode' => '90001',
+            'shipping_country' => 'US',
+        ];
+    }
+
+    /**
+     * Creates the first-pass order via the real checkout create_order() flow.
+     */
+    private function create_initial_order(): int
+    {
+        $result = WC()->checkout()->create_order($this->posted_data());
+
+        if (is_wp_error($result)) {
+            throw new \RuntimeException(
+                'create_order() failed on the first pass: ' . $result->get_error_message()
+            );
+        }
+
+        $order_id = (int) $result;
+        $this->created_order_ids[] = $order_id;
+
+        return $order_id;
+    }
+
+    /**
+     * Marks the order failed and awaiting payment, then resumes checkout with a
+     * chosen shipping method key that resolves to no rate in the recalculated
+     * packages, without recalculating the cart. This reproduces the reported bug:
+     * the cart's cached shipping total survives, but no shipping line item does.
+     */
+    private function resume_with_missing_rate(int $order_id): void
+    {
+        $order = wc_get_order($order_id);
+        $order->set_status('failed');
+        $order->save();
+
+        WC()->session->set('order_awaiting_payment', $order_id);
+        WC()->session->set('chosen_shipping_methods', ['flat_rate:999999']);
+
+        $result = WC()->checkout()->create_order($this->posted_data());
+
+        if (is_wp_error($result)) {
+            throw new \RuntimeException(
+                'create_order() failed while resuming: ' . $result->get_error_message()
+            );
+        }
+    }
+
+    /**
+     * Marks the order failed and awaiting payment, then resumes checkout leaving
+     * the previously chosen (still valid) shipping method key untouched, so core
+     * restores the shipping line item itself.
+     */
+    private function resume_with_existing_rate(int $order_id): void
+    {
+        $order = wc_get_order($order_id);
+        $order->set_status('failed');
+        $order->save();
+
+        WC()->session->set('order_awaiting_payment', $order_id);
+
+        $result = WC()->checkout()->create_order($this->posted_data());
+
+        if (is_wp_error($result)) {
+            throw new \RuntimeException(
+                'create_order() failed while resuming: ' . $result->get_error_message()
+            );
+        }
+    }
+}

--- a/tests/integration/PHPUnit/IntegrationMockedTestCase.php
+++ b/tests/integration/PHPUnit/IntegrationMockedTestCase.php
@@ -22,6 +22,7 @@ use WooCommerce\PayPalCommerce\Tests\Integration\Traits\CleansTestData;
 use WooCommerce\PayPalCommerce\Tests\Integration\Traits\CreateTestOrders;
 use WooCommerce\PayPalCommerce\Tests\Integration\Traits\CreateTestProducts;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
+use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -47,10 +48,23 @@ class IntegrationMockedTestCase extends TestCase
     }
 
     /**
-     * @param array<string, callable> $overriddenServices
+     * Boots the plugin with the given services and/or extensions replaced.
+     *
+     * Overriding a service id is not always enough: a service that another module extends
+     * via `extensions.php` is rebuilt by that extension, which may discard the override
+     * entirely (`woocommerce.logger.woocommerce` is one such service). Registering the
+     * replacement as an extension instead wins, because this module is added last and its
+     * extensions therefore run last.
+     *
+     * @param array<string, callable> $overriddenServices Service id => factory.
+     * @param array<string, callable> $overriddenExtensions Service id => extender, called
+     *                                                      with ($previous, $container).
      * @return ContainerInterface
      */
-    protected function bootstrapModule(array $overriddenServices = []): ContainerInterface
+    protected function bootstrapModule(
+        array $overriddenServices = [],
+        array $overriddenExtensions = []
+    ): ContainerInterface
     {
         $overriddenServices = array_merge([
             'http.redirector' => function () {
@@ -59,17 +73,25 @@ class IntegrationMockedTestCase extends TestCase
         ], $overriddenServices);
 
 
-        $module = new class ($overriddenServices) implements ServiceModule, ExecutableModule {
+        $module = new class ($overriddenServices, $overriddenExtensions) implements ServiceModule, ExtendingModule, ExecutableModule {
             use ModuleClassNameIdTrait;
 
-            public function __construct(array $services)
+            private $extensions;
+
+            public function __construct(array $services, array $extensions = [])
             {
                 $this->services = $services;
+                $this->extensions = $extensions;
             }
 
             public function services(): array
             {
                 return $this->services;
+            }
+
+            public function extensions(): array
+            {
+                return $this->extensions;
             }
 
             public function run(ContainerInterface $c): bool

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -13,8 +13,24 @@ PHPUnit tests that runs against a working WP site. Useful to test modules (ex. c
 - Run all the tests: `ddev npm run integration-tests`
 - Run a single test: `ddev npm run tdd:integration testSomeTestName` or `ddev npm run tdd:integration SomeTestClassName`
 
+> **`setup.php` must have run first.** Only `npm run integration-tests` runs it. It sets the
+> tax-related WooCommerce options and imports `data/tax_rates.csv`, which several tests depend
+> on. Invoking PHPUnit directly — `tdd:integration`, or a bare `phpunit -c
+> tests/integration/phpunit.xml.dist` — skips it, and against an unseeded (or drifted) database
+> that produces failures unrelated to your change: `PurchaseUnitTest` alone reports 11, with
+> wrong tax and discount totals. If a run fails that way, re-seed and try again:
+>
+> ```
+> ddev exec php tests/integration/PHPUnit/setup.php
+> ```
+>
+> Tests that mutate global WooCommerce options or the shipping/tax caches must restore them in
+> `tearDown()`, otherwise they corrupt this seeded state for every test that runs after them in
+> the same process.
+
 ### How to debug tests
 
 - Run `ddev xdebug enable`
 - Setup your IDE to listen to new DEBUG connections
 - Run tests adding --debug flag: `ddev exec phpunit -c tests/integration/phpunit.xml.dist --debug`
+  (this bypasses `setup.php` — see the note above if you get unexpected tax-related failures)


### PR DESCRIPTION
## 🐛 What and why

When an Advanced Card Processing payment is declined by the processor, the WooCommerce order is marked `failed` but kept, and the session still points at it via `order_awaiting_payment`. On retry, WooCommerce resumes that same order: it wipes the line items and rebuilds them from the cart. The rebuild always restores the shipping *total*, but restores the shipping *line item* only when the previously chosen shipping method still resolves to a rate in the recalculated packages.

When that lookup misses, the order ends up with a non-zero shipping total and **no shipping line item at all**. The buyer is charged the full amount including shipping, and every debug log line shows the correct shipping breakdown — so nothing looks wrong — but the merchant is left with an order they cannot fulfil, invoice or report shipping against. A merchant log for order 22028 confirms both attempts patched the same `custom_id`, proving the order was resumed rather than recreated.

## ⚙️ How it works now

`ResumedOrderShippingRestorer::snapshot()` runs on `woocommerce_resume_order`, which WooCommerce fires immediately before `WC_Order::remove_order_items()` — while the shipping items still exist. It records `method_title`, `method_id`, `instance_id`, `total`, `total_tax`, `taxes`, `tax_status` and item meta as plain data, keyed by order ID in a private property that lives for the request only.

`ResumedOrderShippingRestorer::restore()` runs on `woocommerce_checkout_order_processed`, after the rebuild has been saved and before the gateway's `process_payment()`. It re-fetches the order and acts **only** when `get_shipping_total()` is non-zero and `get_shipping_methods()` is empty — the exact divergence — then re-adds fresh `WC_Order_Item_Shipping` objects and calls `save()`. No total is recalculated, so the amount `AmountFactory::from_wc_order()` sends to PayPal is untouched.

The whole body of both methods sits inside a `try`/`catch ( Throwable )`. A failure logs an error naming the order ID and the unbacked shipping total, then returns — leaving exactly today's behaviour. There is no branch that can reject, block or fail a payment.

## 🔍 What to verify in review

### Covered by unit tests

All seven acceptance criteria are covered by `ResumedOrderShippingRestorerTest` (7 tests, 35 assertions, green):

- ✅ All seven shipping-item fields are captured before `remove_order_items()` deletes them, and reproduced exactly on the restored item — including taxes on a taxable rate.
- ✅ A resumed order left with an 18.45 shipping total and zero shipping methods gets exactly one persisted `WC_Order_Item_Shipping` matching the original method title, method ID, instance ID and total.
- ✅ A resumed order whose rebuild already restored the line item is left alone — same item count, same item ID, no duplicate.
- ✅ A resumed order with a 0.00 shipping total and no shipping items gets nothing added.
- ✅ A fresh checkout with no `woocommerce_resume_order` leaves the order untouched, shipping total included.
- ✅ A throw during the restore is caught and logged with the order ID, and later callbacks on `woocommerce_checkout_order_processed` still run, so `process_payment()` is reached.
- ✅ `get_shipping_total()` and `get_total()` are byte-identical strings before and after a successful restoration.

Note that three of these (already-has-items, zero-total, no-resume) also pass without the fix. They are regression guards against an over-reaching implementation, not red-by-design proofs.

### Mutation-tested

The suite was checked against **13 hand-written mutants** of `ResumedOrderShippingRestorer` — one per behaviour the criteria claim. All 13 are killed: dropping either guard, capturing an empty snapshot, skipping `save()`, losing any one restored field, narrowing the `catch`, silencing the log, dropping the order ID from the message, restoring without a snapshot, and recalculating totals.

One mutant initially survived and is worth a reviewer's attention. Inserting `calculate_totals()` before `save()` did **not** fail the byte-identical test, because recalculation happened to arrive at the same numbers — the assertion was satisfied by coincidence rather than by the invariant. That test now pins the order total to a sentinel value recalculation cannot reproduce, so any recalculation inside the restorer is detectable. The shipping total is still compared against its real rebuilt value.

### Not covered by unit tests

- ❌ End-to-end behaviour against a real processor decline (`FraudProcessorResponse` 1300/1330/1335) — the tests reproduce the resulting order state via the real checkout resume path, but do not drive an actual declined capture.
- ❌ Multisite. The restorer reads and writes only order data through `wc_get_order()` and `WC_Order::save()`, so it carries no site-scoped option or path assumptions, but it was not tested under multisite.

## 🔗 Contracts introduced or changed

### Constructor signature changed

None. `ResumedOrderShippingRestorer` is new: `__construct( LoggerInterface $logger )`, wired from `woocommerce.logger.woocommerce`.

### New hook consumers

Two callbacks are attached at priority 10, to WooCommerce core hooks (`woocommerce_resume_order`, `woocommerce_checkout_order_processed`) — not to plugin hooks. No `ppcp_*` or `woocommerce_paypal_payments_*` hook is added, removed, renamed or reordered, so no third-party callback contract changes.

### Test base class signature changed

`IntegrationMockedTestCase::bootstrapModule()` gained an optional second parameter, `array $overriddenExtensions = []`. Existing callers are unaffected.

This was necessary, and is worth a reviewer's attention: **overriding a service ID in `bootstrapModule()` does not reliably replace that service**. `modules/ppcp-wc-gateway/extensions.php` extends `woocommerce.logger.woocommerce` with an extender that ignores `$previous` and rebuilds the logger from scratch, so a service-level override is silently discarded. The failure-path test needs a mock logger, so the override is now registered as an extension — the test module is added last, so its extension runs last and wins. Any other test that assumed a service override survives module extensions has the same latent problem.
