### PR TITLE
Serve the v5 stack to Mexican merchants (6895)

### DIFF
--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\CartQuoteEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
@@ -118,6 +119,13 @@ return array(
 		};
 	},
 
+	'sdk-v6.merchant-country-support'   => static function ( ContainerInterface $container ): MerchantCountrySupport {
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
+
+		return new MerchantCountrySupport( $settings_provider->merchant_country() );
+	},
+
 	'sdk-v6.card-field-styles'          => static function (): CardFieldStyles {
 		return new CardFieldStyles();
 	},
@@ -178,7 +186,8 @@ return array(
 			$container->get( 'sdk-v6.google-pay-config' ),
 			$container->get( 'sdk-v6.apple-pay-config' ),
 			$container->get( 'sdk-v6.fastlane-config' ),
-			$container->get( 'sdk-v6.card-field-styles' )
+			$container->get( 'sdk-v6.card-field-styles' ),
+			$container->get( 'sdk-v6.merchant-country-support' )
 		);
 	},
 
@@ -198,7 +207,8 @@ return array(
 				&& $container->get( 'save-payment-methods.eligible' )
 				&& $settings_provider->save_card_details(),
 			$settings_provider,
-			$container->get( 'sdk-v6.card-field-styles' )
+			$container->get( 'sdk-v6.card-field-styles' ),
+			$container->get( 'sdk-v6.merchant-country-support' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
@@ -22,6 +22,7 @@ use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -46,6 +47,7 @@ class AddPaymentMethodManager {
 	private SettingsProvider $settings_provider;
 
 	private CardFieldStyles $card_field_styles;
+	private MerchantCountrySupport $merchant_country_support;
 
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -55,16 +57,18 @@ class AddPaymentMethodManager {
 		bool $paypal_vaulting_enabled,
 		bool $card_vaulting_enabled,
 		SettingsProvider $settings_provider,
-		CardFieldStyles $card_field_styles
+		CardFieldStyles $card_field_styles,
+		MerchantCountrySupport $merchant_country_support
 	) {
-		$this->asset_getter            = $asset_getter;
-		$this->version                 = $version;
-		$this->environment             = $environment;
-		$this->context                 = $context;
-		$this->paypal_vaulting_enabled = $paypal_vaulting_enabled;
-		$this->card_vaulting_enabled   = $card_vaulting_enabled;
-		$this->settings_provider       = $settings_provider;
-		$this->card_field_styles       = $card_field_styles;
+		$this->asset_getter             = $asset_getter;
+		$this->version                  = $version;
+		$this->environment              = $environment;
+		$this->context                  = $context;
+		$this->paypal_vaulting_enabled  = $paypal_vaulting_enabled;
+		$this->card_vaulting_enabled    = $card_vaulting_enabled;
+		$this->settings_provider        = $settings_provider;
+		$this->card_field_styles        = $card_field_styles;
+		$this->merchant_country_support = $merchant_country_support;
 	}
 
 	/**
@@ -116,7 +120,8 @@ class AddPaymentMethodManager {
 	 * Whether the v6 save surfaces load on the current page.
 	 */
 	public function should_load_on_current_page(): bool {
-		return is_user_logged_in()
+		return $this->merchant_country_support->is_supported()
+			&& is_user_logged_in()
 			&& ( $this->paypal_vaulting_enabled || $this->card_vaulting_enabled )
 			&& $this->context->is_add_payment_method_page();
 	}

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -34,6 +34,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
@@ -114,6 +115,7 @@ class SdkV6Manager {
 	private MessageStyleMapper $message_style_mapper;
 	private MessagesEligibility $messages_eligibility;
 	private string $merchant_country;
+	private MerchantCountrySupport $merchant_country_support;
 
 	/**
 	 * Card brand icons ({type, title, url}); empty when "Show logos" is off.
@@ -192,7 +194,8 @@ class SdkV6Manager {
 		GooglePayConfig $google_pay_config,
 		ApplePayConfig $apple_pay_config,
 		FastlaneConfig $fastlane_config,
-		CardFieldStyles $card_field_styles
+		CardFieldStyles $card_field_styles,
+		MerchantCountrySupport $merchant_country_support
 	) {
 		$this->asset_getter                = $asset_getter;
 		$this->version                     = $version;
@@ -217,6 +220,7 @@ class SdkV6Manager {
 		$this->apple_pay_config            = $apple_pay_config;
 		$this->fastlane_config             = $fastlane_config;
 		$this->card_field_styles           = $card_field_styles;
+		$this->merchant_country_support    = $merchant_country_support;
 
 		$this->placements = array(
 			new MethodPlacement(
@@ -552,6 +556,10 @@ class SdkV6Manager {
 	 * The uncached answer for should_load_on_current_page().
 	 */
 	private function resolve_should_load(): bool {
+		if ( ! $this->merchant_country_support->is_supported() ) {
+			return false;
+		}
+
 		// Native PayPal Subscriptions (subscriptions_api mode) have no v6 path: v6
 		// can only carry a subscription by vaulting, which that mode disables. Hand
 		// the whole page back to the v5 stack, which creates the subscription via

--- a/modules/ppcp-sdk-v6/src/Helper/MerchantCountrySupport.php
+++ b/modules/ppcp-sdk-v6/src/Helper/MerchantCountrySupport.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Whether the v6 SDK may load for the merchant's country.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+/**
+ * Mexican merchants are served the v5 stack.
+ */
+class MerchantCountrySupport {
+
+	/**
+	 * The merchant's two-letter country code.
+	 */
+	private string $merchant_country;
+
+	public function __construct( string $merchant_country ) {
+		$this->merchant_country = $merchant_country;
+	}
+
+	public function is_supported(): bool {
+		/**
+		 * Filters the merchant countries the v6 SDK is withheld from.
+		 *
+		 * @param string[] $countries Two-letter country codes.
+		 */
+		$countries = apply_filters(
+			'woocommerce_paypal_payments_sdk_v6_unsupported_countries',
+			array( 'MX' )
+		);
+
+		return ! in_array( $this->merchant_country, (array) $countries, true );
+	}
+}

--- a/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -40,7 +41,8 @@ class AddPaymentMethodManagerTest extends TestCase
 
     private function createTestee(
         bool $paypal_vaulting_enabled = false,
-        bool $card_vaulting_enabled = false
+        bool $card_vaulting_enabled = false,
+        string $merchant_country = 'US'
     ): AddPaymentMethodManager {
         return new AddPaymentMethodManager(
             $this->asset_getter,
@@ -50,7 +52,8 @@ class AddPaymentMethodManagerTest extends TestCase
             $paypal_vaulting_enabled,
             $card_vaulting_enabled,
             $this->settings_provider,
-            $this->card_field_styles
+            $this->card_field_styles,
+            new MerchantCountrySupport($merchant_country)
         );
     }
 

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
@@ -207,7 +208,8 @@ class SdkV6ManagerTest extends TestCase
 	        $this->google_pay_config,
 	        $this->apple_pay_config,
 	        $this->fastlane_config,
-	        $this->card_field_styles
+	        $this->card_field_styles,
+	        new MerchantCountrySupport($merchant_country)
         );
     }
 

--- a/tests/PHPUnit/SdkV6/Helper/MerchantCountrySupportTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/MerchantCountrySupportTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Filters\expectApplied;
+
+class MerchantCountrySupportTest extends TestCase
+{
+    private const FILTER = 'woocommerce_paypal_payments_sdk_v6_unsupported_countries';
+
+    /**
+     * GIVEN a merchant based in Mexico
+     * WHEN checking whether the v6 SDK may load for them
+     * THEN it is not supported, so they are served the v5 stack instead
+     */
+    public function testMexicanMerchantIsNotSupported(): void
+    {
+        $testee = new MerchantCountrySupport('MX');
+
+        $this->assertFalse($testee->is_supported());
+    }
+
+    /**
+     * GIVEN a merchant based in the United States
+     * WHEN checking whether the v6 SDK may load for them
+     * THEN it is supported
+     */
+    public function testNonMexicanMerchantIsSupported(): void
+    {
+        $testee = new MerchantCountrySupport('US');
+
+        $this->assertTrue($testee->is_supported());
+    }
+
+    /**
+     * GIVEN a third party widens the unsupported-countries filter to include Brazil
+     * WHEN checking whether the v6 SDK may load for a Brazilian merchant
+     * THEN that merchant is no longer supported
+     */
+    public function testFilterCanWidenListToWithholdAnotherCountry(): void
+    {
+        expectApplied(self::FILTER)->andReturn(['MX', 'BR']);
+
+        $testee = new MerchantCountrySupport('BR');
+
+        $this->assertFalse($testee->is_supported());
+    }
+
+    /**
+     * GIVEN a third party empties the unsupported-countries filter as an escape hatch
+     * WHEN checking whether the v6 SDK may load for a Mexican merchant
+     * THEN Mexico becomes supported again
+     */
+    public function testFilterCanEmptyListToRestoreMexicanSupport(): void
+    {
+        expectApplied(self::FILTER)->andReturn([]);
+
+        $testee = new MerchantCountrySupport('MX');
+
+        $this->assertTrue($testee->is_supported());
+    }
+}


### PR DESCRIPTION
### Description

Mexican merchants are served the v5 stack instead of v6.

PayPal's v6 SDK sends the CVV as `securityCode` in its `confirm-payment-source` call. PayPal's Mexican card processing requires `security_code` and rejects the request with `MISSING_REQUIRED_PARAMETER`, so every ACDC payment fails. Reproduced without the SDK - same merchant, order and card, only the key spelling changed.

| Key | MX merchant | US merchant |
| :--- | :--- | :--- |
| `security_code` | 200 APPROVED | 200 APPROVED |
| `securityCode` | **400** | 200 APPROVED |

The payload is built inside PayPal's cross-origin iframe, so there is nothing to fix on our side.

Both v6 entry points are guarded (`SdkV6Manager`, `AddPaymentMethodManager`) so `extensions.php` leaves v5's smart button in place rather than disabling it.

Opt out with `woocommerce_paypal_payments_sdk_v6_unsupported_countries`.

### Steps to Test

Requires a Mexican sandbox merchant and the v6 flag enabled.

1. Connect a MX merchant, enable ACDC
2. Add a product to the cart and go to checkout
3. Pay with the inline card fields

Before: "This card could not be authorized." After: the payment completes through v5.

For a US merchant, confirm nothing changed and v6 still loads.