### PR TITLE
fix(wc-gateway): ignore captures that never took money when reading the transaction id

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/TransactionIdHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/TransactionIdHandlingTrait.php
@@ -12,6 +12,9 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 
 /**
@@ -78,16 +81,38 @@ trait TransactionIdHandlingTrait {
 			return null;
 		}
 
-		$capture = $payments->captures()[0] ?? null;
-		if ( $capture ) {
+		foreach ( $payments->captures() as $capture ) {
+			if ( $this->is_dead_capture( $capture ) ) {
+				continue;
+			}
+
 			return $capture->id();
 		}
 
-		$authorization = $payments->authorizations()[0] ?? null;
-		if ( $authorization ) {
+		foreach ( $payments->authorizations() as $authorization ) {
+			if ( $authorization->status()->is( AuthorizationStatus::DENIED ) ) {
+				continue;
+			}
+
 			return $authorization->id();
 		}
 
 		return null;
+	}
+
+	/**
+	 * Whether a capture never took money and so is not this order's transaction.
+	 *
+	 * Storing one as the WooCommerce transaction id is not merely inaccurate: an order
+	 * carrying that meta is treated as already paid, so every later attempt on it -
+	 * a Subscriptions retry, or the shopper's own order-pay page - is skipped, and the
+	 * order cannot be paid again without the meta being removed by hand.
+	 *
+	 * PENDING is deliberately absent: it may yet settle, so its id is the reference to
+	 * keep. So are the refunded states, which describe money that did move.
+	 */
+	private function is_dead_capture( Capture $capture ): bool {
+		return $capture->status()->is( CaptureStatus::DECLINED )
+			|| $capture->status()->is( CaptureStatus::FAILED );
 	}
 }

