### PR TITLE
Hide PayPal gateway for free trial cart when no saved PayPal account

### DIFF
--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -42,6 +42,8 @@ return array(
 			$container->get( 'wcgateway.place-order-button-text' ),
 			$container->get( 'wcgateway.place-order-button-description' ),
 			$container->get( 'wcgateway.all-funding-sources' ),
+			$container->get( 'wc-subscriptions.free-trial-subscription-helper' ),
+			$container->get( 'wc-payment-tokens.wc-payment-tokens' ),
 		);
 	},
 	'blocks.advanced-card-method'          => static function ( ContainerInterface $container ): AdvancedCardPaymentMethod {

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -20,6 +20,8 @@ use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcPaymentTokens\WooCommercePaymentTokens;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
@@ -126,6 +128,9 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 */
 	private $all_funding_sources;
 
+	private FreeTrialSubscriptionHelper $free_trial_helper;
+	private WooCommercePaymentTokens $wc_payment_tokens;
+
 	/**
 	 * @param AssetGetter                   $asset_getter
 	 * @param string                        $version    The assets version.
@@ -158,7 +163,9 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		bool $use_place_order,
 		string $place_order_button_text,
 		string $place_order_button_description,
-		array $all_funding_sources
+		array $all_funding_sources,
+		FreeTrialSubscriptionHelper $free_trial_helper,
+		WooCommercePaymentTokens $wc_payment_tokens
 	) {
 		$this->name                           = PayPalGateway::ID;
 		$this->asset_getter                   = $asset_getter;
@@ -176,6 +183,8 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		$this->place_order_button_text        = $place_order_button_text;
 		$this->place_order_button_description = $place_order_button_description;
 		$this->all_funding_sources            = $all_funding_sources;
+		$this->free_trial_helper              = $free_trial_helper;
+		$this->wc_payment_tokens              = $wc_payment_tokens;
 	}
 
 	/**
@@ -243,11 +252,20 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		//
 		// The vaulting capability comes from the settings, not $script_data: under SDK v6
 		// the smart button is a DisabledSmartButton whose script_data() is empty.
+		//
+		// A free-trial (vaulting) cart needs an already-saved PayPal account for the
+		// standard "Place order" flow; without one it fails with "No saved PayPal account."
+		// Hide the gateway so the customer uses the express button (which vaults the
+		// account) instead. The token lookup is short-circuited to free-trial carts only.
 		$place_order_enabled = ( $this->use_place_order || $this->add_place_order_method )
 			&& (
 				! $this->subscription_helper->cart_contains_subscription()
 				|| $this->plugin_settings->can_save_vault_token()
 				|| $this->subscription_helper->accept_manual_renewals()
+			)
+			&& (
+				! $this->free_trial_helper->is_free_trial_cart()
+				|| $this->customer_has_saved_paypal()
 			);
 		$cart                = WC()->cart;
 
@@ -282,6 +300,16 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 			'scriptData'                  => $script_data,
 			'needShipping'                => $cart && $cart->needs_shipping(),
 		);
+	}
+
+	/**
+	 * Whether the current customer has a saved PayPal or Venmo payment token.
+	 */
+	private function customer_has_saved_paypal(): bool {
+		$user_id = get_current_user_id();
+
+		return $user_id > 0
+			&& $this->wc_payment_tokens->has_paypal_or_venmo_token( $user_id );
 	}
 
 	/**

--- a/modules/ppcp-wc-payment-tokens/src/WooCommercePaymentTokens.php
+++ b/modules/ppcp-wc-payment-tokens/src/WooCommercePaymentTokens.php
@@ -271,6 +271,23 @@ class WooCommercePaymentTokens {
 	}
 
 	/**
+	 * Whether the given WP user has a saved PayPal or Venmo payment token.
+	 *
+	 * @param int $user_id WP user id.
+	 * @return bool
+	 */
+	public function has_paypal_or_venmo_token( int $user_id ): bool {
+		foreach ( $this->customer_tokens( $user_id ) as $token ) {
+			$name = $token['payment_source']->name() ?? '';
+			if ( 'paypal' === $name || 'venmo' === $name ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Creates WC payment tokens for the given WP user id using PayPal payment tokens as source.
 	 *
 	 * @param array $customer_tokens PayPal customer payment tokens.

--- a/tests/PHPUnit/Blocks/PayPalPaymentMethodTest.php
+++ b/tests/PHPUnit/Blocks/PayPalPaymentMethodTest.php
@@ -12,6 +12,8 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcPaymentTokens\WooCommercePaymentTokens;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use function Brain\Monkey\Functions\when;
 
@@ -25,6 +27,8 @@ class PayPalPaymentMethodTest extends TestCase
     private $cancellation_view;
     private $session_handler;
     private $subscription_helper;
+    private $free_trial_helper;
+    private $wc_payment_tokens;
 
     public function setUp(): void
     {
@@ -38,6 +42,8 @@ class PayPalPaymentMethodTest extends TestCase
         $this->cancellation_view   = Mockery::mock(CancelView::class);
         $this->session_handler     = Mockery::mock(SessionHandler::class);
         $this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $this->free_trial_helper   = Mockery::mock(FreeTrialSubscriptionHelper::class);
+        $this->wc_payment_tokens   = Mockery::mock(WooCommercePaymentTokens::class);
 
         $this->gateway->id          = PayPalGateway::ID;
         $this->gateway->title       = 'PayPal';
@@ -46,6 +52,11 @@ class PayPalPaymentMethodTest extends TestCase
         $this->gateway->shouldReceive('get_description')->andReturn('Pay with PayPal');
 
         $this->session_handler->shouldReceive('funding_source')->andReturn('paypal');
+
+        // Not exercising free-trial gating by default: no cart is a free-trial cart, and
+        // no user is logged in, unless a test overrides these.
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn(false)->byDefault();
+        when('get_current_user_id')->justReturn(0);
 
         when('wp_create_nonce')->justReturn('nonce');
 
@@ -81,7 +92,9 @@ class PayPalPaymentMethodTest extends TestCase
             $use_place_order,
             'Place order',
             'Pay with PayPal',
-            array()
+            array(),
+            $this->free_trial_helper,
+            $this->wc_payment_tokens
         );
     }
 
@@ -188,6 +201,75 @@ class PayPalPaymentMethodTest extends TestCase
                 'assert_smart_buttons_disabled'   => true,
             ),
         );
+    }
+
+    /**
+     * GIVEN a free-trial subscription cart and a logged-in customer with no saved PayPal
+     *      or Venmo account
+     * WHEN get_payment_method_data() is called
+     * THEN the standard "Place order" row is disabled, since it would otherwise fail with
+     *      "No saved PayPal account"
+     */
+    public function testPlaceOrderDisabledForFreeTrialCartWithoutSavedPaypalToken(): void
+    {
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn(false);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn(true);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn(true);
+        when('get_current_user_id')->justReturn(7);
+        $this->wc_payment_tokens->shouldReceive('has_paypal_or_venmo_token')->with(7)->andReturn(false);
+
+        $testee = $this->createTestee(array(), true, false);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertFalse($data['placeOrderEnabled']);
+    }
+
+    /**
+     * GIVEN a free-trial subscription cart and a logged-in customer who already has a
+     *      saved PayPal or Venmo account
+     * WHEN get_payment_method_data() is called
+     * THEN the standard "Place order" row stays enabled, since the saved account lets the
+     *      free-trial vaulting flow succeed
+     */
+    public function testPlaceOrderEnabledForFreeTrialCartWithSavedPaypalToken(): void
+    {
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn(false);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn(true);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn(true);
+        when('get_current_user_id')->justReturn(7);
+        $this->wc_payment_tokens->shouldReceive('has_paypal_or_venmo_token')->with(7)->andReturn(true);
+
+        $testee = $this->createTestee(array(), true, false);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertTrue($data['placeOrderEnabled']);
+    }
+
+    /**
+     * GIVEN a free-trial subscription cart and a guest (no logged-in customer, so no saved
+     *      payment tokens can exist for them)
+     * WHEN get_payment_method_data() is called
+     * THEN the standard "Place order" row is disabled
+     * AND no payment-token lookup is attempted, since a guest cannot have one
+     */
+    public function testPlaceOrderDisabledForFreeTrialCartWhenGuest(): void
+    {
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn(false);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn(true);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn(true);
+        when('get_current_user_id')->justReturn(0);
+        $this->wc_payment_tokens->shouldNotReceive('has_paypal_or_venmo_token');
+
+        $testee = $this->createTestee(array(), true, false);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertFalse($data['placeOrderEnabled']);
     }
 
     /**

--- a/tests/PHPUnit/WcPaymentTokens/WooCommercePaymentTokensTest.php
+++ b/tests/PHPUnit/WcPaymentTokens/WooCommercePaymentTokensTest.php
@@ -113,4 +113,58 @@ class WooCommercePaymentTokensTest extends TestCase
 		// THEN the failure is treated the same as having no tokens.
 		$this->assertSame([], $result);
 	}
+
+	/**
+	 * Builds a customer token whose payment_source reports the given name, matching the
+	 * shape returned by PaymentTokensEndpoint::payment_tokens_for_customer().
+	 *
+	 * @param string $payment_source_name Name reported by the token's payment source.
+	 */
+	private function tokenWithPaymentSourceName(string $payment_source_name): array
+	{
+		return ['payment_source' => Mockery::mock(['name' => $payment_source_name])];
+	}
+
+	/**
+	 * GIVEN a customer whose stored payment tokens include one with the given payment
+	 *      source name
+	 * WHEN has_paypal_or_venmo_token() is called
+	 * THEN it reports whether a PayPal or Venmo token is present among them
+	 *
+	 * @dataProvider payment_source_name_provider
+	 */
+	public function testHasPaypalOrVenmoTokenDetectsMatchingPaymentSource(string $payment_source_name, bool $expected)
+	{
+		$this->stubUserMeta(['_ppcp_target_customer_id' => 'CUST-1']);
+		$this->payment_tokens_endpoint
+			->shouldReceive('payment_tokens_for_customer')
+			->with('CUST-1')
+			->andReturn([$this->tokenWithPaymentSourceName($payment_source_name)]);
+
+		$result = $this->sut->has_paypal_or_venmo_token(42);
+
+		$this->assertSame($expected, $result);
+	}
+
+	public function payment_source_name_provider(): array
+	{
+		return [
+			'paypal token present' => ['paypal', true],
+			'venmo token present'  => ['venmo', true],
+			'only a card token'    => ['card', false],
+		];
+	}
+
+	public function testHasPaypalOrVenmoTokenReturnsFalseWhenThereIsNoResolvableCustomerId()
+	{
+		// GIVEN a user with no stored PayPal customer id, so no tokens can be looked up.
+		$this->stubUserMeta([]);
+
+		// WHEN checking whether the user has a saved PayPal or Venmo token.
+		$result = $this->sut->has_paypal_or_venmo_token(42);
+
+		// THEN the endpoint is never called and the user is treated as having no such token.
+		$this->payment_tokens_endpoint->shouldNotHaveReceived('payment_tokens_for_customer');
+		$this->assertFalse($result);
+	}
 }


### PR DESCRIPTION
In Blocks checkout, a free-trial subscription cart showed the non-express PayPal gateway. Selecting it and clicking "Proceed to PayPal" failed with "No saved PayPal account." because that flow needs an already-vaulted PayPal/Venmo token.                                                                                                                             
                                                                                                                                                                                             
This PR hides the non-express PayPal gateway (`placeOrderEnabled = false`) when the cart is a free-trial cart and the customer has no saved PayPal/Venmo token. The PayPal express button still shows, so the customer can vault their account and place the order.    