--- a/tests/PHPUnit/WcGateway/Processor/TransactionIdHandlingTraitTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/TransactionIdHandlingTraitTest.php
@@ -1,0 +1,234 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class TransactionIdHandlingTraitTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * @var object
+	 */
+	private $fixture;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->fixture = new class() {
+			use TransactionIdHandlingTrait;
+		};
+	}
+
+	/**
+	 * GIVEN a PayPal order whose purchase unit has a single completed capture
+	 * WHEN the transaction id is looked up
+	 * THEN the completed capture's id is returned, the ordinary path
+	 */
+	public function testCompletedCaptureReturnsItsId(): void
+	{
+		$order = $this->orderWithCaptures(
+			array( $this->capture( 'capture-1', CaptureStatus::COMPLETED ) )
+		);
+
+		$this->assertSame( 'capture-1', $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN a renewal on a vaulted card whose only capture was declined
+	 * WHEN the transaction id is looked up
+	 * THEN null is returned instead of the declined capture's id, so the order is not
+	 *      wrongly treated as already paid
+	 */
+	public function testDeclinedCaptureReturnsNull(): void
+	{
+		$order = $this->orderWithCaptures(
+			array( $this->capture( 'capture-declined', CaptureStatus::DECLINED ) )
+		);
+
+		$this->assertNull( $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN a capture that failed to process
+	 * WHEN the transaction id is looked up
+	 * THEN null is returned instead of the failed capture's id
+	 */
+	public function testFailedCaptureReturnsNull(): void
+	{
+		$order = $this->orderWithCaptures(
+			array( $this->capture( 'capture-failed', CaptureStatus::FAILED ) )
+		);
+
+		$this->assertNull( $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN a capture whose status still describes money that moved or may yet settle
+	 * WHEN the transaction id is looked up
+	 * THEN its id is returned, since it is deliberately not treated as dead
+	 *
+	 * @dataProvider live_capture_status_provider
+	 */
+	public function testLiveCaptureStatusReturnsItsId( string $status ): void
+	{
+		$order = $this->orderWithCaptures(
+			array( $this->capture( 'capture-live', $status ) )
+		);
+
+		$this->assertSame( 'capture-live', $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	public function live_capture_status_provider(): array
+	{
+		return array(
+			'completed'          => array( CaptureStatus::COMPLETED ),
+			'pending may settle' => array( CaptureStatus::PENDING ),
+			'refunded'           => array( CaptureStatus::REFUNDED ),
+			'partially refunded' => array( CaptureStatus::PARTIALLY_REFUNDED ),
+		);
+	}
+
+	/**
+	 * GIVEN a purchase unit with a declined capture followed by a completed one
+	 * WHEN the transaction id is looked up
+	 * THEN the completed capture's id is returned, proving the whole list is scanned
+	 *      rather than only the first element
+	 */
+	public function testDeclinedCaptureFollowedByCompletedReturnsCompletedId(): void
+	{
+		$order = $this->orderWithCaptures(
+			array(
+				$this->capture( 'capture-declined', CaptureStatus::DECLINED ),
+				$this->capture( 'capture-completed', CaptureStatus::COMPLETED ),
+			)
+		);
+
+		$this->assertSame( 'capture-completed', $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN no usable capture but a still-open authorization
+	 * WHEN the transaction id is looked up
+	 * THEN the authorization's id is returned as a fallback
+	 */
+	public function testDeclinedCaptureFallsBackToUsableAuthorization(): void
+	{
+		$order = $this->orderWithCapturesAndAuthorizations(
+			array( $this->capture( 'capture-declined', CaptureStatus::DECLINED ) ),
+			array( $this->authorization( 'auth-created', AuthorizationStatus::CREATED ) )
+		);
+
+		$this->assertSame( 'auth-created', $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN neither a usable capture nor a usable authorization is available
+	 * WHEN the transaction id is looked up
+	 * THEN null is returned, so the fall-through to authorizations does not reintroduce
+	 *      the same bug
+	 */
+	public function testDeclinedCaptureAndDeniedAuthorizationReturnsNull(): void
+	{
+		$order = $this->orderWithCapturesAndAuthorizations(
+			array( $this->capture( 'capture-declined', CaptureStatus::DECLINED ) ),
+			array( $this->authorization( 'auth-denied', AuthorizationStatus::DENIED ) )
+		);
+
+		$this->assertNull( $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN a PayPal order with no purchase units at all
+	 * WHEN the transaction id is looked up
+	 * THEN null is returned
+	 */
+	public function testNoPurchaseUnitsReturnsNull(): void
+	{
+		$order = Mockery::mock( Order::class );
+		$order->shouldReceive( 'purchase_units' )->andReturn( array() );
+
+		$this->assertNull( $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * GIVEN a purchase unit that has no payments information at all
+	 * WHEN the transaction id is looked up
+	 * THEN null is returned
+	 */
+	public function testNoPaymentsOnPurchaseUnitReturnsNull(): void
+	{
+		$purchase_unit = Mockery::mock( PurchaseUnit::class );
+		$purchase_unit->shouldReceive( 'payments' )->andReturnNull();
+
+		$order = Mockery::mock( Order::class );
+		$order->shouldReceive( 'purchase_units' )->andReturn( array( $purchase_unit ) );
+
+		$this->assertNull( $this->fixture->get_paypal_order_transaction_id( $order ) );
+	}
+
+	/**
+	 * @param Capture[] $captures The captures the order's purchase unit should contain.
+	 * @return Order&Mockery\MockInterface
+	 */
+	private function orderWithCaptures( array $captures )
+	{
+		return $this->orderWithCapturesAndAuthorizations( $captures, array() );
+	}
+
+	/**
+	 * @param Capture[]       $captures       The captures the order's purchase unit should contain.
+	 * @param Authorization[] $authorizations The authorizations the order's purchase unit should contain.
+	 * @return Order&Mockery\MockInterface
+	 */
+	private function orderWithCapturesAndAuthorizations( array $captures, array $authorizations )
+	{
+		$payments = new Payments( $authorizations, $captures );
+
+		$purchase_unit = Mockery::mock( PurchaseUnit::class );
+		$purchase_unit->shouldReceive( 'payments' )->andReturn( $payments );
+
+		$order = Mockery::mock( Order::class );
+		$order->shouldReceive( 'purchase_units' )->andReturn( array( $purchase_unit ) );
+
+		return $order;
+	}
+
+	private function capture( string $id, string $status ): Capture
+	{
+		return new Capture(
+			$id,
+			new CaptureStatus( $status ),
+			new Amount( new Money( 10.00, 'USD' ) ),
+			true,
+			'',
+			'',
+			'',
+			null,
+			null
+		);
+	}
+
+	private function authorization( string $id, string $status ): Authorization
+	{
+		return new Authorization(
+			$id,
+			new AuthorizationStatus( $status ),
+			null
+		);
+	}
+}


### PR DESCRIPTION
### Description

`get_paypal_order_transaction_id()` returned the first capture's id without looking at its status.

A vaulted-card subscription renewal is processed during order creation, so a decline comes back as an order whose first capture is already `DECLINED`. `RenewalHandler::handle_paypal_order()` stores that id as the WooCommerce transaction id at `:491-499`, and only then handles the status at `:501` and marks the order failed.

An order carrying that meta is then treated as already paid. `OrderProcessor::verify_order_can_be_processed()` refuses any order with a transaction id, whatever its status:

```php
if ( $wc_order->get_transaction_id() ) {
    $this->logger->info( 'Order #%d already has transaction ID "%s", skipping payment processing.' );
    return false;
}
```

So Subscriptions' automatic retries and the shopper's own order-pay page are both skipped, and the failed renewal cannot be paid again without the meta being deleted by hand.

The trait now scans for the first capture that is not `DECLINED` or `FAILED`. Measured against the exact PayPal order shape a declined renewal returns:

| Captures on the order | Before | After |
|---|---|---|
| `DECLINED` | `6VV364076U2109212` — stored, order blocked | `null`, order stays payable |
| `FAILED` | id stored | `null` |
| `COMPLETED` | id stored | unchanged |
| `PENDING` | id stored | unchanged, deliberately |
| `DECLINED` then `COMPLETED` | the **declined** id | the completed id |

That last row is a second, quieter bug the same change fixes: a declined capture used to mask a successful one on the same order.

`PENDING` is deliberately still returned, since it may yet settle and its id is the reference to keep; so are the refunded states, which describe money that did move. Denied authorizations are now skipped for the same reason as declined captures — with dead captures passed over, the authorization branch became reachable where it previously was not.

Fixing the shared trait covers all ten callers, including the renewal handler, the card gateway's vaulted-card finalization, the PayPal gateway and the four order-tracking integrations.

**Why only half the reported proposal.** The report also suggested loosening `verify_order_can_be_processed()` so a stale transaction id cannot block an order that still returns `needs_payment()`. That is not included: it removes the guard against double-processing, and in a race where a capture succeeded but the order status has not caught up, the order reads as needing payment and could be charged twice. This change stops the bad data being written; that one would make a safety check tolerate bad data. Worth revisiting with a narrower condition if the team wants belt-and-braces.

**What was not executed.** The declined-renewal flow itself. Staging a real decline needs a sandbox card that declines on a vaulted merchant-initiated transaction, which is a different path from an interactive decline. The unit tests and the before/after table above pin the decision precisely, but `RenewalHandler::handle_paypal_order()` was verified by reading rather than running. The reporter observed the full flow on a live store (order `#251686`), including the log line quoted above.

No signature or hook changes. Not tested under multisite.

### Steps to Test

The behaviour can be checked directly, without staging a decline:

1. Build a PayPal `Order` whose purchase unit has `payments.captures[0]` with status `DECLINED`, and pass it to `get_paypal_order_transaction_id()`. It should return `null`; on `dev/develop` it returns the declined capture's id.
2. Repeat with `COMPLETED`, `PENDING`, `REFUNDED` and `PARTIALLY_REFUNDED` — each should still return its id.
3. Repeat with a `DECLINED` capture followed by a `COMPLETED` one — it should return the completed id.

End to end, if a card that declines on renewal is available:

4. Create a subscription paid by a vaulted card, make the renewal decline, and trigger the renewal.
5. Confirm the renewal order is `failed` and has **no** `_transaction_id`.
6. Retry through the customer's order-pay page. The attempt should proceed, rather than logging `Order #… already has transaction ID "…", skipping payment processing.`
7. Regression: a successful renewal still records its capture id as the transaction id.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix: A declined subscription renewal no longer records the declined transaction against the order, which previously blocked every later retry and the customer's own payment page.
