### PR TITLE
Keep the express shipping methods when PayPal has no usable address yet (6898)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -32,6 +32,7 @@ patchwork.json
 README.md
 AGENTS.md
 CLAUDE.md
+.claude/
 E2E-TESTS.md
 wordpress_org_assets*
 .DS_Store

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.1.3 - XXXX-XX-XX =
+* TBD
+
 = 4.1.2 - 2026-08-04 =
 * Enhancement - Advanced onboarding options for onboarding wizard #4496
 * Enhancement - Improved buyer-facing card decline reason display #4509

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,24 @@
 *** Changelog ***
 
 = 4.1.3 - XXXX-XX-XX =
-* TBD
+* Enhancement - PayPal JS SDK v6 is now the default for new store setups, moving PayPal buttons, Apple Pay, Google Pay, Advanced Card Fields, Fastlane, Pay Later messaging and vaulting subscriptions onto the new integration; existing stores remain on SDK v5 with this version #4641
+* Enhancement - Add filter hooks to customize the payment method title and allow payment method icons #4586
+* Enhancement - Clearer, customer-friendly decline messages for 3D Secure rejections #4573
+* Enhancement - First-party WooCommerce plugin detection for product customizations #4552
+* Enhancement - Allow Pay Later to remain available when vaulting is enabled #4611
+* Enhancement - Improve manual-renewal-only subscription scenarios #4621
+* Enhancement - Exclude connection details from Blueprint exports by default #4647
+* Fix - Apple Pay shown under the PayPal gateway when a vaulting subscription is in the cart #4546
+* Fix - Prevent Vault API calls made with an empty customer ID #4567
+* Fix - Keep recoverable PAYER_ACTION_REQUIRED orders from failing prematurely #4569
+* Fix - Retain the shopper's checkout data when returning from PayPal on mobile #4649
+* Fix - PayPal gateway missing on Block Checkout when WooCommerce Subscriptions automatic renewals are enabled #4659
+* Fix - Webhook registration hitting the wrong API host right after onboarding #4669
+* Fix - Give the Pay upon Invoice phone field its own ID #4666
+* Fix - Stop polling the merchant-integrations endpoint on every cron run #4640
+* Fix - Skip WooCommerce Inbox note registration during AJAX requests #4607
+* Fix - Remove the orphaned reCAPTCHA Inbox note and align its enabled checks #4634
+* Fix - Prevent Advanced Card Fields submission when Blocks checkout fields are invalid (author @marcofucito) #4435
 
 = 4.1.2 - 2026-08-04 =
 * Enhancement - Advanced onboarding options for onboarding wizard #4496

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,8 @@
 * Fix - Skip WooCommerce Inbox note registration during AJAX requests #4607
 * Fix - Remove the orphaned reCAPTCHA Inbox note and align its enabled checks #4634
 * Fix - Prevent Advanced Card Fields submission when Blocks checkout fields are invalid (author @marcofucito) #4435
+* Fix - Show the product button on variable products with no preselected attributes #4691
+* Fix - Fix negative tax_total when a discount is not reported by WooCommerce #4690
 
 = 4.1.2 - 2026-08-04 =
 * Enhancement - Advanced onboarding options for onboarding wizard #4496

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\ResolvingBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\ClientCredentials;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\ConnectBearer;
@@ -105,6 +106,23 @@ return array(
 	},
 	'api.host-resolver'                              => static function ( ContainerInterface $container ): ApiHostResolver {
 		return new ApiHostResolver( $container->get( 'settings.connection-state' ) );
+	},
+	/**
+	 * Scoped the same way as api.host-resolver; see ResolvingBearer's class
+	 * docblock for the rationale. The shared api.bearer service below is
+	 * intentionally left untouched.
+	 */
+	'api.bearer-resolver'                            => static function ( ContainerInterface $container ): ResolvingBearer {
+		return new ResolvingBearer(
+			$container->get( 'settings.connection-state' ),
+			$container->get( 'api.paypal-bearer-cache' ),
+			$container->get( 'api.host-resolver' ),
+			$container->get( 'api.key' ),
+			$container->get( 'api.secret' ),
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'settings.settings-provider' ),
+			$container->get( 'api.token-rate-limiter' )
+		);
 	},
 	'api.paypal-host'                                => function ( ContainerInterface $container ): string {
 		return PAYPAL_API_URL;
@@ -219,7 +237,7 @@ return array(
 	'api.endpoint.webhook'                           => static function ( ContainerInterface $container ): WebhookEndpoint {
 		return new WebhookEndpoint(
 			$container->get( 'api.host-resolver' ),
-			$container->get( 'api.bearer' ),
+			$container->get( 'api.bearer-resolver' ),
 			$container->get( 'api.factory.webhook' ),
 			$container->get( 'api.factory.webhook-event' ),
 			$container->get( 'woocommerce.logger.woocommerce' )

--- a/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Resolves the API bearer to use for the current connection state.
- *
- * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
- */
 
 declare(strict_types=1);
 
@@ -17,7 +12,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 
 /**
- * Class ResolvingBearer
+ * Resolves the API bearer to use for the current connection state.
  *
  * A Bearer that mirrors ApiHostResolver's approach for the host: is_connected()
  * decides between ConnectBearer and PayPalBearer on every call rather than

--- a/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/ResolvingBearer.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Resolves the API bearer to use for the current connection state.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ApiHostResolver;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
+
+/**
+ * Class ResolvingBearer
+ *
+ * A Bearer that mirrors ApiHostResolver's approach for the host: is_connected()
+ * decides between ConnectBearer and PayPalBearer on every call rather than
+ * freezing that choice at construction time. Without this, a Bearer resolved
+ * (e.g. via rest_api_init building the webhook controller) before
+ * ConnectionState::connect() runs in the same request stays a ConnectBearer -
+ * a hardcoded placeholder token - for the rest of that request, even after
+ * the merchant is connected and api.host has moved on to the real PayPal API.
+ */
+class ResolvingBearer implements Bearer {
+
+	private ConnectionState $connection_state;
+
+	private Cache $cache;
+
+	private ApiHostResolver $host_resolver;
+
+	private string $key;
+
+	private string $secret;
+
+	private LoggerInterface $logger;
+
+	private ?SettingsProvider $settings;
+
+	private TokenRateLimiter $rate_limiter;
+
+	public function __construct(
+		ConnectionState $connection_state,
+		Cache $cache,
+		ApiHostResolver $host_resolver,
+		string $key,
+		string $secret,
+		LoggerInterface $logger,
+		?SettingsProvider $settings,
+		TokenRateLimiter $rate_limiter
+	) {
+		$this->connection_state = $connection_state;
+		$this->cache            = $cache;
+		$this->host_resolver    = $host_resolver;
+		$this->key              = $key;
+		$this->secret           = $secret;
+		$this->logger           = $logger;
+		$this->settings         = $settings;
+		$this->rate_limiter     = $rate_limiter;
+	}
+
+	/**
+	 * Returns the bearer to use right now.
+	 *
+	 * Must be called fresh for every request, not resolved once and cached -
+	 * see the class docblock.
+	 */
+	public function bearer(): Token {
+		if ( ! $this->connection_state->is_connected() ) {
+			return ( new ConnectBearer() )->bearer();
+		}
+
+		return ( new PayPalBearer(
+			$this->cache,
+			$this->host_resolver->host(),
+			$this->key,
+			$this->secret,
+			$this->logger,
+			$this->settings,
+			$this->rate_limiter
+		) )->bearer();
+	}
+}

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -194,6 +194,10 @@ class OrderEndpoint {
 					if ( $shipping_preference !== ExperienceContext::SHIPPING_PREFERENCE_GET_FROM_FILE ) {
 						// Shipping options are not allowed to be sent when not getting the address from PayPal.
 						unset( $data['shipping']['options'] );
+
+						if ( empty( $data['shipping'] ) ) {
+							unset( $data['shipping'] );
+						}
 					}
 
 					return $data;

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -216,13 +216,23 @@ class AmountFactory {
 		} else {
 			$wc_total              = (float) $order->get_total();
 			$wc_total_cents        = (int) round( $wc_total * 100 );
+			$discount_cents        = (int) round( $discount_value * 100 );
 			$component_total_cents = (int) round( $item_total_val * 100 )
 				+ (int) round( $shipping_val * 100 )
 				+ (int) round( $taxes_val * 100 )
-				- (int) round( $discount_value * 100 );
-			$taxes_cents           = (int) round( $taxes_val * 100 ) + ( $wc_total_cents - $component_total_cents );
-			$taxes                 = new Money( $taxes_cents / 100, $currency );
-			$total                 = new Money( $wc_total, $currency );
+				- $discount_cents;
+			$delta_cents           = $wc_total_cents - $component_total_cents;
+			$taxes_cents           = (int) round( $taxes_val * 100 ) + $delta_cents;
+
+			// Deeper than the tax means an unreported discount, not rounding. Book it
+			// as one: PayPal rejects a negative tax_total on Level 2 card data.
+			if ( $taxes_cents < 0 ) {
+				$taxes_cents = (int) round( $taxes_val * 100 );
+				$discount    = new Money( ( $discount_cents - $delta_cents ) / 100, $currency );
+			}
+
+			$taxes = new Money( $taxes_cents / 100, $currency );
+			$total = new Money( $wc_total, $currency );
 		}
 
 		$breakdown = new AmountBreakdown(

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -224,11 +224,17 @@ class AmountFactory {
 			$delta_cents           = $wc_total_cents - $component_total_cents;
 			$taxes_cents           = (int) round( $taxes_val * 100 ) + $delta_cents;
 
-			// Deeper than the tax means an unreported discount, not rounding. Book it
-			// as one: PayPal rejects a negative tax_total on Level 2 card data.
+			// Deeper than the tax means an unreported discount, not rounding. Book it as
+			// one: PayPal rejects a negative tax_total on Level 2 card data.
 			if ( $taxes_cents < 0 ) {
-				$taxes_cents = (int) round( $taxes_val * 100 );
-				$discount    = new Money( ( $discount_cents - $delta_cents ) / 100, $currency );
+				$taxes_cents = max( 0, (int) round( $taxes_val * 100 ) );
+				$discount    = new Money(
+					( (int) round( $item_total_val * 100 )
+						+ (int) round( $shipping_val * 100 )
+						+ $taxes_cents
+						- $wc_total_cents ) / 100,
+					$currency
+				);
 			}
 
 			$taxes = new Money( $taxes_cents / 100, $currency );

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 use WC_Session_Handler;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelEligibility;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelHelper;
@@ -191,8 +192,15 @@ class PurchaseUnitFactory {
 		if ( $this->shipping_needed( ...array_values( $items ) ) && $customer instanceof \WC_Customer ) {
 			$shipping         = $this->shipping_factory->from_wc_customer( \WC()->customer, $with_shipping_options );
 			$shipping_address = $shipping->address();
+
 			if ( ! $shipping_address || ! $this->can_use_shipping_address( $shipping_address ) ) {
-				$shipping = null;
+				// GET_FROM_FILE: PayPal withholds the street until after approval, so the address
+				// stays unusable for the whole flow. The options must survive it, or the order
+				// carries no shipping method to select. The result is shipping data with options
+				// and no address, which every consumer must tolerate.
+				$shipping = $shipping->options()
+					? new Shipping( $shipping->name(), null, null, null, $shipping->options() )
+					: null;
 			}
 		}
 

--- a/modules/ppcp-api-client/src/Factory/ShippingPreferenceFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ShippingPreferenceFactory.php
@@ -65,7 +65,8 @@ class ShippingPreferenceFactory {
 			return ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING;
 		}
 
-		$has_shipping              = null !== $purchase_unit->shipping();
+		$shipping                  = $purchase_unit->shipping();
+		$has_shipping_address      = $shipping && null !== $shipping->address();
 		$needs_shipping            = ( $wc_order && $this->wc_order_needs_shipping( $wc_order ) ) || ( $cart && $cart->needs_shipping() );
 		$shipping_address_is_fixed = $needs_shipping && in_array( $context, array( 'checkout', 'pay-now' ), true );
 
@@ -74,8 +75,7 @@ class ShippingPreferenceFactory {
 		}
 
 		if ( $shipping_address_is_fixed ) {
-			// Checkout + no address given? Probably something weird happened, like no form validation?
-			if ( ! $has_shipping ) {
+			if ( ! $has_shipping_address ) {
 				return ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING;
 			}
 
@@ -83,7 +83,7 @@ class ShippingPreferenceFactory {
 		}
 
 		if ( 'card' === $funding_source ) {
-			if ( ! $has_shipping ) {
+			if ( ! $has_shipping_address ) {
 				return ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING;
 			}
 			// Looks like GET_FROM_FILE does not work for the vaulted card button.

--- a/modules/ppcp-applepay/resources/js/Block/hooks/usePayPalScript.js
+++ b/modules/ppcp-applepay/resources/js/Block/hooks/usePayPalScript.js
@@ -4,7 +4,11 @@ import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
 const usePayPalScript = ( namespace, ppcpConfig ) => {
 	const [ isPayPalLoaded, setIsPayPalLoaded ] = useState( false );
 
-	ppcpConfig.url_params.components += ',applepay';
+	// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+	// there and localizes no script data.
+	if ( ppcpConfig.url_params ) {
+		ppcpConfig.url_params.components += ',applepay';
+	}
 
 	useEffect( () => {
 		const loadScript = async () => {

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -36,7 +36,11 @@ const ApplePayComponent = ( { isEditing, buttonAttributes } ) => {
 			setApplePayLoaded( true );
 		} );
 
-		ppcpConfig.url_params.components += ',applepay';
+		// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+		// there and localizes no script data.
+		if ( ppcpConfig.url_params ) {
+			ppcpConfig.url_params.components += ',applepay';
+		}
 
 		// Load PayPal
 		loadPayPalScript( namespace, ppcpConfig )

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -171,7 +171,20 @@ return array(
 			$container->get( 'applepay.button' ),
 			$container->get( 'blocks.method' ),
 			$container->get( 'button.helper.context' ),
-			$container->get( 'settings.settings-provider' )
+			$container->get( 'settings.settings-provider' ),
+			/**
+			 * The v6 module is feature-flagged and may not be loaded, hence the has()
+			 * guard. Resolved on each call so it reflects the page being rendered.
+			 */
+			static function () use ( $container ): bool {
+				if ( ! $container->has( 'sdk-v6.owns-current-page' ) ) {
+					return false;
+				}
+
+				$owns_current_page = $container->get( 'sdk-v6.owns-current-page' );
+
+				return $owns_current_page();
+			}
 		);
 	},
 

--- a/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
@@ -25,6 +25,13 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private Context $context;
 	private SettingsProvider $settings_provider;
 
+	/**
+	 * Answers whether the SDK v6 module renders the PayPal stack on the current page.
+	 *
+	 * @var (callable():bool)|null
+	 */
+	private $v6_owns_current_page;
+
 	public function __construct(
 		string $name,
 		AssetGetter $asset_getter,
@@ -32,7 +39,8 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		ButtonInterface $button,
 		PaymentMethodTypeInterface $paypal_payment_method,
 		Context $context,
-		SettingsProvider $settings_provider
+		SettingsProvider $settings_provider,
+		?callable $v6_owns_current_page = null
 	) {
 		$this->name                  = $name;
 		$this->asset_getter          = $asset_getter;
@@ -41,11 +49,21 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		$this->paypal_payment_method = $paypal_payment_method;
 		$this->context               = $context;
 		$this->settings_provider     = $settings_provider;
+		$this->v6_owns_current_page  = $v6_owns_current_page;
 	}
 
 	public function initialize() {  }
 
 	public function is_active(): bool {
+		/*
+		 * On a page the v6 SDK owns, the v5 smart button is swapped for a disabled
+		 * one whose script data is empty, and this block bundle reads that data
+		 * expecting the v5 shape. v6 renders Apple Pay on those pages itself.
+		 */
+		if ( is_callable( $this->v6_owns_current_page ) && ( $this->v6_owns_current_page )() ) {
+			return false;
+		}
+
 		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
 
 		if ( ! in_array( ApplePayGateway::ID, $methods, true ) ) {

--- a/modules/ppcp-blocks/resources/css/gateway.scss
+++ b/modules/ppcp-blocks/resources/css/gateway.scss
@@ -24,3 +24,36 @@ li[id^="express-payment-method-ppcp-"] {
 	}
 }
 
+
+// The v6 advanced card fields, whose elements are created by the SDK bundle.
+.ppcp-sdk-v6-card-fields {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	// WooCommerce's "save payment information" checkbox follows this block
+	// with no margin of its own.
+	margin-bottom: 16px;
+}
+
+.ppcp-sdk-v6-card-fields__row {
+	display: flex;
+	gap: 16px;
+
+	> .ppcp-sdk-v6-card-field {
+		flex: 1;
+	}
+}
+
+// The wc-block-components-text-input class carries a top margin that Blocks
+// resets only for :first-of-type. The flex gap already spaces these fields.
+.ppcp-sdk-v6-card-fields .ppcp-sdk-v6-card-field.wc-block-components-text-input {
+	margin-top: 0;
+}
+
+// A hosted field is a cross-origin iframe that a label cannot focus, so its
+// label passes clicks through to it. The cardholder-name label has a real
+// for/id target and keeps its clicks.
+.ppcp-sdk-v6-card-field__label {
+	pointer-events: none;
+}

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -240,10 +240,13 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		// A subscription cart may still use the standard "Place order" flow when a vault
 		// token can be saved (vaulting mode) or when manual renewals are accepted (the
 		// subscription is charged as a plain, one-time Orders API payment).
+		//
+		// The vaulting capability comes from the settings, not $script_data: under SDK v6
+		// the smart button is a DisabledSmartButton whose script_data() is empty.
 		$place_order_enabled = ( $this->use_place_order || $this->add_place_order_method )
 			&& (
 				! $this->subscription_helper->cart_contains_subscription()
-				|| ( $script_data['can_save_vault_token'] ?? false )
+				|| $this->plugin_settings->can_save_vault_token()
 				|| $this->subscription_helper->accept_manual_renewals()
 			);
 		$cart                = WC()->cart;

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -909,16 +909,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 * @return bool
 	 */
 	public function can_save_vault_token(): bool {
-		$merchant_data = $this->settings_provider->merchant_data();
-		if ( ! $merchant_data->client_id ) {
-			return false;
-		}
-
-		if ( ! $this->settings_provider->save_paypal_and_venmo() ) {
-			return false;
-		}
-
-		return true;
+		return $this->settings_provider->can_save_vault_token();
 	}
 
 	/**

--- a/modules/ppcp-googlepay/resources/js/Block/hooks/usePayPalScript.js
+++ b/modules/ppcp-googlepay/resources/js/Block/hooks/usePayPalScript.js
@@ -4,7 +4,11 @@ import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
 const usePayPalScript = ( namespace, ppcpConfig ) => {
 	const [ isPayPalLoaded, setIsPayPalLoaded ] = useState( false );
 
-	ppcpConfig.url_params.components += ',googlepay';
+	// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+	// there and localizes no script data.
+	if ( ppcpConfig.url_params ) {
+		ppcpConfig.url_params.components += ',googlepay';
+	}
 
 	useEffect( () => {
 		const loadScript = async () => {

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -1,5 +1,7 @@
 import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
-import SimulateCart, { isSimulateCartEnabled } from '@ppcp-button/Helper/SimulateCart';
+import SimulateCart, {
+	isSimulateCartEnabled,
+} from '@ppcp-button/Helper/SimulateCart';
 import ErrorHandler from '@ppcp-button/ErrorHandler';
 import UpdateCart from '@ppcp-button/Helper/UpdateCart';
 import BaseHandler from './BaseHandler';
@@ -14,18 +16,32 @@ class SingleProductHandler extends BaseHandler {
 	}
 
 	transactionInfo() {
-		// Simulation is this method's only mechanism for fetching product data;
-		// reject early to avoid a pointless AJAX call.
-		if ( ! isSimulateCartEnabled( this.ppcpConfig ) ) {
-			return Promise.reject( new Error( 'Cart simulation is disabled.' ) );
-		}
-
 		const form = document.querySelector( 'form.cart' );
 		const variationIdInput = form?.querySelector(
 			'input[name="variation_id"]'
 		);
 		if ( variationIdInput && ! parseInt( variationIdInput.value ) ) {
-			return Promise.reject( new Error( 'No variation selected.' ) );
+			/*
+			 * No variation chosen, so there is no product total to price yet.
+			 * Rejecting here left the manager without transaction info and it
+			 * skipped the button entirely, so a variable product with no default
+			 * attributes never offered Google Pay at all - not even once the
+			 * shopper picked one, since nothing re-runs the init on that event.
+			 *
+			 * Fall back to the cart-based figures purely so the button renders.
+			 * ProductButtonGate keeps it disabled until a variation exists, and
+			 * onButtonClick() re-reads this method before opening the sheet, so
+			 * this total is never the one presented to the shopper.
+			 */
+			return super.transactionInfo();
+		}
+
+		// Simulation is this method's only mechanism for fetching product data;
+		// reject early to avoid a pointless AJAX call.
+		if ( ! isSimulateCartEnabled( this.ppcpConfig ) ) {
+			return Promise.reject(
+				new Error( 'Cart simulation is disabled.' )
+			);
 		}
 
 		const errorHandler = new ErrorHandler(

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
@@ -90,9 +90,9 @@ describe( 'SingleProductHandler', () => {
 					null
 				);
 
-				await expect( disabledHandler.transactionInfo() ).rejects.toThrow(
-					'Cart simulation is disabled.'
-				);
+				await expect(
+					disabledHandler.transactionInfo()
+				).rejects.toThrow( 'Cart simulation is disabled.' );
 				expect( mockSimulate ).not.toHaveBeenCalled();
 			} );
 
@@ -113,31 +113,43 @@ describe( 'SingleProductHandler', () => {
 		} );
 
 		describe( 'variation_id guard', () => {
-			test( 'rejects immediately when variation_id is empty', async () => {
-				document.body.innerHTML = `
+			// Falling back rather than rejecting is what lets the button render at
+			// all: the manager skips a button it has no transaction info for, and
+			// nothing re-runs that init when a variation is later chosen, so a
+			// rejection here removed Google Pay from the product for good.
+			// ProductButtonGate keeps the rendered button disabled, and
+			// onButtonClick() re-reads this method before opening the sheet.
+			test.each( [
+				[ 'empty', '' ],
+				[ '"0"', '0' ],
+			] )(
+				'falls back to the cart totals, without simulating, when variation_id is %s',
+				async ( _label, value ) => {
+					document.body.innerHTML = `
 					<form class="cart">
-						<input type="hidden" name="variation_id" value="" />
+						<input type="hidden" name="variation_id" value="${ value }" />
 					</form>
 				`;
 
-				await expect( handler.transactionInfo() ).rejects.toThrow(
-					'No variation selected.'
-				);
-				expect( mockSimulate ).not.toHaveBeenCalled();
-			} );
+					const fallback = Symbol( 'cart transaction info' );
+					const baseTransactionInfo = jest
+						.spyOn(
+							Object.getPrototypeOf(
+								Object.getPrototypeOf( handler )
+							),
+							'transactionInfo'
+						)
+						.mockResolvedValue( fallback );
 
-			test( 'rejects immediately when variation_id is "0"', async () => {
-				document.body.innerHTML = `
-					<form class="cart">
-						<input type="hidden" name="variation_id" value="0" />
-					</form>
-				`;
+					await expect( handler.transactionInfo() ).resolves.toBe(
+						fallback
+					);
+					expect( baseTransactionInfo ).toHaveBeenCalled();
+					expect( mockSimulate ).not.toHaveBeenCalled();
 
-				await expect( handler.transactionInfo() ).rejects.toThrow(
-					'No variation selected.'
-				);
-				expect( mockSimulate ).not.toHaveBeenCalled();
-			} );
+					baseTransactionInfo.mockRestore();
+				}
+			);
 
 			test( 'calls simulate_cart when variation_id is set', async () => {
 				document.body.innerHTML = `
@@ -184,7 +196,9 @@ describe( 'SingleProductHandler', () => {
 
 			test( 'resolves with TransactionInfo built from response data', async () => {
 				const mockTransactionInstance = { totalPrice: '45.00' };
-				TransactionInfo.mockImplementation( () => mockTransactionInstance );
+				TransactionInfo.mockImplementation(
+					() => mockTransactionInstance
+				);
 
 				mockSimulate.mockImplementation( ( onResolve ) =>
 					Promise.resolve(
@@ -199,12 +213,19 @@ describe( 'SingleProductHandler', () => {
 
 				const result = await handler.transactionInfo();
 
-				expect( TransactionInfo ).toHaveBeenCalledWith( 45, 5, 'USD', 'US' );
+				expect( TransactionInfo ).toHaveBeenCalledWith(
+					45,
+					5,
+					'USD',
+					'US'
+				);
 				expect( result ).toBe( mockTransactionInstance );
 			} );
 
 			test( 'propagates rejection from simulate_cart', async () => {
-				const serverError = { message: 'Error adding products to cart.' };
+				const serverError = {
+					message: 'Error adding products to cart.',
+				};
 				mockSimulate.mockRejectedValue( serverError );
 
 				await expect( handler.transactionInfo() ).rejects.toEqual(

--- a/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.js
+++ b/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.js
@@ -1,0 +1,102 @@
+/**
+ * Gates the product-page Google Pay button behind the native add-to-cart state.
+ *
+ * The v5 product bootstrap disables only its own wrapper, and this button's
+ * container is a sibling of it rather than a descendant (SmartButton::button_renderer()
+ * prints both inside .ppc-button-wrapper), so `.ppcp-disabled` never reaches it.
+ * Without this the button would sit enabled next to a disabled "Add to cart",
+ * offering a payment for a variable product with no variation chosen.
+ *
+ * @file
+ */
+
+import {
+	disable,
+	enable,
+	isDisabled,
+} from '@ppcp-button/Helper/ButtonDisabler';
+
+const FORM_SELECTOR = 'form.cart';
+
+// The native submit whose disabled state WooCommerce drives from the variation
+// selection. Its absence means nothing gates the purchase, so the button stays live.
+const ADD_TO_CART_SELECTOR = '.single_add_to_cart_button';
+
+// Attached once per page, however many times init is called.
+let initialized = false;
+
+/**
+ * Resets module state. Test seam only.
+ */
+export function resetProductButtonGate() {
+	initialized = false;
+}
+
+/**
+ * Starts gating the product-page Google Pay button.
+ *
+ * No-ops off the product page and on pages without a classic add-to-cart form,
+ * so it is safe to call unconditionally.
+ *
+ * @param {string} wrapperSelector - Selector of the button's container.
+ * @param {string} context         - The current page context.
+ */
+export function initProductButtonGate( wrapperSelector, context ) {
+	if ( 'product' !== context || initialized || ! wrapperSelector ) {
+		return;
+	}
+
+	const form = document.querySelector( FORM_SELECTOR );
+	if ( ! form ) {
+		return;
+	}
+
+	const shouldEnable = () => {
+		// Re-queried each time: WooCommerce re-renders the button as the
+		// variation selection changes.
+		const button = form.querySelector( ADD_TO_CART_SELECTOR );
+
+		return ! button || ! button.classList.contains( 'disabled' );
+	};
+
+	const sync = () => {
+		const wrapper = document.querySelector( wrapperSelector );
+		if ( ! wrapper ) {
+			return;
+		}
+
+		const enableNow = shouldEnable();
+		const wasDisabled = isDisabled( wrapper );
+
+		// Only act on a transition: disable() binds a fresh mouseup handler each
+		// call, so calling it twice without an intervening enable() would stack
+		// handlers and submit the form more than once.
+		if ( enableNow && wasDisabled ) {
+			enable( wrapper );
+		} else if ( ! enableNow && ! wasDisabled ) {
+			disable( wrapper, form );
+		}
+	};
+
+	initialized = true;
+
+	sync();
+
+	const addToCartButton = form.querySelector( ADD_TO_CART_SELECTOR );
+	if ( addToCartButton ) {
+		new MutationObserver( sync ).observe( form, {
+			subtree: true,
+			attributes: true,
+			attributeFilter: [ 'class' ],
+		} );
+	}
+
+	// Covers quantity changes and the attribute selects.
+	form.addEventListener( 'change', sync );
+
+	if ( window.jQuery ) {
+		// WooCommerce fills variation_id and flips the add-to-cart button only
+		// after these fire, so the change event above can run a beat too early.
+		window.jQuery( form ).on( 'found_variation reset_data', sync );
+	}
+}

--- a/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.test.js
+++ b/modules/ppcp-googlepay/resources/js/Helper/ProductButtonGate.test.js
@@ -1,0 +1,174 @@
+/* global jest, describe, test, expect, beforeEach, afterEach */
+
+import jQuery from 'jquery';
+
+// isDisabled() is backed by the wrapper's real class list, and disable()/enable()
+// mutate it the same way the real ButtonDisabler's `ppcp-disabled` class does, so
+// the module's own transition guard (isDisabled() vs the new state) is genuinely
+// exercised rather than assumed.
+const getElement = ( selectorOrElement ) =>
+	typeof selectorOrElement === 'string'
+		? document.querySelector( selectorOrElement )
+		: selectorOrElement;
+
+jest.mock( '@ppcp-button/Helper/ButtonDisabler', () => ( {
+	disable: jest.fn( ( selectorOrElement ) => {
+		getElement( selectorOrElement ).classList.add( 'ppcp-disabled' );
+	} ),
+	enable: jest.fn( ( selectorOrElement ) => {
+		getElement( selectorOrElement ).classList.remove( 'ppcp-disabled' );
+	} ),
+	isDisabled: jest.fn( ( selectorOrElement ) =>
+		getElement( selectorOrElement ).classList.contains( 'ppcp-disabled' )
+	),
+} ) );
+
+import { disable, enable } from '@ppcp-button/Helper/ButtonDisabler';
+import {
+	initProductButtonGate,
+	resetProductButtonGate,
+} from './ProductButtonGate';
+
+const WRAPPER_SELECTOR = '#ppc-button-googlepay-container';
+
+function renderPage( {
+	addToCartDisabled = false,
+	withAddToCart = true,
+} = {} ) {
+	document.body.innerHTML = `
+		<div id="ppc-button-googlepay-container"></div>
+		<form class="cart">
+			${
+				withAddToCart
+					? `<button type="submit" class="single_add_to_cart_button${
+							addToCartDisabled ? ' disabled' : ''
+					  }"></button>`
+					: ''
+			}
+		</form>
+	`;
+}
+
+function wrapperIsDisabled() {
+	return document
+		.querySelector( WRAPPER_SELECTOR )
+		.classList.contains( 'ppcp-disabled' );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	document.body.innerHTML = '';
+	resetProductButtonGate();
+	global.jQuery = jQuery;
+} );
+
+afterEach( () => {
+	delete global.jQuery;
+	document.body.innerHTML = '';
+} );
+
+describe( 'initProductButtonGate()', () => {
+	test.each( [ 'checkout', 'cart', undefined ] )(
+		'does nothing when context is %s, even with a disabled add-to-cart button',
+		( context ) => {
+			renderPage( { addToCartDisabled: true } );
+
+			initProductButtonGate( WRAPPER_SELECTOR, context );
+
+			expect( wrapperIsDisabled() ).toBe( false );
+			expect( disable ).not.toHaveBeenCalled();
+		}
+	);
+
+	test( 'does nothing when wrapperSelector is falsy', () => {
+		renderPage( { addToCartDisabled: true } );
+
+		initProductButtonGate( '', 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does nothing when there is no form.cart on the page', () => {
+		document.body.innerHTML = `<div id="ppc-button-googlepay-container"></div>`;
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+		expect( enable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'disables the wrapper on init when the add-to-cart button is disabled', () => {
+		renderPage( { addToCartDisabled: true } );
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( true );
+	} );
+
+	test( 'leaves the wrapper enabled on init when the add-to-cart button is not disabled', () => {
+		renderPage( { addToCartDisabled: false } );
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'leaves the wrapper enabled on init when there is no add-to-cart button at all', () => {
+		renderPage( { withAddToCart: false } );
+
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+		expect( disable ).not.toHaveBeenCalled();
+	} );
+
+	test( 'enables the wrapper once the disabled class is removed and the form changes, as when a shopper picks a variation', () => {
+		renderPage( { addToCartDisabled: true } );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		expect( wrapperIsDisabled() ).toBe( true );
+
+		document
+			.querySelector( '.single_add_to_cart_button' )
+			.classList.remove( 'disabled' );
+		document
+			.querySelector( 'form.cart' )
+			.dispatchEvent( new Event( 'change' ) );
+
+		expect( wrapperIsDisabled() ).toBe( false );
+	} );
+
+	test( 'disables the wrapper again once the disabled class returns and the form changes, as when the selection is cleared', () => {
+		renderPage( { addToCartDisabled: false } );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		expect( wrapperIsDisabled() ).toBe( false );
+
+		document
+			.querySelector( '.single_add_to_cart_button' )
+			.classList.add( 'disabled' );
+		document
+			.querySelector( 'form.cart' )
+			.dispatchEvent( new Event( 'change' ) );
+
+		expect( wrapperIsDisabled() ).toBe( true );
+	} );
+
+	test( 'a repeated init call does not double-attach: a single transition still disables only once', () => {
+		renderPage( { addToCartDisabled: false } );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		initProductButtonGate( WRAPPER_SELECTOR, 'product' );
+		disable.mockClear();
+
+		document
+			.querySelector( '.single_add_to_cart_button' )
+			.classList.add( 'disabled' );
+		document
+			.querySelector( 'form.cart' )
+			.dispatchEvent( new Event( 'change' ) );
+
+		expect( wrapperIsDisabled() ).toBe( true );
+		expect( disable ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/modules/ppcp-googlepay/resources/js/boot-block.js
+++ b/modules/ppcp-googlepay/resources/js/boot-block.js
@@ -29,7 +29,11 @@ const GooglePayComponent = ( { isEditing, buttonAttributes, onClick } ) => {
 				setGooglePayLoaded( true );
 			} );
 
-			ppcpConfig.url_params.components += ',googlepay';
+			// Absent when the v6 SDK owns the page: the v5 smart button is disabled
+			// there and localizes no script data.
+			if ( ppcpConfig.url_params ) {
+				ppcpConfig.url_params.components += ',googlepay';
+			}
 
 			loadPayPalScript( namespace, ppcpConfig )
 				.then( () => {

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -13,6 +13,7 @@ import GooglepayManager from './GooglepayManager';
 import { setupButtonEvents } from '@ppcp-button/Helper/ButtonRefreshHelper';
 import { CheckoutBootstrap } from './ContextBootstrap/CheckoutBootstrap';
 import moduleStorage from './Helper/GooglePayStorage';
+import { initProductButtonGate } from './Helper/ProductButtonGate';
 
 ( function ( { buttonConfig, ppcpConfig = {} } ) {
 	const context = ppcpConfig.context;
@@ -32,6 +33,8 @@ import moduleStorage from './Helper/GooglePayStorage';
 		setupButtonEvents( function () {
 			manager.reinit();
 		} );
+
+		initProductButtonGate( buttonConfig?.button?.wrapper, context );
 	}
 
 	function bootstrapCheckout() {

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -202,7 +202,20 @@ return array(
 			$container->get( 'googlepay.button' ),
 			$container->get( 'blocks.method' ),
 			$container->get( 'button.helper.context' ),
-			$container->get( 'settings.settings-provider' )
+			$container->get( 'settings.settings-provider' ),
+			/**
+			 * The v6 module is feature-flagged and may not be loaded, hence the has()
+			 * guard. Resolved on each call so it reflects the page being rendered.
+			 */
+			static function () use ( $container ): bool {
+				if ( ! $container->has( 'sdk-v6.owns-current-page' ) ) {
+					return false;
+				}
+
+				$owns_current_page = $container->get( 'sdk-v6.owns-current-page' );
+
+				return $owns_current_page();
+			}
 		);
 	},
 

--- a/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
@@ -25,6 +25,13 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private Context $context;
 	private SettingsProvider $settings_provider;
 
+	/**
+	 * Answers whether the SDK v6 module renders the PayPal stack on the current page.
+	 *
+	 * @var (callable():bool)|null
+	 */
+	private $v6_owns_current_page;
+
 	public function __construct(
 		string $name,
 		AssetGetter $asset_getter,
@@ -32,7 +39,8 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		ButtonInterface $button,
 		PaymentMethodTypeInterface $paypal_payment_method,
 		Context $context,
-		SettingsProvider $settings_provider
+		SettingsProvider $settings_provider,
+		?callable $v6_owns_current_page = null
 	) {
 		$this->name                  = $name;
 		$this->asset_getter          = $asset_getter;
@@ -41,11 +49,21 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		$this->paypal_payment_method = $paypal_payment_method;
 		$this->context               = $context;
 		$this->settings_provider     = $settings_provider;
+		$this->v6_owns_current_page  = $v6_owns_current_page;
 	}
 
 	public function initialize() {  }
 
 	public function is_active() {
+		/*
+		 * On a page the v6 SDK owns, the v5 smart button is swapped for a disabled
+		 * one whose script data is empty, and this block bundle reads that data
+		 * expecting the v5 shape. v6 renders Google Pay on those pages itself.
+		 */
+		if ( is_callable( $this->v6_owns_current_page ) && ( $this->v6_owns_current_page )() ) {
+			return false;
+		}
+
 		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
 
 		if ( ! in_array( GooglePayGateway::ID, $methods, true ) ) {

--- a/modules/ppcp-order-endpoints/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-order-endpoints/src/Helper/WooCommerceOrderCreator.php
@@ -113,6 +113,11 @@ class WooCommerceOrderCreator {
 			$this->configure_addresses( $wc_order, $payer, $shipping, $cart_data->needs_shipping() );
 			$this->configure_coupons( $wc_order, $cart_data->coupons() );
 
+			// Mirror WC_Checkout::create_order() so the order carries the cart hash. Downstream
+			// gates (e.g. the PayPal subscription replay guard) compare this against the hash
+			// captured at approval time; an unset hash makes a legitimate express purchase fail.
+			$wc_order->set_cart_hash( $cart_data->cart_hash() );
+
 			$wc_order->calculate_totals();
 			$wc_order->save();
 		} catch ( Exception $exception ) {

--- a/modules/ppcp-order-endpoints/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-order-endpoints/src/Helper/WooCommerceOrderCreator.php
@@ -276,6 +276,31 @@ class WooCommerceOrderCreator {
 			);
 		}
 
+		// Fall back to the logged-in customer's saved billing address when PayPal returned no
+		// payer address (common with shipping disabled / NO_SHIPPING, where the payer carries
+		// only an email). Without this the order and any subscription are left with an empty
+		// billing address even though the customer has one saved. Only fires when the payer
+		// billing address block is empty, so a valid PayPal address is never overwritten.
+		$has_billing_address = $billing_address
+			&& ( ! empty( $billing_address['address_1'] ) || ! empty( $billing_address['country'] ) );
+		if ( ! $has_billing_address
+			&& $wc_customer instanceof WC_Customer
+			&& $wc_customer->get_billing_address_1()
+		) {
+			$billing_address = array(
+				'email'      => ( $billing_address['email'] ?? '' ) ?: ( $wc_customer->get_billing_email() ?: '' ),
+				'first_name' => $wc_customer->get_billing_first_name(),
+				'last_name'  => $wc_customer->get_billing_last_name(),
+				'address_1'  => $wc_customer->get_billing_address_1(),
+				'address_2'  => $wc_customer->get_billing_address_2(),
+				'city'       => $wc_customer->get_billing_city(),
+				'state'      => $wc_customer->get_billing_state(),
+				'postcode'   => $wc_customer->get_billing_postcode(),
+				'country'    => $wc_customer->get_billing_country(),
+				'phone'      => $wc_customer->get_billing_phone(),
+			);
+		}
+
 		if ( $shipping ) {
 			$address = $shipping->address();
 			if ( $address ) {

--- a/modules/ppcp-sdk-v6/resources/css/checkout-block.scss
+++ b/modules/ppcp-sdk-v6/resources/css/checkout-block.scss
@@ -1,0 +1,19 @@
+// Widths for the express buttons on block pages.
+//
+// The v6 button Web Components are inline-block boxes of a fixed 225px, which
+// fits neither layout WooCommerce Blocks gives them: they under-fill the cart
+// block's column and overflow the checkout block's grid cell, clipping the
+// label. The wallets size themselves through the SDK and need nothing here.
+//
+// gateway.scss carries the same rule for the classic stack and the mini cart.
+// This file exists because SdkV6Manager::enqueue() deliberately skips block
+// pages, so their assets ship from V6PaymentMethod instead.
+
+.wc-block-components-express-payment__event-buttons {
+	paypal-button,
+	venmo-button,
+	paypal-pay-later-button {
+		display: block;
+		width: 100%;
+	}
+}

--- a/modules/ppcp-sdk-v6/resources/css/gateway.scss
+++ b/modules/ppcp-sdk-v6/resources/css/gateway.scss
@@ -22,3 +22,20 @@
 		width: 100%;
 	}
 }
+
+// Gating the express stack until the product form is ready to be purchased
+// (e.g. a variable product with no variation selected). The wrapper carries
+// this class from ButtonDisabler; the grayscale dims the whole stack and
+// pointer-events blocks every button so the click lands on the wrapper, whose
+// handler routes it to WooCommerce's native "select your options" validation.
+// v5 ships the same rule in ppcp-button's gateway.css, but that stylesheet is
+// not enqueued on v6 pages, so it is repeated here for the v6 stack.
+.ppcp-disabled {
+	cursor: not-allowed;
+	-webkit-filter: grayscale(100%);
+	filter: grayscale(100%);
+
+	* {
+		pointer-events: none;
+	}
+}

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldContainer.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldContainer.js
@@ -2,8 +2,8 @@
  * Renders one v6 card field into React.
  *
  * React owns an empty container and never reconciles the SDK-owned subtree:
- * the field element is appended imperatively and removed on cleanup, and is
- * recreated only when the session or field type changes.
+ * the field element and its label are appended imperatively and removed on
+ * cleanup, and are recreated only when the session or field type changes.
  *
  * @package
  */
@@ -11,13 +11,14 @@
 import { createElement, useEffect, useRef } from '@wordpress/element';
 
 /**
- * @param {Object} props                  - Component props.
- * @param {Object} props.session          - The v6 card-fields session.
- * @param {string} props.type             - The field type (number, expiry, cvv, name).
- * @param {Object} props.style            - The `style.input` object for the field.
- * @param {string} [props.height]         - CSS height for the field's own box.
- * @param {string} [props.placeholder]    - The field placeholder text.
- * @param {Object} [props.containerStyle] - Extra styles for the wrapper (e.g. flex sizing).
+ * @param {Object}  props                  - Component props.
+ * @param {Object}  props.session          - The v6 card-fields session.
+ * @param {string}  props.type             - The field type (number, expiry, cvv, name).
+ * @param {Object}  props.style            - The `style.input` object for the field.
+ * @param {string}  [props.height]         - CSS height for the field's own box.
+ * @param {string}  [props.label]          - The field's visible name.
+ * @param {boolean} [props.floatingLabel]  - Whether the page carries WooCommerce's floating-label CSS.
+ * @param {boolean} [props.isActive]       - Whether the field is focused or filled.
  * @return {Object} The container element.
  */
 export function V6CardFieldContainer( {
@@ -25,8 +26,9 @@ export function V6CardFieldContainer( {
 	type,
 	style,
 	height,
-	placeholder,
-	containerStyle,
+	label,
+	floatingLabel = false,
+	isActive = false,
 } ) {
 	const containerRef = useRef( null );
 
@@ -37,31 +39,62 @@ export function V6CardFieldContainer( {
 		}
 
 		const options = { type, style: { input: style } };
-		if ( placeholder ) {
-			options.placeholder = placeholder;
+		if ( label ) {
+			// A floating label covers the empty field, leaving no room
+			// for a placeholder; ariaLabel then carries the name.
+			if ( floatingLabel ) {
+				options.ariaLabel = label;
+			} else {
+				options.placeholder = label;
+			}
 		}
 
 		const field = session.createCardFieldsComponent( options );
-		// style.input only reaches the text inside the element, so its box is
-		// sized here or it keeps the SDK default (much taller than the form
-		// inputs) — hence height as its own prop rather than part of style.
+		// style.input only reaches the text inside the element. Its box keeps
+		// the SDK default height, much taller than the form inputs, unless
+		// sized here.
 		field.style.width = '100%';
 		if ( height ) {
 			field.style.height = height;
 		}
 		container.appendChild( field );
 
+		// WooCommerce's floating-label CSS expects the label after the input.
+		// It is aria-hidden: the hosted field is a cross-origin iframe with
+		// its own aria-label.
+		let labelElement = null;
+		if ( floatingLabel && label ) {
+			labelElement = document.createElement( 'label' );
+			labelElement.className = 'ppcp-sdk-v6-card-field__label';
+			labelElement.textContent = label;
+			labelElement.setAttribute( 'aria-hidden', 'true' );
+			container.appendChild( labelElement );
+		}
+
 		return () => {
 			field.remove();
+			if ( labelElement ) {
+				labelElement.remove();
+			}
 		};
-		// style, height and placeholder are captured at mount: depending on them
-		// would recreate the field on every render.
+		// Everything but session and type is captured at mount: depending on
+		// it would recreate the field on every render.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ session, type ] );
 
+	const classNames = [
+		'ppcp-sdk-v6-card-field',
+		`ppcp-sdk-v6-card-field--${ type }`,
+	];
+	if ( floatingLabel ) {
+		classNames.push( 'wc-block-components-text-input' );
+		if ( isActive ) {
+			classNames.push( 'is-active' );
+		}
+	}
+
 	return createElement( 'div', {
 		ref: containerRef,
-		className: `ppcp-sdk-v6-card-field ppcp-sdk-v6-card-field--${ type }`,
-		style: containerStyle,
+		className: classNames.join( ' ' ),
 	} );
 }

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -31,6 +31,11 @@ import { V6CardFieldContainer } from './V6CardFieldContainer';
 import { amountFromBilling } from '../utils/amount';
 import { isFreeTrialCart } from '../utils/freeTrial';
 import { hasCheckoutValidationErrors } from './checkoutValidation';
+import {
+	CARD_DECLINE_MESSAGE,
+	CARD_SAVE_DECLINE_MESSAGE,
+	userFacingMessage,
+} from '../utils/cardDeclineMessages';
 
 const CHECKOUT_FIELDS_NOT_VALID_MESSAGE = __(
 	'Please complete all required checkout fields before continuing with payment.',
@@ -97,10 +102,7 @@ async function submitCardPayment( {
 		if ( result.state !== 'succeeded' ) {
 			return {
 				type: responseTypes.ERROR,
-				message: __(
-					'Card payment failed.',
-					'woocommerce-paypal-payments'
-				),
+				message: CARD_DECLINE_MESSAGE,
 			};
 		}
 
@@ -110,9 +112,7 @@ async function submitCardPayment( {
 	} catch ( error ) {
 		return {
 			type: responseTypes.ERROR,
-			message:
-				error?.message ||
-				__( 'Card payment failed.', 'woocommerce-paypal-payments' ),
+			message: userFacingMessage( error, CARD_DECLINE_MESSAGE ),
 		};
 	}
 }
@@ -173,10 +173,7 @@ async function submitCardSave( { config, session, responseTypes } ) {
 		if ( result.state !== 'succeeded' ) {
 			return {
 				type: responseTypes.ERROR,
-				message: __(
-					'Card could not be saved.',
-					'woocommerce-paypal-payments'
-				),
+				message: CARD_SAVE_DECLINE_MESSAGE,
 			};
 		}
 
@@ -186,9 +183,7 @@ async function submitCardSave( { config, session, responseTypes } ) {
 	} catch ( error ) {
 		return {
 			type: responseTypes.ERROR,
-			message:
-				error?.message ||
-				__( 'Card could not be saved.', 'woocommerce-paypal-payments' ),
+			message: userFacingMessage( error, CARD_SAVE_DECLINE_MESSAGE ),
 		};
 	}
 }
@@ -211,7 +206,8 @@ export function V6CardFieldsComponent( {
 	shouldSavePayment,
 	billing,
 } ) {
-	const { onPaymentSetup, onCheckoutValidation } = eventRegistration;
+	const { onPaymentSetup, onCheckoutValidation, onCheckoutFail } =
+		eventRegistration;
 	const { responseTypes } = emitResponse;
 
 	const context = config.page_context;
@@ -367,6 +363,28 @@ export function V6CardFieldsComponent( {
 			return true;
 		} );
 	}, [ onCheckoutValidation, activePaymentMethod, methodId, responseTypes ] );
+
+	// The Store API clears the gateway's notices and Blocks ignores the
+	// errorMessage it returns, so a decline raised during process_payment
+	// reaches the shopper as WooCommerce's generic string unless it is put
+	// back here.
+	useEffect( () => {
+		if (
+			activePaymentMethod !== methodId ||
+			typeof onCheckoutFail !== 'function'
+		) {
+			return undefined;
+		}
+
+		return onCheckoutFail( ( { processingResponse } ) => {
+			const message = processingResponse?.paymentDetails?.errorMessage;
+			if ( ! message ) {
+				return true;
+			}
+
+			return { type: responseTypes.ERROR, message };
+		} );
+	}, [ onCheckoutFail, activePaymentMethod, methodId, responseTypes ] );
 
 	const fieldsReady = session && inputStyle && textStyle;
 

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -42,6 +42,23 @@ const CHECKOUT_FIELDS_NOT_VALID_MESSAGE = __(
 	'woocommerce-paypal-payments'
 );
 
+const FIELD_LABELS = {
+	number: __( 'Card number', 'woocommerce-paypal-payments' ),
+	expiry: __( 'Expiry (MM/YY)', 'woocommerce-paypal-payments' ),
+	cvv: __( 'CVV', 'woocommerce-paypal-payments' ),
+};
+
+const CARD_NAME_LABEL = __(
+	'Cardholder name (optional)',
+	'woocommerce-paypal-payments'
+);
+
+// Each event payload carries the state of all three fields, so these four
+// events keep every label in sync.
+const FIELD_STATE_EVENTS = [ 'focus', 'blur', 'empty', 'notempty' ];
+
+const NAME_FIELD_ID = 'ppcp-sdk-v6-card-name';
+
 /**
  * Creates the order, confirms it through the card session (which runs 3D
  * Secure), approves it, and maps the outcome to a Blocks onPaymentSetup
@@ -224,6 +241,9 @@ export function V6CardFieldsComponent( {
 	const [ inputStyle, setInputStyle ] = useState( null );
 	const [ textStyle, setTextStyle ] = useState( null );
 	const [ cardName, setCardName ] = useState( '' );
+	const [ nameFocused, setNameFocused ] = useState( false );
+	const [ floatingLabel, setFloatingLabel ] = useState( false );
+	const [ fieldStates, setFieldStates ] = useState( {} );
 	const referenceRef = useRef( null );
 
 	// The choice comes from WC Blocks' native "Save payment information…"
@@ -283,14 +303,61 @@ export function V6CardFieldsComponent( {
 	// decoration has no business.
 	const cardFieldOverrides = config.card_fields.styles;
 	useEffect( () => {
-		const source =
-			document.querySelector( '.wc-block-components-text-input input' ) ||
-			referenceRef.current;
+		const blockInput = document.querySelector(
+			'.wc-block-components-text-input input'
+		);
+		const source = blockInput || referenceRef.current;
+
+		// A Blocks text input on the page means its floating-label CSS is
+		// loaded. Without one, the fields fall back to plain placeholders.
+		setFloatingLabel( Boolean( blockInput ) );
+
 		if ( source ) {
 			setInputStyle( cardFieldStyles( source ) );
 			setTextStyle( hostedFieldTextStyles( source, cardFieldOverrides ) );
 		}
 	}, [ cardFieldOverrides ] );
+
+	// Mirrors the SDK's field state onto the wrappers so WooCommerce's CSS can
+	// float each label.
+	useEffect( () => {
+		if ( ! session || ! floatingLabel ) {
+			return undefined;
+		}
+
+		let listening = true;
+		const handler = ( payload ) => {
+			if ( ! listening || ! payload?.data ) {
+				return;
+			}
+
+			const { number, expiry, cvv } = payload.data;
+			setFieldStates( { number, expiry, cvv } );
+		};
+
+		// The session exposes no per-listener removal, only destroy(), so this
+		// flag is what stops a late event from reaching an unmounted component.
+		FIELD_STATE_EVENTS.forEach( ( event ) => {
+			Promise.resolve( session.on( event, handler ) ).catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'[PPCP SDK v6] card field event not available',
+					event,
+					error
+				);
+			} );
+		} );
+
+		return () => {
+			listening = false;
+		};
+	}, [ session, floatingLabel ] );
+
+	// WooCommerce floats a label once its field is focused or filled.
+	const isFieldActive = ( type ) => {
+		const state = fieldStates[ type ];
+		return Boolean( state && ( state.isFocused || ! state.isEmpty ) );
+	};
 
 	const sessionRef = useLatestRef( session );
 
@@ -386,13 +453,21 @@ export function V6CardFieldsComponent( {
 		} );
 	}, [ onCheckoutFail, activePaymentMethod, methodId, responseTypes ] );
 
+	const nameFieldClassName = [
+		'ppcp-sdk-v6-card-field',
+		'ppcp-sdk-v6-card-field--name',
+		floatingLabel && 'wc-block-components-text-input',
+		floatingLabel && ( nameFocused || cardName !== '' ) && 'is-active',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
 	const fieldsReady = session && inputStyle && textStyle;
 
 	return createElement(
 		'div',
 		{
 			className: 'ppcp-sdk-v6-card-fields',
-			style: { display: 'flex', flexDirection: 'column', gap: '16px' },
 		},
 		// Off-screen rather than display:none, which would make getComputedStyle
 		// return nothing.
@@ -419,56 +494,60 @@ export function V6CardFieldsComponent( {
 					createElement(
 						'div',
 						{
-							className:
-								'ppcp-sdk-v6-card-field ppcp-sdk-v6-card-field--name',
+							className: nameFieldClassName,
 						},
 						createElement( 'input', {
+							id: NAME_FIELD_ID,
 							type: 'text',
 							className: 'input-text',
 							value: cardName,
 							onChange: ( event ) =>
 								setCardName( event.target.value ),
-							placeholder: __(
-								'Cardholder name (optional)',
-								'woocommerce-paypal-payments'
-							),
+							onFocus: () => setNameFocused( true ),
+							onBlur: () => setNameFocused( false ),
+							placeholder: floatingLabel
+								? undefined
+								: CARD_NAME_LABEL,
 							style: { width: '100%', ...inputStyle },
-						} )
+						} ),
+						// A real input, so this label uses for/id where the
+						// hosted fields' labels are aria-hidden.
+						floatingLabel &&
+							createElement(
+								'label',
+								{ htmlFor: NAME_FIELD_ID },
+								CARD_NAME_LABEL
+							)
 					),
 				createElement( V6CardFieldContainer, {
 					session,
 					type: 'number',
 					style: textStyle,
 					height: inputStyle.height,
-					placeholder: __(
-						'Card number',
-						'woocommerce-paypal-payments'
-					),
+					label: FIELD_LABELS.number,
+					floatingLabel,
+					isActive: isFieldActive( 'number' ),
 				} ),
 				createElement(
 					'div',
-					{
-						className: 'ppcp-sdk-v6-card-fields__row',
-						style: { display: 'flex', gap: '16px' },
-					},
+					{ className: 'ppcp-sdk-v6-card-fields__row' },
 					createElement( V6CardFieldContainer, {
 						session,
 						type: 'expiry',
 						style: textStyle,
 						height: inputStyle.height,
-						placeholder: __(
-							'MM / YY',
-							'woocommerce-paypal-payments'
-						),
-						containerStyle: { flex: 1 },
+						label: FIELD_LABELS.expiry,
+						floatingLabel,
+						isActive: isFieldActive( 'expiry' ),
 					} ),
 					createElement( V6CardFieldContainer, {
 						session,
 						type: 'cvv',
 						style: textStyle,
 						height: inputStyle.height,
-						placeholder: __( 'CVV', 'woocommerce-paypal-payments' ),
-						containerStyle: { flex: 1 },
+						label: FIELD_LABELS.cvv,
+						floatingLabel,
+						isActive: isFieldActive( 'cvv' ),
 					} )
 				)
 			),

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -39,6 +39,18 @@ import {
 import '@testing-library/jest-dom';
 import { createElement } from '@wordpress/element';
 import { V6CardFieldsComponent } from './V6CardFieldsComponent';
+const { V6CardFieldContainer: ActualV6CardFieldContainer } = jest.requireActual(
+	'./V6CardFieldContainer'
+);
+
+// The component detects floating-label support by querying for this markup.
+function appendFloatingLabelMarker() {
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'wc-block-components-text-input';
+	wrapper.appendChild( document.createElement( 'input' ) );
+	document.body.appendChild( wrapper );
+	return wrapper;
+}
 
 function cardConfig( overrides = {} ) {
 	return {
@@ -149,6 +161,7 @@ beforeEach( () => {
 			document.createElement( 'div' )
 		),
 		submit: jest.fn(),
+		on: jest.fn(),
 	};
 
 	mockLoadSdkV6.mockReset().mockResolvedValue( {
@@ -199,6 +212,18 @@ describe( 'V6CardFieldsComponent', () => {
 		await waitForSessionReady();
 
 		expect( onPaymentSetup ).toHaveBeenCalled();
+	} );
+
+	test( 'the root container and the expiry/CVV row carry the class hooks the stylesheet spacing depends on', async () => {
+		renderComponent();
+		await waitForSessionReady();
+
+		expect(
+			document.querySelector( '.ppcp-sdk-v6-card-fields' )
+		).toBeInTheDocument();
+		expect(
+			document.querySelector( '.ppcp-sdk-v6-card-fields__row' )
+		).toBeInTheDocument();
 	} );
 
 	test( 'a pending checkout validation error blocks the card submission before an order is created', async () => {
@@ -530,6 +555,25 @@ describe( 'V6CardFieldsComponent', () => {
 		expect( types ).toContain( 'number' );
 	} );
 
+	test( 'keeps the plain placeholder and passes floatingLabel false to each field when no Blocks text-input markup is on the page', async () => {
+		renderComponent();
+		await waitForSessionReady();
+
+		[ 'number', 'expiry', 'cvv' ].forEach( ( type ) => {
+			const call = mockCardFieldContainer.mock.calls.find(
+				( c ) => c[ 0 ].type === type
+			);
+			expect( call[ 0 ].floatingLabel ).toBe( false );
+		} );
+
+		expect(
+			screen.getByPlaceholderText( 'Cardholder name (optional)' )
+		).toBeInTheDocument();
+		expect(
+			document.querySelector( 'label[for="ppcp-sdk-v6-card-name"]' )
+		).not.toBeInTheDocument();
+	} );
+
 	test( 'forwards the typed cardholder name to createCardOrder on submit', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
@@ -766,5 +810,257 @@ describe( 'V6CardFieldsComponent', () => {
 			).toBe( true );
 		} );
 	} );
+
+	describe( 'floating-label mode (Blocks text-input markup present)', () => {
+		let marker;
+
+		beforeEach( () => {
+			marker = appendFloatingLabelMarker();
+		} );
+
+		afterEach( () => {
+			marker.remove();
+		} );
+
+		function lastCallFor( type ) {
+			const calls = mockCardFieldContainer.mock.calls.filter(
+				( call ) => call[ 0 ].type === type
+			);
+			return calls[ calls.length - 1 ][ 0 ];
+		}
+
+		test( 'passes floatingLabel true to each V6CardFieldContainer', async () => {
+			renderComponent();
+			await waitForSessionReady();
+
+			expect( lastCallFor( 'number' ).floatingLabel ).toBe( true );
+			expect( lastCallFor( 'expiry' ).floatingLabel ).toBe( true );
+			expect( lastCallFor( 'cvv' ).floatingLabel ).toBe( true );
+		} );
+
+		test( 'subscribes to focus, blur, empty and notempty on the card session', async () => {
+			renderComponent();
+			await waitForSessionReady();
+
+			await waitFor( () =>
+				expect(
+					session.on.mock.calls.map( ( call ) => call[ 0 ] )
+				).toEqual(
+					expect.arrayContaining( [
+						'focus',
+						'blur',
+						'empty',
+						'notempty',
+					] )
+				)
+			);
+		} );
+
+		describe( 'is-active derivation from the session event payload', () => {
+			function fieldState( overrides ) {
+				return {
+					isEmpty: true,
+					isFocused: false,
+					isPotentiallyValid: true,
+					isValid: false,
+					...overrides,
+				};
+			}
+
+			test.each( [
+				[
+					'a focused but still empty field',
+					fieldState( { isFocused: true, isEmpty: true } ),
+					true,
+				],
+				[
+					'a blurred field that already holds a value',
+					fieldState( { isFocused: false, isEmpty: false } ),
+					true,
+				],
+				[
+					'a blurred, empty field',
+					fieldState( { isFocused: false, isEmpty: true } ),
+					false,
+				],
+			] )(
+				'marks the wrapper active=%p for %s',
+				async ( _label, numberState, expectedActive ) => {
+					renderComponent();
+					await waitForSessionReady();
+
+					await waitFor( () =>
+						expect( session.on ).toHaveBeenCalled()
+					);
+					const handler = session.on.mock.calls[ 0 ][ 1 ];
+
+					act( () => {
+						handler( {
+							data: {
+								cards: [],
+								emittedBy: 'number',
+								number: numberState,
+								expiry: fieldState(),
+								cvv: fieldState(),
+							},
+							instanceId: 'instance-1',
+							sender: 'number',
+						} );
+					} );
+
+					expect( lastCallFor( 'number' ).isActive ).toBe(
+						expectedActive
+					);
+				}
+			);
+		} );
+
+		describe( 'cardholder name field', () => {
+			test( 'the label is associated with the input via for/id', async () => {
+				renderComponent();
+				await waitForSessionReady();
+
+				const input = screen.getByLabelText(
+					'Cardholder name (optional)'
+				);
+				expect( input ).toHaveAttribute(
+					'id',
+					'ppcp-sdk-v6-card-name'
+				);
+			} );
+
+			test( 'the wrapper carries the Blocks text-input class the stylesheet margin rule targets', async () => {
+				renderComponent();
+				await waitForSessionReady();
+
+				const input = screen.getByLabelText(
+					'Cardholder name (optional)'
+				);
+				const wrapper = input.closest( 'div' );
+
+				expect( wrapper ).toHaveClass(
+					'wc-block-components-text-input'
+				);
+			} );
+
+			test( 'the wrapper becomes active on focus and stays active once the field holds a value', async () => {
+				renderComponent();
+				await waitForSessionReady();
+
+				const input = screen.getByLabelText(
+					'Cardholder name (optional)'
+				);
+				const wrapper = input.closest( 'div' );
+
+				expect( wrapper ).not.toHaveClass( 'is-active' );
+
+				fireEvent.focus( input );
+				expect( wrapper ).toHaveClass( 'is-active' );
+
+				fireEvent.blur( input );
+				expect( wrapper ).not.toHaveClass( 'is-active' );
+
+				fireEvent.change( input, {
+					target: { value: 'Jane Doe' },
+				} );
+				fireEvent.blur( input );
+				expect( wrapper ).toHaveClass( 'is-active' );
+			} );
+		} );
+	} );
 } );
 
+describe( 'V6CardFieldContainer', () => {
+	function containerSession( fieldElement ) {
+		return {
+			createCardFieldsComponent: jest.fn(
+				() => fieldElement || document.createElement( 'div' )
+			),
+		};
+	}
+
+	test( 'in fallback mode, the SDK receives a placeholder, not an aria-label, and no label element is appended', () => {
+		const session = containerSession();
+
+		const { container } = render(
+			createElement( ActualV6CardFieldContainer, {
+				session,
+				type: 'number',
+				style: {},
+				label: 'Card number',
+			} )
+		);
+
+		expect( session.createCardFieldsComponent ).toHaveBeenCalledWith(
+			expect.objectContaining( { placeholder: 'Card number' } )
+		);
+		expect(
+			session.createCardFieldsComponent.mock.calls[ 0 ][ 0 ]
+		).not.toHaveProperty( 'ariaLabel' );
+		expect( container.firstChild ).not.toHaveClass(
+			'wc-block-components-text-input'
+		);
+		expect( container.querySelector( 'label' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'in floating-label mode, the SDK receives an aria-label, the wrapper gets the Blocks class, and an aria-hidden label is appended after the field', () => {
+		const field = document.createElement( 'div' );
+		const session = containerSession( field );
+
+		const { container } = render(
+			createElement( ActualV6CardFieldContainer, {
+				session,
+				type: 'number',
+				style: {},
+				label: 'Card number',
+				floatingLabel: true,
+			} )
+		);
+
+		expect( session.createCardFieldsComponent ).toHaveBeenCalledWith(
+			expect.objectContaining( { ariaLabel: 'Card number' } )
+		);
+		expect(
+			session.createCardFieldsComponent.mock.calls[ 0 ][ 0 ]
+		).not.toHaveProperty( 'placeholder' );
+
+		const wrapper = container.firstChild;
+		expect( wrapper ).toHaveClass( 'wc-block-components-text-input' );
+
+		expect( wrapper.children[ 0 ] ).toBe( field );
+
+		const label = wrapper.querySelector( 'label' );
+		expect( label ).toHaveTextContent( 'Card number' );
+		expect( label ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( label ).toHaveClass( 'ppcp-sdk-v6-card-field__label' );
+		expect( wrapper.lastChild ).toBe( label );
+	} );
+
+	test.each( [
+		[ true, true ],
+		[ false, false ],
+	] )(
+		'the wrapper is-active class follows the isActive prop (%p) in floating-label mode',
+		( isActive, expectActive ) => {
+			const session = containerSession();
+
+			const { container } = render(
+				createElement( ActualV6CardFieldContainer, {
+					session,
+					type: 'number',
+					style: {},
+					floatingLabel: true,
+					isActive,
+				} )
+			);
+
+			if ( expectActive ) {
+				expect( container.firstChild ).toHaveClass( 'is-active' );
+			} else {
+				expect( container.firstChild ).not.toHaveClass(
+					'is-active'
+				);
+			}
+		}
+	);
+} );

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -63,6 +63,8 @@ let onPaymentSetup;
 let paymentSetupCb;
 let onCheckoutValidation;
 let checkoutValidationCb;
+let onCheckoutFail;
+let checkoutFailCb;
 let hasValidationErrors;
 let eventRegistration;
 let session;
@@ -101,6 +103,10 @@ async function waitForCheckoutValidationReady() {
 	await waitFor( () => expect( checkoutValidationCb ).not.toBeNull() );
 }
 
+async function waitForCheckoutFailReady() {
+	await waitFor( () => expect( checkoutFailCb ).not.toBeNull() );
+}
+
 beforeEach( () => {
 	paymentSetupCb = null;
 	onPaymentSetup = jest.fn( ( cb ) => {
@@ -112,7 +118,16 @@ beforeEach( () => {
 		checkoutValidationCb = cb;
 		return () => {};
 	} );
-	eventRegistration = { onPaymentSetup, onCheckoutValidation };
+	checkoutFailCb = null;
+	onCheckoutFail = jest.fn( ( cb ) => {
+		checkoutFailCb = cb;
+		return () => {};
+	} );
+	eventRegistration = {
+		onPaymentSetup,
+		onCheckoutValidation,
+		onCheckoutFail,
+	};
 
 	hasValidationErrors = false;
 	global.wp = {
@@ -378,7 +393,7 @@ describe( 'V6CardFieldsComponent', () => {
 		);
 	} );
 
-	test( 'reports an error and skips approval when 3D Secure is canceled', async () => {
+	test( 'reports the "authentication not completed" message and skips approval when 3D Secure is canceled', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'canceled' } );
 
@@ -390,12 +405,14 @@ describe( 'V6CardFieldsComponent', () => {
 			result = await paymentSetupCb();
 		} );
 
-		expect( result.type ).toBe( 'error' );
-		expect( result.message ).toBeTruthy();
+		expect( result ).toEqual( {
+			type: 'error',
+			message: 'Card authentication was not completed. Please try again.',
+		} );
 		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
 	} );
 
-	test( 'reports an error and skips approval when the card payment fails', async () => {
+	test( 'reports the friendly decline message and skips approval when the card payment does not succeed', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'failed' } );
 
@@ -407,13 +424,17 @@ describe( 'V6CardFieldsComponent', () => {
 			result = await paymentSetupCb();
 		} );
 
-		expect( result.type ).toBe( 'error' );
+		expect( result ).toEqual( {
+			type: 'error',
+			message:
+				'This card could not be authorized. Please try a different payment method.',
+		} );
 		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
 	} );
 
-	test( 'reports the thrown error message when creating the order fails', async () => {
+	test( 'shows the friendly decline message instead of leaking a thrown error that is not marked user-facing', async () => {
 		mockCreateCardOrder.mockRejectedValueOnce(
-			new Error( 'nonce expired' )
+			new Error( 'PayPal SDK internal failure XYZ' )
 		);
 
 		renderComponent();
@@ -424,7 +445,30 @@ describe( 'V6CardFieldsComponent', () => {
 			result = await paymentSetupCb();
 		} );
 
-		expect( result ).toEqual( { type: 'error', message: 'nonce expired' } );
+		expect( result ).toEqual( {
+			type: 'error',
+			message:
+				'This card could not be authorized. Please try a different payment method.',
+		} );
+	} );
+
+	test( 'shows a thrown error verbatim when it is marked user-facing', async () => {
+		const userFacing = new Error( 'Your card was declined by the bank.' );
+		userFacing.isUserFacing = true;
+		mockCreateCardOrder.mockRejectedValueOnce( userFacing );
+
+		renderComponent();
+		await waitForSessionReady();
+
+		let result;
+		await act( async () => {
+			result = await paymentSetupCb();
+		} );
+
+		expect( result ).toEqual( {
+			type: 'error',
+			message: 'Your card was declined by the bank.',
+		} );
 	} );
 
 	test( "passes the reference input's height to each V6CardFieldContainer via its own height prop, not inside style", async () => {
@@ -610,7 +654,7 @@ describe( 'V6CardFieldsComponent', () => {
 			expect( result ).toEqual( { type: 'success' } );
 		} );
 
-		test( 'reports an error and skips the exchange when 3D Secure is canceled', async () => {
+		test( 'reports the "authentication not completed" message and skips the exchange when 3D Secure is canceled', async () => {
 			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
 			session.submit.mockResolvedValueOnce( { state: 'canceled' } );
 
@@ -622,12 +666,15 @@ describe( 'V6CardFieldsComponent', () => {
 				result = await paymentSetupCb();
 			} );
 
-			expect( result.type ).toBe( 'error' );
-			expect( result.message ).toBeTruthy();
+			expect( result ).toEqual( {
+				type: 'error',
+				message:
+					'Card authentication was not completed. Please try again.',
+			} );
 			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
 		} );
 
-		test( 'reports an error and skips the exchange when the save session fails', async () => {
+		test( 'reports the friendly decline message and skips the exchange when the save session does not succeed', async () => {
 			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
 			session.submit.mockResolvedValueOnce( { state: 'failed' } );
 
@@ -639,15 +686,19 @@ describe( 'V6CardFieldsComponent', () => {
 				result = await paymentSetupCb();
 			} );
 
-			expect( result.type ).toBe( 'error' );
+			expect( result ).toEqual( {
+				type: 'error',
+				message:
+					'This card could not be authorized. Please try a different card.',
+			} );
 			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
 		} );
 
-		test( 'reports the thrown error message when the token exchange fails', async () => {
+		test( 'shows the friendly save-decline message instead of leaking a thrown error that is not marked user-facing', async () => {
 			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
 			session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
 			mockExchangeSetupToken.mockRejectedValueOnce(
-				new Error( 'exchange failed' )
+				new Error( 'internal exchange error' )
 			);
 
 			renderComponent( { config: freeTrialConfig() } );
@@ -660,8 +711,60 @@ describe( 'V6CardFieldsComponent', () => {
 
 			expect( result ).toEqual( {
 				type: 'error',
-				message: 'exchange failed',
+				message:
+					'This card could not be authorized. Please try a different card.',
+			} );
+		} );
+
+		test( 'shows a thrown error verbatim when it is marked user-facing', async () => {
+			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
+			session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+			const userFacing = new Error( 'This card is already saved.' );
+			userFacing.isUserFacing = true;
+			mockExchangeSetupToken.mockRejectedValueOnce( userFacing );
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( result ).toEqual( {
+				type: 'error',
+				message: 'This card is already saved.',
 			} );
 		} );
 	} );
+
+	describe( 'onCheckoutFail observer', () => {
+		test( 'surfaces the gateway decline message from processingResponse when present', async () => {
+			renderComponent();
+			await waitForCheckoutFailReady();
+
+			const result = checkoutFailCb( {
+				processingResponse: {
+					paymentDetails: {
+						errorMessage: 'Card declined during capture.',
+					},
+				},
+			} );
+
+			expect( result ).toEqual( {
+				type: 'error',
+				message: 'Card declined during capture.',
+			} );
+		} );
+
+		test( 'returns true, leaving the default checkout error, when no gateway error message is present', async () => {
+			renderComponent();
+			await waitForCheckoutFailReady();
+
+			expect(
+				checkoutFailCb( { processingResponse: {} } )
+			).toBe( true );
+		} );
+	} );
 } );
+

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -31,6 +31,7 @@ import { initCardFields } from './cardFields/renderer';
 import { initCardButton } from './cardButton/renderCardButton';
 import { hasJQuery } from './utils/api';
 import { watchViewedTotal } from './utils/viewedTotal';
+import { initProductButtonGate } from './utils/productButtonGate';
 import { setErrorLabels } from './utils/errorHandler';
 import { isFreeTrialCart } from './utils/freeTrial';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
@@ -452,6 +453,7 @@ const ELIGIBILITY_REFRESH_DEBOUNCE_MS = 300;
 		initCardButtonSafely();
 		initMessagesSafely();
 		trackProductTotal();
+		initProductButtonGate( config );
 		syncPlaceOrderButton();
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
@@ -12,6 +12,72 @@ import { hide } from '@ppcp-button/Helper/Hiding';
 import { hostedFieldTextStyles } from './cardFieldStyles';
 
 /**
+ * Reads the input's rendered height, briefly undoing the hiding applied here.
+ *
+ * getComputedStyle() resolves height to pixels only for an element that has a
+ * layout box, and yields the literal "auto" otherwise. Showing and restoring
+ * happen within one task, so nothing is painted in between. display is set
+ * directly rather than through show()/hide(), which broadcast jQuery events
+ * other code listens for.
+ *
+ * @param {HTMLElement} inputField - The WC input being replaced.
+ * @return {string|null} The height in pixels, or null when it has no box.
+ */
+function measureHeight( inputField ) {
+	const wasHidden = inputField.hidden;
+	const display = inputField.style.getPropertyValue( 'display' );
+	const priority = inputField.style.getPropertyPriority( 'display' );
+
+	inputField.hidden = false;
+	inputField.style.removeProperty( 'display' );
+
+	const height = window.getComputedStyle( inputField ).height;
+
+	if ( display ) {
+		inputField.style.setProperty( 'display', display, priority );
+	}
+	inputField.hidden = wasHidden;
+
+	return height.endsWith( 'px' ) ? height : null;
+}
+
+/**
+ * Sizes the field to the input it replaced, correcting later when the form is
+ * not on screen yet.
+ *
+ * WooCommerce keeps the new-card form display:none while a saved payment token
+ * is selected, so a field mounted there has no layout box and measures as auto.
+ * The observer applies the height once the form is revealed. Nothing in the
+ * payment flow depends on the height being correct.
+ *
+ * @param {HTMLElement} fieldElement - The mounted v6 field.
+ * @param {HTMLElement} inputField   - The WC input being replaced.
+ */
+function applyHeight( fieldElement, inputField ) {
+	const height = measureHeight( inputField );
+	if ( height ) {
+		fieldElement.style.height = height;
+		return;
+	}
+
+	if ( typeof ResizeObserver !== 'function' ) {
+		return;
+	}
+
+	const observer = new ResizeObserver( () => {
+		const corrected = measureHeight( inputField );
+		if ( ! corrected ) {
+			return;
+		}
+
+		// Disconnect first: the write below resizes the observed element.
+		observer.disconnect();
+		fieldElement.style.height = corrected;
+	} );
+	observer.observe( fieldElement );
+}
+
+/**
  * Replaces a WC card input with its hosted v6 field, hiding the original.
  *
  * The element v6 returns is ours to size: `style.input` only reaches the text
@@ -51,9 +117,10 @@ export function mountField(
 		`ppcp-sdk-v6-card-field--${ fieldType }`
 	);
 	fieldElement.style.width = '100%';
-	fieldElement.style.height = window.getComputedStyle( inputField ).height;
 
 	inputField.parentNode.appendChild( fieldElement );
+	applyHeight( fieldElement, inputField );
+
 	hide( inputField, true );
 	inputField.hidden = true;
 }

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -24,6 +24,11 @@ import {
 import { hasJQuery } from '../utils/api';
 import { handleError } from '../utils/errorHandler';
 import { isFreeTrialCart } from '../utils/freeTrial';
+import {
+	CARD_DECLINE_MESSAGE,
+	CARD_SAVE_DECLINE_MESSAGE,
+	userFacingError,
+} from '../utils/cardDeclineMessages';
 
 const FIELD_TYPES = [ 'number', 'expiry', 'cvv' ];
 
@@ -230,7 +235,7 @@ export async function initCardFields( config, getTotal = () => undefined ) {
 					return;
 				}
 				if ( saveResult.state !== 'succeeded' ) {
-					throw new Error( 'Card could not be saved.' );
+					throw userFacingError( CARD_SAVE_DECLINE_MESSAGE );
 				}
 
 				await exchangeSetupToken( config, setupTokenId );
@@ -258,7 +263,7 @@ export async function initCardFields( config, getTotal = () => undefined ) {
 			}
 
 			if ( result.state !== 'succeeded' ) {
-				throw new Error( 'Card payment failed.' );
+				throw userFacingError( CARD_DECLINE_MESSAGE );
 			}
 
 			await approveCardOrder( config, orderId );

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
@@ -16,6 +16,10 @@ import { loadSdkV6 } from '../sdkLoader';
 import { postJson } from '../utils/api';
 import { handleError } from '../utils/errorHandler';
 import { navigation } from '../utils/navigation';
+import {
+	CARD_SAVE_DECLINE_MESSAGE,
+	userFacingError,
+} from '../utils/cardDeclineMessages';
 
 const FIELD_TYPES = [ 'number', 'expiry', 'cvv', 'name' ];
 
@@ -120,7 +124,7 @@ export function initCardSaveFields( config ) {
 				return;
 			}
 			if ( result.state !== 'succeeded' ) {
-				throw new Error( 'Card could not be saved.' );
+				throw userFacingError( CARD_SAVE_DECLINE_MESSAGE );
 			}
 
 			await postJson( config.ajax.create_payment_token, {

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -409,15 +409,27 @@ const placeOrderEnabled =
  * coupon applied on the checkout is taken into account. Mirrors v5's
  * paypalPaymentMethodAllowed().
  *
+ * A free-trial ($0) subscription is the exception: it cannot be paid through
+ * this row. The "Place order" flow redirects to a PayPal order that cannot be
+ * created for a zero total, and PayPal can only vault a payment method without a
+ * purchase through an approval the buyer opens from a button. So the row is
+ * withheld and the express "Pay with PayPal" button (which runs that save flow)
+ * is offered instead. Read live, so a coupon that zeroes or un-zeroes the cart
+ * after render is honoured.
+ *
  * @param {Object} [cartTotals] - The canMakePayment cart totals.
  * @return {boolean} Whether the row may show.
  */
 function regularRowAllowedForCart( cartTotals ) {
+	const amount = amountFromCartTotals( cartTotals ) || config.amount;
+
+	if ( isFreeTrialCart( config, amount ) ) {
+		return false;
+	}
+
 	if ( config.has_subscriptions ) {
 		return true;
 	}
-
-	const amount = amountFromCartTotals( cartTotals ) || config.amount;
 
 	return parseFloat( amount ) > 0;
 }
@@ -489,7 +501,9 @@ if ( savedPayPalEligible || placeOrderEnabled ) {
 	} else {
 		rowProps = {
 			// The row exists because a saved token does, so it is always
-			// available; a new PayPal payment uses the express button.
+			// available; a new PayPal payment uses the express button. A saved
+			// token completes a free-trial order too (the gateway attaches it),
+			// so this variant carries no broken redirect to withhold.
 			content: createElement( SavedTokenNote ),
 			canMakePayment: () => true,
 		};

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -248,17 +248,19 @@ if ( config && config.page_context && config.continuation ) {
 					return false;
 				}
 
-				// A $0 free-trial subscription is vaulted through the PayPal
-				// save flow (see V6ExpressComponent), which the amount-based
-				// eligibility check would reject for a zero amount. Only PayPal
-				// is offered on such carts (see FUNDING_SOURCES above), so guard
-				// on it; mirrors boot.js, which bypasses eligibility too.
-				if ( config.is_free_trial_cart ) {
-					return fundingSource === FundingSources.PAYPAL;
-				}
-
 				const amount =
 					amountFromCartTotals( cartTotals ) || config.amount;
+
+				// A free-trial ($0) subscription is vaulted through the PayPal
+				// save flow (see V6ExpressComponent), which the amount-based
+				// eligibility check would reject for a zero amount. Only PayPal
+				// is offered on such carts, so guard on it and bypass eligibility
+				// (mirrors boot.js). Read live from the amount, not the server's
+				// page-load flag, so a coupon that zeroes or un-zeroes the cart
+				// after render is honoured.
+				if ( isFreeTrialCart( config, amount ) ) {
+					return fundingSource === FundingSources.PAYPAL;
+				}
 
 				// Before the SDK is asked, so a cart that only PayPal can pay
 				// for costs no eligibility lookup for the other methods.

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -232,6 +232,15 @@ if ( config && config.page_context && config.continuation ) {
 					return false;
 				}
 
+				// A $0 free-trial subscription is vaulted through the PayPal
+				// save flow (see V6ExpressComponent), which the amount-based
+				// eligibility check would reject for a zero amount. Only PayPal
+				// is offered on such carts (see FUNDING_SOURCES above), so guard
+				// on it; mirrors boot.js, which bypasses eligibility too.
+				if ( config.is_free_trial_cart ) {
+					return fundingSource === FundingSources.PAYPAL;
+				}
+
 				const amount =
 					amountFromCartTotals( cartTotals ) || config.amount;
 				const eligibility = await getEligibility( amount );

--- a/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.js
+++ b/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.js
@@ -21,3 +21,18 @@ export function buttonStyle( styles ) {
 		borderRadius: styles.borderRadius,
 	};
 }
+
+/**
+ * The button height for a context.
+ *
+ * The flat `button_height` is the page context's. The mini cart carries its
+ * own, shorter one, and it renders on pages whose own context is something
+ * else entirely, so the context has to be asked for by name.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} context - The page context.
+ * @return {string|undefined} The CSS length, or undefined when neither is set.
+ */
+export function buttonHeight( config, context ) {
+	return config.button_styles?.[ context ]?.height || config.button_height;
+}

--- a/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/methods/buttonStyle.test.js
@@ -1,0 +1,59 @@
+import { buttonHeight } from './buttonStyle';
+
+const config = ( overrides = {} ) => ( {
+	...overrides,
+} );
+
+describe( 'buttonHeight()', () => {
+	test( 'returns the per-context height even when a different flat button_height is also set', () => {
+		const result = buttonHeight(
+			config( {
+				button_height: '48px',
+				button_styles: { 'mini-cart': { height: '35px' } },
+			} ),
+			'mini-cart'
+		);
+
+		expect( result ).toBe( '35px' );
+	} );
+
+	test( 'falls back to the flat button_height when the context has no entry in button_styles', () => {
+		const result = buttonHeight(
+			config( {
+				button_height: '48px',
+				button_styles: { cart: { height: '40px' } },
+			} ),
+			'checkout'
+		);
+
+		expect( result ).toBe( '48px' );
+	} );
+
+	test( 'falls back to the flat button_height when button_styles is absent entirely', () => {
+		const result = buttonHeight(
+			config( { button_height: '48px' } ),
+			'mini-cart'
+		);
+
+		expect( result ).toBe( '48px' );
+	} );
+
+	test( 'returns undefined when neither button_styles nor button_height is set', () => {
+		const result = buttonHeight( config(), 'mini-cart' );
+
+		expect( result ).toBeUndefined();
+	} );
+
+	test( 'resolves two different contexts in the same config to their own heights', () => {
+		const conf = config( {
+			button_height: '48px',
+			button_styles: {
+				'mini-cart': { height: '35px' },
+				product: { height: '55px' },
+			},
+		} );
+
+		expect( buttonHeight( conf, 'mini-cart' ) ).toBe( '35px' );
+		expect( buttonHeight( conf, 'product' ) ).toBe( '55px' );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/boot.test.js
@@ -73,6 +73,11 @@ jest.mock( '../utils/viewedTotal', () => ( {
 	watchViewedTotal: ( ...args ) => mockWatchViewedTotal( ...args ),
 } ) );
 
+const mockInitProductButtonGate = jest.fn();
+jest.mock( '../utils/productButtonGate', () => ( {
+	initProductButtonGate: ( ...args ) => mockInitProductButtonGate( ...args ),
+} ) );
+
 const WRAPPER_SELECTOR = '#ppcp-button-checkout';
 const MINI_CART_WRAPPER_SELECTOR = '#ppcp-mini-cart-button';
 
@@ -334,6 +339,9 @@ describe( 'boot', () => {
 			expect( mockWatchViewedTotal ).toHaveBeenCalledWith(
 				expect.objectContaining( { page_context: 'product' } ),
 				'product'
+			);
+			expect( mockInitProductButtonGate ).toHaveBeenCalledWith(
+				expect.objectContaining( { page_context: 'product' } )
 			);
 
 			notify( '42.00' );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -268,6 +268,137 @@ describe( 'initCardFields', () => {
 		expect( numberInput.nextSibling.style.height ).toBe( '45px' );
 	} );
 
+	test( 'leaves no bogus height on the field when the original input has no layout box at mount time, and does not throw without ResizeObserver support', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const numberInput = document.querySelector(
+			'#ppcp-credit-card-gateway-card-number'
+		);
+		numberInput.style.width = '300px';
+		// With no height set, jsdom reports "" rather than a px value, the
+		// same as a real "auto" from display:none.
+
+		const cardSession = makeCardSession();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+
+		await expect(
+			initCardFields( baseConfig() )
+		).resolves.not.toThrow();
+		await flushPromises();
+
+		expect( numberInput.nextSibling.style.height ).toBe( '' );
+	} );
+
+	describe( 'correcting the field height once the input gains a box', () => {
+		let observers;
+
+		function fireObserverFor( target ) {
+			const observer = observers.find( ( o ) => o.target === target );
+			observer.callback();
+		}
+
+		function disconnectMockFor( target ) {
+			return observers.find( ( o ) => o.target === target )
+				.disconnectMock;
+		}
+
+		beforeEach( () => {
+			observers = [];
+			global.ResizeObserver = class {
+				constructor( callback ) {
+					this.callback = callback;
+					this.disconnectMock = jest.fn();
+				}
+				observe( target ) {
+					observers.push( {
+						target,
+						callback: this.callback,
+						disconnectMock: this.disconnectMock,
+					} );
+				}
+				disconnect( ...args ) {
+					this.disconnectMock( ...args );
+				}
+			};
+		} );
+
+		afterEach( () => {
+			delete global.ResizeObserver;
+		} );
+
+		test( 'applies the height and disconnects once the input gains a box', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const numberInput = document.querySelector(
+				'#ppcp-credit-card-gateway-card-number'
+			);
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( baseConfig() );
+			await flushPromises();
+			expect( observers.length ).toBe( 3 );
+
+			numberInput.style.height = '45px';
+			fireObserverFor( numberInput.nextSibling );
+
+			expect( numberInput.nextSibling.style.height ).toBe( '45px' );
+			expect( disconnectMockFor( numberInput.nextSibling ) ).toHaveBeenCalled();
+		} );
+
+		test( 'does not write a height or disconnect when the observer fires while the input is still unmeasurable', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const numberInput = document.querySelector(
+				'#ppcp-credit-card-gateway-card-number'
+			);
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( baseConfig() );
+			await flushPromises();
+
+			fireObserverFor( numberInput.nextSibling );
+
+			expect( numberInput.nextSibling.style.height ).toBe( '' );
+			expect(
+				disconnectMockFor( numberInput.nextSibling )
+			).not.toHaveBeenCalled();
+		} );
+
+		test( 'restores the input\'s own hidden state and !important display after reading through them', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const numberInput = document.querySelector(
+				'#ppcp-credit-card-gateway-card-number'
+			);
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( baseConfig() );
+			await flushPromises();
+			// The real hide() is mocked away in this suite, so its !important
+			// display:none is applied here instead.
+			numberInput.style.setProperty( 'display', 'none', 'important' );
+
+			numberInput.style.height = '45px';
+			fireObserverFor( numberInput.nextSibling );
+
+			expect( numberInput.nextSibling.style.height ).toBe( '45px' );
+			expect( numberInput.hidden ).toBe( true );
+			expect( numberInput.style.getPropertyValue( 'display' ) ).toBe(
+				'none'
+			);
+			expect(
+				numberInput.style.getPropertyPriority( 'display' )
+			).toBe( 'important' );
+		} );
+	} );
+
 	test( 're-attaches to the fresh #payment DOM after WC replaces it on updated_checkout', async () => {
 		buildCheckoutDom( 'ppcp-credit-card-gateway' );
 		const firstSession = makeCardSession();

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -350,26 +350,47 @@ describe( 'checkout-block', () => {
 					totalPrice: '4900',
 					expected: true,
 				},
-			] )( '$name', ( { hasSubscriptions, totalPrice, expected } ) => {
-				loadCheckoutBlock(
-					baseConfig( {
-						place_order: { enabled: true, text: 'Complete order' },
-						has_subscriptions: hasSubscriptions,
-						amount: '10.00',
-					} )
-				);
+				{
+					name: 'a free-trial subscription cart at a $0 live total is not allowed: it is vaulted through the express button instead',
+					hasSubscriptions: true,
+					totalPrice: '0',
+					cartNeedsVaulting: true,
+					expected: false,
+				},
+			] )(
+				'$name',
+				( {
+					hasSubscriptions,
+					totalPrice,
+					cartNeedsVaulting,
+					expected,
+				} ) => {
+					loadCheckoutBlock(
+						baseConfig( {
+							place_order: {
+								enabled: true,
+								text: 'Complete order',
+							},
+							has_subscriptions: hasSubscriptions,
+							cart_needs_vaulting: cartNeedsVaulting,
+							amount: '10.00',
+						} )
+					);
 
-				const { canMakePayment } = regularCallFor( 'ppcp-gateway' );
+					const { canMakePayment } = regularCallFor(
+						'ppcp-gateway'
+					);
 
-				expect(
-					canMakePayment( {
-						cartTotals: {
-							total_price: totalPrice,
-							currency_minor_unit: 2,
-						},
-					} )
-				).toBe( expected );
-			} );
+					expect(
+						canMakePayment( {
+							cartTotals: {
+								total_price: totalPrice,
+								currency_minor_unit: 2,
+							},
+						} )
+					).toBe( expected );
+				}
+			);
 		} );
 
 		describe( 'when only the saved-PayPal vault row is eligible', () => {

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -13,8 +13,14 @@ jest.mock(
 	{ virtual: true }
 );
 
-jest.mock( '../sdkLoader', () => ( { loadSdkV6: jest.fn() } ) );
-jest.mock( '../eligibility', () => ( { checkEligibility: jest.fn() } ) );
+const mockLoadSdkV6 = jest.fn();
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+const mockCheckEligibility = jest.fn();
+jest.mock( '../eligibility', () => ( {
+	checkEligibility: ( ...args ) => mockCheckEligibility( ...args ),
+} ) );
 jest.mock( '../utils/errorHandler', () => ( { setErrorLabels: jest.fn() } ) );
 jest.mock( '../blocks/V6ExpressComponent', () => ( {
 	V6ExpressComponent: () => null,
@@ -166,5 +172,42 @@ describe( 'checkout-block', () => {
 				'ppcp_continuation',
 			] );
 		} );
+	} );
+
+	describe( 'PayPal express canMakePayment()', () => {
+		const cartTotals = { total_price: '0', currency_minor_unit: 2 };
+
+		test( 'resolves to true on a free-trial cart without checking eligibility', async () => {
+			loadCheckoutBlock( baseConfig( { is_free_trial_cart: true } ) );
+
+			const { canMakePayment } = expressCallFor( 'ppcp-gateway-paypal' );
+
+			await expect( canMakePayment( { cartTotals } ) ).resolves.toBe(
+				true
+			);
+			expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+			expect( mockCheckEligibility ).not.toHaveBeenCalled();
+		} );
+
+		test.each( [
+			[ { paypal: true }, true ],
+			[ { paypal: false }, false ],
+		] )(
+			'on a non-free-trial cart, resolves to %s when eligibility reports %s',
+			async ( eligibility, expected ) => {
+				mockLoadSdkV6.mockResolvedValue( {} );
+				mockCheckEligibility.mockResolvedValue( eligibility );
+				loadCheckoutBlock( baseConfig() );
+
+				const { canMakePayment } = expressCallFor(
+					'ppcp-gateway-paypal'
+				);
+
+				await expect(
+					canMakePayment( { cartTotals } )
+				).resolves.toBe( expected );
+				expect( mockCheckEligibility ).toHaveBeenCalled();
+			}
+		);
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -1,6 +1,3 @@
-import { loadSdkV6 } from '../sdkLoader';
-import { checkEligibility } from '../eligibility';
-
 const mockRegisterExpressPaymentMethod = jest.fn();
 const mockRegisterPaymentMethod = jest.fn();
 // virtual: webpack resolves this to the wc.wcBlocksRegistry global, so there is
@@ -218,8 +215,8 @@ describe( 'checkout-block', () => {
 		};
 
 		beforeEach( () => {
-			loadSdkV6.mockResolvedValue( {} );
-			checkEligibility.mockResolvedValue( eligibleForEveryMethod );
+			mockLoadSdkV6.mockResolvedValue( {} );
+			mockCheckEligibility.mockResolvedValue( eligibleForEveryMethod );
 		} );
 
 		test( 'a cart that became $0 after page load is a free trial even though the server said it was not', async () => {
@@ -439,7 +436,12 @@ describe( 'checkout-block', () => {
 		const cartTotals = { total_price: '0', currency_minor_unit: 2 };
 
 		test( 'resolves to true on a free-trial cart without checking eligibility', async () => {
-			loadCheckoutBlock( baseConfig( { is_free_trial_cart: true } ) );
+			loadCheckoutBlock(
+				baseConfig( {
+					is_free_trial_cart: true,
+					cart_needs_vaulting: true,
+				} )
+			);
 
 			const { canMakePayment } = expressCallFor( 'ppcp-gateway-paypal' );
 

--- a/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/checkout-block.test.js
@@ -193,7 +193,7 @@ describe( 'checkout-block', () => {
 			[ { paypal: true }, true ],
 			[ { paypal: false }, false ],
 		] )(
-			'on a non-free-trial cart, resolves to %s when eligibility reports %s',
+			'on a non-free-trial cart, eligibility %s resolves to %s',
 			async ( eligibility, expected ) => {
 				mockLoadSdkV6.mockResolvedValue( {} );
 				mockCheckEligibility.mockResolvedValue( eligibility );

--- a/modules/ppcp-sdk-v6/resources/js/test/productButtonGate.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/productButtonGate.test.js
@@ -1,0 +1,334 @@
+import jQuery from 'jquery';
+
+const mockHasJQuery = jest.fn( () => true );
+jest.mock( '../utils/api', () => ( {
+	hasJQuery: () => mockHasJQuery(),
+} ) );
+
+jest.mock( '../endpointsAdapter', () => ( {
+	// Not stubbed: it only reads the DOM the fixtures below build, and the
+	// selector pair it uses must live in one place.
+	productForm: jest.requireActual( '../endpointsAdapter' ).productForm,
+} ) );
+
+import {
+	initProductButtonGate,
+	resetProductButtonGate,
+} from '../utils/productButtonGate';
+
+const WRAPPER_ID = 'ppc-button-ppcp-gateway-v6';
+const WRAPPER_SELECTOR = `#${ WRAPPER_ID }`;
+
+const baseConfig = ( overrides = {} ) => ( {
+	page_context: 'product',
+	wrapper: WRAPPER_SELECTOR,
+	...overrides,
+} );
+
+/**
+ * Builds a classic product form plus its native add-to-cart button and the
+ * express-button wrapper this gate controls.
+ *
+ * The add-to-cart button is deliberately `type="button"`, not `type="submit"`,
+ * so it never itself matches the `:submit` selector the gate's mouseup handler
+ * clicks — keeping the "did the native submit get triggered" assertions
+ * unambiguous.
+ *
+ * @param {Object}  options
+ * @param {boolean} options.hasAddToCartButton
+ * @param {boolean} options.disabled
+ * @return {HTMLFormElement} The rendered product form.
+ */
+function buildDom( { hasAddToCartButton = true, disabled = false } = {} ) {
+	const addToCartButtonHtml = hasAddToCartButton
+		? `<button type="button" class="single_add_to_cart_button${
+				disabled ? ' disabled' : ''
+		  }"></button>`
+		: '';
+
+	document.body.innerHTML = `
+		<form class="cart variations_form">
+			<input name="add-to-cart" value="1" />
+			${ addToCartButtonHtml }
+			<button type="submit" class="submit-trigger"></button>
+		</form>
+		<div id="${ WRAPPER_ID }"></div>
+	`;
+
+	return document.querySelector( 'form' );
+}
+
+function wrapperEl() {
+	return document.querySelector( WRAPPER_SELECTOR );
+}
+
+/**
+ * Attaches a spy to the form's native submit trigger and returns it, so tests
+ * can assert whether the gate's mouseup handler routed a click to it.
+ *
+ * @param {HTMLFormElement} form
+ * @return {jest.Mock}
+ */
+function spyOnSubmit( form ) {
+	const spy = jest.fn();
+	form.querySelector( '.submit-trigger' ).addEventListener( 'click', spy );
+	return spy;
+}
+
+// jsdom's internal form-submission algorithm (run when a submit button's
+// default click action fires) hits an unimplemented path and throws. Every
+// test in this file that fires a wrapper mouseup while disabled ends up
+// clicking the form's :submit control, so the real submission is cancelled
+// globally by capturing the submit event itself, rather than in only the
+// tests that happen to spy on the click.
+const preventSubmit = ( event ) => event.preventDefault();
+
+beforeEach( () => {
+	mockHasJQuery.mockReturnValue( true );
+	global.jQuery = jQuery;
+	document.addEventListener( 'submit', preventSubmit, true );
+} );
+
+afterEach( () => {
+	resetProductButtonGate();
+	document.body.innerHTML = '';
+	delete global.jQuery;
+	document.removeEventListener( 'submit', preventSubmit, true );
+} );
+
+describe( 'initProductButtonGate()', () => {
+	describe( 'page_context guard', () => {
+		test.each( [ 'checkout', 'cart', 'mini-cart', undefined ] )(
+			'does nothing when page_context is %s',
+			( pageContext ) => {
+				const form = buildDom( { disabled: true } );
+
+				initProductButtonGate(
+					baseConfig( { page_context: pageContext } )
+				);
+
+				expect(
+					wrapperEl().classList.contains( 'ppcp-disabled' )
+				).toBe( false );
+
+				// No listeners were attached: toggling the button and firing
+				// the events the gate would otherwise react to changes nothing.
+				form
+					.querySelector( '.single_add_to_cart_button' )
+					.classList.remove( 'disabled' );
+				form.dispatchEvent( new Event( 'change' ) );
+
+				expect(
+					wrapperEl().classList.contains( 'ppcp-disabled' )
+				).toBe( false );
+			}
+		);
+	} );
+
+	describe( 'initial gating decision', () => {
+		test( 'adds ppcp-disabled to the wrapper when the add-to-cart button is disabled', () => {
+			buildDom( { disabled: true } );
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+		} );
+
+		test( 'leaves the wrapper enabled when the add-to-cart button is not disabled', () => {
+			buildDom( { disabled: false } );
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+
+		test( 'leaves the wrapper enabled when the form has no classic add-to-cart button (simple product)', () => {
+			buildDom( { hasAddToCartButton: false } );
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+
+		test( 'does nothing when the page has no product form', () => {
+			document.body.innerHTML = `<div id="${ WRAPPER_ID }"></div>`;
+
+			initProductButtonGate( baseConfig() );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+	} );
+
+	describe( 'mouseup on a disabled wrapper', () => {
+		test( 'routes the click to the form\'s native submit', () => {
+			const form = buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			const submitSpy = spyOnSubmit( form );
+
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'stops immediate propagation so no other handler on the wrapper receives it', () => {
+			buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			const wrapper = wrapperEl();
+			const laterListener = jest.fn();
+			wrapper.addEventListener( 'mouseup', laterListener );
+
+			wrapper.dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( laterListener ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does not submit the form when the wrapper is enabled', () => {
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+			const submitSpy = spyOnSubmit( form );
+
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'transition guard against stacking mouseup handlers', () => {
+		/**
+		 * Regression test: disable() binds a fresh mouseup handler on every
+		 * call, so re-running it without an intervening enable() would stack
+		 * handlers and submit the form once per stacked handler.
+		 */
+		test( 'a burst of sync triggers while the button stays disabled still results in exactly one submit per click', () => {
+			const form = buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+
+			form.dispatchEvent( new Event( 'change' ) );
+			form.dispatchEvent( new Event( 'change' ) );
+			form.dispatchEvent( new Event( 'change' ) );
+
+			const submitSpy = spyOnSubmit( form );
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'calling init again for the same page does not attach a second set of listeners', () => {
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+			initProductButtonGate( baseConfig() );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.add( 'disabled' );
+			form.dispatchEvent( new Event( 'change' ) );
+			form.dispatchEvent( new Event( 'change' ) );
+
+			const submitSpy = spyOnSubmit( form );
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 're-enabling once the button stops being disabled', () => {
+		test( 'removes ppcp-disabled from the wrapper and stops routing clicks to the native submit', () => {
+			const form = buildDom( { disabled: true } );
+			initProductButtonGate( baseConfig() );
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.remove( 'disabled' );
+			form.dispatchEvent( new Event( 'change' ) );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+
+			const submitSpy = spyOnSubmit( form );
+			wrapperEl().dispatchEvent(
+				new Event( 'mouseup', { bubbles: true } )
+			);
+
+			expect( submitSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'MutationObserver on the add-to-cart button', () => {
+		test( 're-syncs the wrapper when WooCommerce toggles the disabled class', async () => {
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.add( 'disabled' );
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'jQuery variation events', () => {
+		test.each( [ 'found_variation', 'reset_data' ] )(
+			'a %s event on the form re-syncs the wrapper',
+			( eventName ) => {
+				const form = buildDom( { disabled: false } );
+				initProductButtonGate( baseConfig() );
+
+				form
+					.querySelector( '.single_add_to_cart_button' )
+					.classList.add( 'disabled' );
+				jQuery( form ).trigger( eventName );
+
+				expect(
+					wrapperEl().classList.contains( 'ppcp-disabled' )
+				).toBe( true );
+			}
+		);
+
+		test( 'is not wired up when hasJQuery() reports jQuery is unavailable', () => {
+			mockHasJQuery.mockReturnValue( false );
+			const form = buildDom( { disabled: false } );
+			initProductButtonGate( baseConfig() );
+
+			form
+				.querySelector( '.single_add_to_cart_button' )
+				.classList.add( 'disabled' );
+			jQuery( form ).trigger( 'found_variation' );
+
+			expect(
+				wrapperEl().classList.contains( 'ppcp-disabled' )
+			).toBe( false );
+		} );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.js
@@ -1,0 +1,50 @@
+/**
+ * Shopper-facing wording for a card session that did not succeed.
+ *
+ * v6 runs 3D Secure client-side, so a rejected card never reaches the PHP
+ * capture gate that produces these messages in v5. The payment wording matches
+ * CardFieldsModule::capture_rejection_message(); change it there first.
+ *
+ * @package
+ */
+
+import { __ } from '@wordpress/i18n';
+
+export const CARD_DECLINE_MESSAGE = __(
+	'This card could not be authorized. Please try a different payment method.',
+	'woocommerce-paypal-payments'
+);
+
+export const CARD_SAVE_DECLINE_MESSAGE = __(
+	'This card could not be authorized. Please try a different card.',
+	'woocommerce-paypal-payments'
+);
+
+/**
+ * The message for a thrown error, keeping internal wording away from shoppers.
+ *
+ * Server errors are marked isUserFacing by the AJAX helper (utils/api.js) and
+ * are already translated; anything else (an SDK error, a bug) falls back.
+ *
+ * @param {Object|Error} error    - The thrown error.
+ * @param {string}       fallback - The message to show for an internal error.
+ * @return {string} The message.
+ */
+export function userFacingMessage( error, fallback ) {
+	return error?.isUserFacing && error.message ? error.message : fallback;
+}
+
+/**
+ * Builds an error whose message the error handler renders verbatim.
+ *
+ * The classic-page handleError() only shows a message it knows is shopper-safe,
+ * so a decline raised on the page must opt in the same way a server error does.
+ *
+ * @param {string} message - The shopper-facing message.
+ * @return {Error} The error.
+ */
+export function userFacingError( message ) {
+	const error = new Error( message );
+	error.isUserFacing = true;
+	return error;
+}

--- a/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/cardDeclineMessages.test.js
@@ -1,0 +1,45 @@
+import { userFacingMessage, userFacingError } from './cardDeclineMessages';
+
+describe( 'userFacingMessage()', () => {
+	test( 'returns the fallback when the error is not marked user-facing', () => {
+		const error = new Error( 'PayPal SDK internal failure XYZ' );
+
+		expect( userFacingMessage( error, 'Fallback message.' ) ).toBe(
+			'Fallback message.'
+		);
+	} );
+
+	test( 'returns the error message when it is marked user-facing', () => {
+		const error = new Error( 'Your card was declined by the bank.' );
+		error.isUserFacing = true;
+
+		expect( userFacingMessage( error, 'Fallback message.' ) ).toBe(
+			'Your card was declined by the bank.'
+		);
+	} );
+
+	test( 'returns the fallback when a user-facing error has no message', () => {
+		const error = new Error( '' );
+		error.isUserFacing = true;
+
+		expect( userFacingMessage( error, 'Fallback message.' ) ).toBe(
+			'Fallback message.'
+		);
+	} );
+
+	test( 'returns the fallback for a null error', () => {
+		expect( userFacingMessage( null, 'Fallback message.' ) ).toBe(
+			'Fallback message.'
+		);
+	} );
+} );
+
+describe( 'userFacingError()', () => {
+	test( 'builds an Error carrying the given message and the isUserFacing flag', () => {
+		const error = userFacingError( 'This card could not be authorized.' );
+
+		expect( error ).toBeInstanceOf( Error );
+		expect( error.message ).toBe( 'This card could not be authorized.' );
+		expect( error.isUserFacing ).toBe( true );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/utils/productButtonGate.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/productButtonGate.js
@@ -1,0 +1,101 @@
+/**
+ * Gates the product-page express buttons behind the native add-to-cart state.
+ *
+ * When WooCommerce disables `.single_add_to_cart_button` (e.g. a variable
+ * product with no variation chosen), this mirrors v5's SingleProductBootstrap
+ * via the shared ButtonDisabler: it disables the wrapper so a click surfaces
+ * WooCommerce's own validation instead of reaching ppc-change-cart.
+ *
+ * @package
+ */
+
+import { disable, enable, isDisabled } from '@ppcp-button/Helper/ButtonDisabler';
+import { productForm } from '../endpointsAdapter';
+import { hasJQuery } from './api';
+
+// The native submit whose disabled state WooCommerce drives from the variation
+// selection. Its absence marks a non-classic form (e.g. the block add-to-cart),
+// which this gate deliberately leaves alone.
+const ADD_TO_CART_SELECTOR = '.single_add_to_cart_button';
+
+// Attached once per page, however many times init is called.
+let initialized = false;
+let buttonObserver = null;
+
+/**
+ * Resets module state. Test seam only.
+ */
+export function resetProductButtonGate() {
+	initialized = false;
+	if ( buttonObserver ) {
+		buttonObserver.disconnect();
+		buttonObserver = null;
+	}
+}
+
+/**
+ * Starts gating the product-page express buttons.
+ *
+ * No-ops off product pages and on forms without a classic add-to-cart button,
+ * so it is safe to call unconditionally.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ */
+export function initProductButtonGate( config ) {
+	if ( 'product' !== config?.page_context || initialized ) {
+		return;
+	}
+
+	const form = productForm();
+	if ( ! form ) {
+		return;
+	}
+
+	// A missing button is treated as "enabled", not as a reason to bail: a simple
+	// product still has one and must stay live, and only a classic form carries
+	// this selector, which scopes the gate to classic themes.
+	const addToCartButton = form.querySelector( ADD_TO_CART_SELECTOR );
+
+	const shouldEnable = () => {
+		// Re-queried each time: WooCommerce can re-render the button.
+		const button = form.querySelector( ADD_TO_CART_SELECTOR );
+		return ! button || ! button.classList.contains( 'disabled' );
+	};
+
+	const sync = () => {
+		const wrapper = document.querySelector( config.wrapper );
+		if ( ! wrapper ) {
+			return;
+		}
+
+		const enableNow = shouldEnable();
+		const wasDisabled = isDisabled( wrapper );
+
+		// Only act on a transition: disable() binds a fresh mouseup handler each
+		// call, so calling it twice without an intervening enable() would stack
+		// handlers and submit the form more than once.
+		if ( enableNow && wasDisabled ) {
+			enable( wrapper );
+		} else if ( ! enableNow && ! wasDisabled ) {
+			disable( wrapper, form );
+		}
+	};
+
+	initialized = true;
+
+	sync();
+
+	if ( addToCartButton ) {
+		buttonObserver = new MutationObserver( sync );
+		buttonObserver.observe( addToCartButton, { attributes: true } );
+	}
+
+	// Covers quantity changes and the attribute selects.
+	form.addEventListener( 'change', sync );
+
+	if ( hasJQuery() ) {
+		// WooCommerce fills variation_id and flips the add-to-cart button only
+		// after these fire, so the change event above can run a beat too early.
+		jQuery( form ).on( 'found_variation reset_data', sync );
+	}
+}

--- a/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/applePay.js
@@ -24,7 +24,7 @@ import { APPLE_PAY_VERSION, buildApplePayRequest } from './applePayRequest';
 import { watchSheetTotal } from './applePaySheetTotal';
 import { applePayFailure, attachShippingHandlers } from './applePayShipping';
 import { recordDomainValidation } from './applePayValidation';
-import { buttonStyle } from '../methods/buttonStyle';
+import { buttonHeight, buttonStyle } from '../methods/buttonStyle';
 import {
 	applePayPayer,
 	applePayShippingAddress,
@@ -330,7 +330,11 @@ export async function renderApplePay( {
 	}
 
 	container.appendChild(
-		createButton( styles, overrides.height || config.button_height, pay )
+		createButton(
+			styles,
+			overrides.height || buttonHeight( config, context ),
+			pay
+		)
 	);
 }
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/googlePay.js
@@ -22,7 +22,7 @@ import {
 	buildReadyToPayRequest,
 } from './googlePayRequest';
 import { buildPaymentDataCallbacks } from './googlePayShipping';
-import { buttonStyle } from '../methods/buttonStyle';
+import { buttonHeight, buttonStyle } from '../methods/buttonStyle';
 import {
 	googlePayPayer,
 	googlePayShippingAddress,
@@ -73,7 +73,8 @@ export async function renderGooglePay( {
 	const settings = methodConfig( config, method );
 
 	const container = document.createElement( 'div' );
-	container.style.height = overrides.height || config.button_height;
+	container.style.height =
+		overrides.height || buttonHeight( config, context );
 	wrapper.appendChild( container );
 
 	// Independent: fetching PayPal's config does not need Google's global,

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -573,6 +573,24 @@ class SdkV6Manager {
 			return true;
 		}
 
+		// Home and shop, where v5 places a Pay Later message and v6 has no
+		// message hook of its own yet. Whether v5 rendered there came down to the
+		// unrelated mini-cart setting: with the mini-cart on, the fallback below
+		// claimed the page and v5 went dark; with it off, v5 stayed and drew the
+		// banner. Claim the page either way, so one stack owns messaging
+		// everywhere rather than v6 and v5 splitting it per page. The message is
+		// withheld until v6 can draw it itself, at which point should_load_messages()
+		// above claims the page first and this branch stops being reached.
+		//
+		// Scoped to the empty page context so the block and page-context
+		// locations keep deciding without consulting messaging, as
+		// testShouldLoadOnCurrentPageInBlockContextsIsUnaffectedByMessagingEligibility
+		// pins.
+		$message_location = $page_location ? '' : $this->context->location();
+		if ( $message_location && $this->settings_status->is_pay_later_messaging_enabled_for_location( $message_location ) ) {
+			return true;
+		}
+
 		// Sitewide, because the mini-cart can appear on any page as either the
 		// classic "Cart" widget or the block Mini-Cart, and is_active_widget()
 		// only detects the classic one. boot.js renders into the mini-cart

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -307,12 +307,19 @@ class SdkV6Manager {
 
 		$needs_payment = $this->cart_needs_payment();
 
+		// A free-trial ($0) subscription cart needs no one-time payment, so
+		// $needs_payment is false, but the checkout still needs the PayPal
+		// save-without-purchase button (boot.js renders it for the checkout /
+		// pay-now contexts only). Confined to checkout: the cart and mini-cart
+		// have no form to submit the vaulted token with.
+		$free_trial_checkout = $this->free_trial_helper->is_free_trial_cart();
+
 		// pay-now is driven by the existing WC order rather than the cart, so
 		// the zero-total guard does not apply to it.
 		return array(
 			'product'   => $this->settings_status->is_smart_button_enabled_for_location( 'product' ),
 			'cart'      => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'cart' ),
-			'checkout'  => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'checkout' ),
+			'checkout'  => ( $needs_payment || $free_trial_checkout ) && $this->settings_status->is_smart_button_enabled_for_location( 'checkout' ),
 			'pay-now'   => $this->settings_status->is_smart_button_enabled_for_location( 'pay-now' ),
 			'mini-cart' => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' ),
 		);
@@ -321,8 +328,10 @@ class SdkV6Manager {
 	/**
 	 * Whether the current cart still needs payment.
 	 *
-	 * Keeps buttons off $0 orders (a full-value coupon, a free trial), where no
-	 * payment method should be offered at all.
+	 * Keeps buttons off $0 orders (a full-value coupon), where no payment method
+	 * should be offered at all. A free-trial subscription cart is $0 too but is
+	 * handled separately in determine_render_places(), since it still needs the
+	 * PayPal save-without-purchase button on the checkout.
 	 */
 	private function cart_needs_payment(): bool {
 		$cart = WC()->cart;

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -63,6 +63,14 @@ class SdkV6Manager {
 	 */
 	public const PAYMENT_BUTTON_HEIGHT = '48px';
 
+	/**
+	 * The button height in the mini cart, which is narrower than a page column
+	 * and so carries a shorter button. Matches the v5 default for the location
+	 * (see SmartButton::script_data(), which sends 35 there and 48 for the
+	 * block contexts).
+	 */
+	public const MINI_CART_BUTTON_HEIGHT = '35px';
+
 	// The pay-for-order page has no pre-payment hook, so the message renders
 	// after the submit button and is relocated by SdkV6Module.
 	public const PAY_ORDER_MESSAGE_HOOK = 'woocommerce_pay_order_before_submit';
@@ -938,7 +946,7 @@ class SdkV6Manager {
 
 	/**
 	 * The button styles for one context, carrying the height every button in
-	 * the express stack shares.
+	 * that context's express stack shares.
 	 *
 	 * @param string $context The page context.
 	 * @return array{colorClass: string, borderRadius: string, height: string}
@@ -946,8 +954,17 @@ class SdkV6Manager {
 	private function button_styles( string $context ): array {
 		return array_merge(
 			$this->style_mapper->styles_for_context( $context ),
-			array( 'height' => self::PAYMENT_BUTTON_HEIGHT )
+			array( 'height' => $this->button_height( $context ) )
 		);
+	}
+
+	/**
+	 * The button height for a context.
+	 */
+	private function button_height( string $context ): string {
+		return 'mini-cart' === $context
+			? self::MINI_CART_BUTTON_HEIGHT
+			: self::PAYMENT_BUTTON_HEIGHT;
 	}
 
 	/**

--- a/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
+++ b/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
@@ -83,6 +83,7 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 	 * @return void
 	 */
 	public function initialize() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 	}
 
 	public function is_active() {
@@ -111,6 +112,34 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 		);
 
 		return array( $handle );
+	}
+
+	/**
+	 * Enqueues the styles for the express buttons on block pages.
+	 *
+	 * Block pages bypass SdkV6Manager::enqueue(), which serves the classic
+	 * pages only, so their styles are registered here instead.
+	 */
+	public function enqueue_style(): void {
+		if ( ! $this->is_active() ) {
+			return;
+		}
+
+		$style_url = $this->asset_getter->get_asset_url( 'checkout-block.css' );
+		if ( ! $style_url ) {
+			return;
+		}
+
+		$handle = 'wc-ppcp-sdk-v6-blocks-style';
+
+		wp_register_style(
+			$handle,
+			$style_url,
+			array(),
+			$this->version
+		);
+
+		wp_enqueue_style( $handle );
 	}
 
 	public function get_payment_method_data(): array {

--- a/modules/ppcp-sdk-v6/src/Helper/ButtonStyleMapper.php
+++ b/modules/ppcp-sdk-v6/src/Helper/ButtonStyleMapper.php
@@ -42,9 +42,9 @@ class ButtonStyleMapper {
 	 * Returns v6-compatible styles for a given context.
 	 *
 	 * Color and shape come from the styling DTOs, the same source the v5
-	 * SmartButton reads. There is no height: the styling DTOs have no
-	 * height field (the legacy button_*_height keys are unmaintained
-	 * fossils that current v5 no longer honors either).
+	 * SmartButton reads. There is no height, because the styling DTOs have no
+	 * height field; SdkV6Manager::button_height() supplies one per context
+	 * instead, matching the per-location defaults v5 sends.
 	 *
 	 * @param string $context The page context (product, cart, checkout, mini-cart).
 	 * @return array{colorClass: string, borderRadius: string}

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -277,7 +277,8 @@ return array(
 		return new WebhookSettingsEndpoint(
 			$container->get( 'api.endpoint.webhook' ),
 			$container->get( 'webhook.registrar' ),
-			$container->get( 'webhook.status.simulation' )
+			$container->get( 'webhook.status.simulation' ),
+			$container->get( 'webhook.own-resolver' )
 		);
 	},
 	'settings.rest.pay_later_messaging'                   => static function ( ContainerInterface $container ): PayLaterMessagingEndpoint {

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -428,6 +428,16 @@ class SettingsProvider {
 	}
 
 	/**
+	 * Whether a PayPal/Venmo vault token can be saved for this merchant.
+	 *
+	 * @return bool True if PayPal/Venmo vaulting is available, false otherwise.
+	 */
+	public function can_save_vault_token(): bool {
+		return (bool) $this->merchant_data()->client_id
+			&& $this->save_paypal_and_venmo();
+	}
+
+	/**
 	 * Whether Pay Later may run alongside vaulting ("Save PayPal and Venmo").
 	 *
 	 * Allowed whenever the merchant may use Pay Later at all, which is the same

--- a/modules/ppcp-settings/src/Endpoint/WebhookSettingsEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/WebhookSettingsEndpoint.php
@@ -14,6 +14,7 @@ use WP_REST_Response;
 use WP_REST_Server;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 use stdClass;
@@ -53,21 +54,31 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	private WebhookSimulation $webhook_simulation;
 
 	/**
-	 * WebhookSettingsEndpoint constructor.
-	 *
-	 * @param WebhookEndpoint   $webhook_endpoint   A list of subscribed webhooks and a webhook
-	 *                                              endpoint URL.
-	 * @param WebhookRegistrar  $webhook_registrar  A service that allows resubscribing webhooks.
-	 * @param WebhookSimulation $webhook_simulation A service that allows webhook simulations.
+	 * Tells this site's own webhook apart from other sites' webhooks on the same app.
+	 */
+	private OwnWebhookResolver $own_webhook_resolver;
+
+	/**
+	 * @param WebhookEndpoint    $webhook_endpoint     A list of subscribed webhooks and a
+	 *                                                 webhook endpoint URL.
+	 * @param WebhookRegistrar   $webhook_registrar    A service that allows resubscribing
+	 *                                                 webhooks.
+	 * @param WebhookSimulation  $webhook_simulation   A service that allows webhook
+	 *                                                 simulations.
+	 * @param OwnWebhookResolver $own_webhook_resolver Tells this site's own webhook apart
+	 *                                                 from other sites' webhooks on the same
+	 *                                                 app.
 	 */
 	public function __construct(
 		WebhookEndpoint $webhook_endpoint,
 		WebhookRegistrar $webhook_registrar,
-		WebhookSimulation $webhook_simulation
+		WebhookSimulation $webhook_simulation,
+		OwnWebhookResolver $own_webhook_resolver
 	) {
-		$this->webhook_endpoint   = $webhook_endpoint;
-		$this->webhook_registrar  = $webhook_registrar;
-		$this->webhook_simulation = $webhook_simulation;
+		$this->webhook_endpoint     = $webhook_endpoint;
+		$this->webhook_registrar    = $webhook_registrar;
+		$this->webhook_simulation   = $webhook_simulation;
+		$this->own_webhook_resolver = $own_webhook_resolver;
 	}
 
 	/**
@@ -194,15 +205,14 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 
 
 	/**
-	 * Retrieves the Webhooks API response object.
+	 * Retrieves this site's own webhook from the PayPal app
+	 * (it can include webhooks of other sites).
 	 *
 	 * @return Webhook|null The webhook data instance, or null.
 	 */
 	private function get_webhook_data(): ?Webhook {
 		try {
-			$api_response = $this->webhook_endpoint->list();
-
-			return $api_response[0] ?? null;
+			return $this->own_webhook_resolver->find_own( $this->webhook_endpoint->list() );
 		} catch ( Throwable $error ) {
 			return null;
 		}

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookEventStorage;
 
 /**
@@ -147,7 +148,10 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 						'label'          => esc_html__( 'Webhook delivery host', 'woocommerce-paypal-payments' ),
 						'exported_label' => 'Webhook delivery host',
 						'description'    => esc_html__( 'Whether PayPal delivers webhooks to this site or to a different host.', 'woocommerce-paypal-payments' ),
-						'value'          => $this->webhook_delivery_host_status( $this->registered_webhooks( $c, $is_connected ) ),
+						'value'          => $this->webhook_delivery_host_status(
+							$this->registered_webhooks( $c, $is_connected ),
+							$c->get( 'webhook.own-resolver' )
+						),
 					),
 					array(
 						'label'          => esc_html__( 'PayPal Vault enabled', 'woocommerce-paypal-payments' ),
@@ -335,36 +339,37 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 	/**
 	 * Reports whether PayPal's registered webhook points at this site.
 	 *
-	 * Compares each registered webhook's host against this site's host. When they
-	 * differ, webhook events are being delivered elsewhere - typically a staging or dev
-	 * clone connected to the same PayPal account - which the "Webhook status" row above
-	 * cannot detect.
+	 * Asks the resolver which webhooks deliver to this install's incoming endpoint.
+	 * When none of them does, webhook events are going elsewhere.
 	 *
-	 * @param Webhook[] $registered_webhooks The live PayPal-side registered webhooks.
+	 * points_here() rather than is_own() on purpose: the question is where PayPal
+	 * delivers now, so a webhook we once registered under a former domain must not
+	 * excuse a mismatch.
+	 *
+	 * @param Webhook[]          $registered_webhooks The live PayPal-side registered webhooks.
+	 * @param OwnWebhookResolver $resolver            Tells this install's webhook apart from other sites'.
 	 * @return string
 	 */
-	private function webhook_delivery_host_status( array $registered_webhooks ): string {
-		$site_host = $this->normalized_host( home_url() );
-
-		$foreign_hosts = array();
+	private function webhook_delivery_host_status( array $registered_webhooks, OwnWebhookResolver $resolver ): string {
+		$foreign_targets = array();
 		foreach ( $registered_webhooks as $webhook ) {
 			if ( ! $webhook instanceof Webhook ) {
 				continue;
 			}
 
-			$webhook_host = $this->normalized_host( $webhook->url() );
-			if ( '' === $webhook_host ) {
-				continue;
-			}
-
-			if ( $webhook_host === $site_host ) {
+			if ( $resolver->points_here( $webhook ) ) {
 				return $this->bool_to_html( true );
 			}
 
-			$foreign_hosts[ $webhook_host ] = $webhook_host;
+			$webhook_identity = $resolver->identity( $webhook->url() );
+			if ( $webhook_identity === '' ) {
+				continue;
+			}
+
+			$foreign_targets[ $webhook_identity ] = $webhook_identity;
 		}
 
-		if ( array() === $foreign_hosts ) {
+		if ( $foreign_targets === array() ) {
 			return $this->bool_to_html( false );
 		}
 
@@ -372,24 +377,12 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 			'<mark class="error"><span class="dashicons dashicons-warning"></span> %s</mark>',
 			esc_html(
 				sprintf(
-					/* translators: 1: host(s) receiving the webhooks, 2: this site's host. */
+					/* translators: 1: host(s) and path(s) receiving the webhooks, 2: this site's own webhook host and path. */
 					__( 'Delivered to %1$s (this site: %2$s)', 'woocommerce-paypal-payments' ),
-					implode( ', ', $foreign_hosts ),
-					$site_host
+					implode( ', ', $foreign_targets ),
+					$resolver->own_identity()
 				)
 			)
 		);
-	}
-
-	/**
-	 * Extracts the lower-cased host from a URL, or an empty string when it cannot be parsed.
-	 *
-	 * @param string $url The URL to extract the host from.
-	 * @return string
-	 */
-	private function normalized_host( string $url ): string {
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-
-		return is_string( $host ) ? strtolower( $host ) : '';
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -75,6 +75,16 @@ class DisableGateways {
 			}
 		}
 
+		// Hide the PayPal gateway when the subscription cart cannot be processed (e.g. vaulting
+		// disabled for a subscription that requires it, with no PayPal plan or manual renewals),
+		// instead of showing it with a disabled button.
+		if (
+			isset( $methods[ PayPalGateway::ID ] )
+			&& ! $this->subscription_helper->subscription_cart_processable( $this->settings_provider )
+		) {
+			unset( $methods[ PayPalGateway::ID ] );
+		}
+
 		if ( $this->card_configuration->use_acdc() && $this->store_country !== 'MX' ) {
 			unset( $methods[ CardButtonGateway::ID ] );
 		}

--- a/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ShippingOption;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
@@ -82,37 +83,39 @@ class ShippingCallbackEndpoint {
 		$this->logger->debug( 'Shipping callback received: ' . $request->get_body() );
 
 		$request_id = $request_data['id'];
-		$pu_id      = $request_data['purchase_units'][0]['reference_id'];
+		$pu_id      = $request_data['purchase_units'][0]['reference_id'] ?? 'default';
 
-		$address = $this->convert_address_to_wc( $request_data['shipping_address'] );
+		$address = $this->convert_address_to_wc( $request_data['shipping_address'] ?? array() );
 
-		$cart_response = $this->cart_endpoint->update_customer(
-			$cart_token,
-			array(
-				'shipping_address' => $address,
-			)
-		);
+		try {
+			$cart_response = $this->cart_endpoint->update_customer(
+				$cart_token,
+				array(
+					'shipping_address' => $address,
+				)
+			);
+		} catch ( Exception $exception ) {
+			$this->logger->warning( 'Shipping callback response: ADDRESS_ERROR (' . $exception->getMessage() . ').' );
+
+			return $this->error_response( 'ADDRESS_ERROR' );
+		}
 
 		if ( empty( $cart_response->cart()->shipping_rates() ) ) {
 			$this->logger->debug( 'Shipping callback response: ADDRESS_ERROR (no shipping rates found).' );
 
-			return new WP_REST_Response(
-				array(
-					'name'    => 'UNPROCESSABLE_ENTITY',
-					'details' => array(
-						array(
-							'issue' => 'ADDRESS_ERROR',
-						),
-					),
-				),
-				422
-			);
+			return $this->error_response( 'ADDRESS_ERROR' );
 		}
 
 		if ( isset( $request_data['shipping_option'] ) ) {
 			$selected_shipping_method_id = $request_data['shipping_option']['id'];
 
-			$cart_response = $this->cart_endpoint->select_shipping_rate( $cart_token, 0, $selected_shipping_method_id );
+			try {
+				$cart_response = $this->cart_endpoint->select_shipping_rate( $cart_token, 0, $selected_shipping_method_id );
+			} catch ( Exception $exception ) {
+				$this->logger->warning( 'Shipping callback response: METHOD_UNAVAILABLE (' . $exception->getMessage() . ').' );
+
+				return $this->error_response( 'METHOD_UNAVAILABLE' );
+			}
 		}
 
 		$cart = $cart_response->cart();
@@ -157,6 +160,25 @@ class ShippingCallbackEndpoint {
 		$url = rest_url( self::NAMESPACE . '/' . self::ROUTE );
 
 		return $url;
+	}
+
+	/**
+	 * Tells PayPal that the order cannot be updated for the requested address or shipping option.
+	 *
+	 * @param string $issue The PayPal issue, like ADDRESS_ERROR or METHOD_UNAVAILABLE.
+	 */
+	private function error_response( string $issue ): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'name'    => 'UNPROCESSABLE_ENTITY',
+				'details' => array(
+					array(
+						'issue' => $issue,
+					),
+				),
+			),
+			422
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
@@ -159,16 +159,23 @@ class ShippingCallbackEndpoint {
 		return $url;
 	}
 
+	/**
+	 * Converts the PayPal address into the fields of the Store API customer endpoint.
+	 *
+	 * The callback payload contains no street lines, so those fields are omitted and the address
+	 * that is already stored for the customer remains unchanged.
+	 *
+	 * @param array<string, mixed> $address The shipping_address of the callback payload.
+	 * @return array<string, string>
+	 */
 	private function convert_address_to_wc( array $address ): array {
 		$country = (string) ( $address['country_code'] ?? '' );
 
 		return array(
-			'country'        => $country,
-			'state'          => $this->convert_state_to_wc( (string) ( $address['admin_area_1'] ?? '' ), $country ),
-			'city'           => (string) ( $address['admin_area_2'] ?? '' ),
-			'postcode'       => (string) ( $address['postal_code'] ?? '' ),
-			'address_line_1' => '',
-			'address_line_2' => '',
+			'country'  => $country,
+			'state'    => $this->convert_state_to_wc( (string) ( $address['admin_area_1'] ?? '' ), $country ),
+			'city'     => (string) ( $address['admin_area_2'] ?? '' ),
+			'postcode' => (string) ( $address['postal_code'] ?? '' ),
 		);
 	}
 

--- a/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
@@ -160,13 +160,51 @@ class ShippingCallbackEndpoint {
 	}
 
 	private function convert_address_to_wc( array $address ): array {
+		$country = (string) ( $address['country_code'] ?? '' );
+
 		return array(
-			'country'        => $address['country_code'] ?? '',
-			'state'          => $address['admin_area_1'] ?? '',
-			'city'           => $address['admin_area_2'] ?? '',
-			'postcode'       => $address['postal_code'] ?? '',
+			'country'        => $country,
+			'state'          => $this->convert_state_to_wc( (string) ( $address['admin_area_1'] ?? '' ), $country ),
+			'city'           => (string) ( $address['admin_area_2'] ?? '' ),
+			'postcode'       => (string) ( $address['postal_code'] ?? '' ),
 			'address_line_1' => '',
 			'address_line_2' => '',
 		);
+	}
+
+	/**
+	 * Converts the PayPal state into a state that WooCommerce accepts for the given country.
+	 *
+	 * PayPal sends regions that are not always part of the WooCommerce state list of the country,
+	 * and the Store API rejects the whole address in that case. Such states are dropped, so that
+	 * the shipping rates are calculated based on the remaining address fields.
+	 *
+	 * @param string $state The admin_area_1 of the callback payload, a state code or name.
+	 * @param string $country The 2-letter country code.
+	 */
+	private function convert_state_to_wc( string $state, string $country ): string {
+		if ( '' === $state || '' === $country ) {
+			return $state;
+		}
+
+		$states = array_filter( (array) WC()->countries->get_states( $country ) );
+		if ( ! $states ) {
+			return $state;
+		}
+
+		$state = wc_strtoupper( $state );
+
+		if ( in_array( $state, array_map( 'wc_strtoupper', array_keys( $states ) ), true ) ) {
+			return $state;
+		}
+
+		$code = array_search( $state, array_map( 'wc_strtoupper', $states ), true );
+		if ( false !== $code ) {
+			return (string) $code;
+		}
+
+		$this->logger->debug( sprintf( 'Shipping callback: dropped the state "%1$s", which is unknown in %2$s.', $state, $country ) );
+
+		return '';
 	}
 }

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -233,6 +233,34 @@ class SubscriptionHelper {
 	}
 
 	/**
+	 * Whether the current (subscription) cart can actually be processed by the PayPal gateway.
+	 *
+	 * This resolves the mode-aware {@see self::paypal_subscription_button_allowed()} rule from
+	 * settings, so callers that only have a {@see SettingsProvider} (such as the classic-checkout
+	 * gateway-availability filter) can hide the PayPal gateway when it could not fulfil the payment
+	 * instead of leaving it visible with a disabled button. A non-subscription cart is always
+	 * processable.
+	 *
+	 * @param SettingsProvider $settings_provider The settings provider.
+	 * @return bool
+	 * @throws NotFoundException If setting is not found.
+	 */
+	public function subscription_cart_processable( SettingsProvider $settings_provider ): bool {
+		if ( ! $this->cart_contains_subscription() ) {
+			return true;
+		}
+
+		$is_paypal_subscription = self::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS === $this->resolve_subscription_mode( $settings_provider );
+
+		// Mirrors SmartButton::can_save_vault_token(): a token can only be saved with a
+		// connected merchant and vaulting ("Save PayPal and Venmo") enabled.
+		$can_save_vault_token = ! empty( $settings_provider->merchant_data()->client_id )
+			&& $settings_provider->save_paypal_and_venmo();
+
+		return $this->paypal_subscription_button_allowed( $is_paypal_subscription, $can_save_vault_token );
+	}
+
+	/**
 	 * Resolves how a subscription checkout must be routed.
 	 *
 	 * This is the single deciding function for the subscriptions mode. Rules:

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -33,6 +33,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureReversed;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentSaleCompleted;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentSaleRefunded;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\VaultPaymentTokenDeleted;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 return array(
@@ -51,7 +52,13 @@ return array(
 			$last_webhook_storage,
 			$container->get( 'webhook.status.simulation' ),
 			$container->get( 'webhook.orchestration' ),
-			$logger
+			$logger,
+			$container->get( 'webhook.own-resolver' )
+		);
+	},
+	'webhook.own-resolver'                    => static function ( ContainerInterface $container ): OwnWebhookResolver {
+		return new OwnWebhookResolver(
+			$container->get( 'webhook.endpoint.controller' )
 		);
 	},
 	'webhook.orchestration'                   => static function ( ContainerInterface $container ): WebhookOrchestrator {

--- a/modules/ppcp-webhooks/src/OwnWebhookResolver.php
+++ b/modules/ppcp-webhooks/src/OwnWebhookResolver.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+
+/**
+ * Decides which of the webhooks configured on the connected PayPal REST app
+ * belongs to this install.
+ *
+ * Sometimes a REST app can end up with several sites, and PayPal returns every webhook
+ * on the app in creation order.
+ */
+class OwnWebhookResolver {
+
+	private IncomingWebhookEndpoint $incoming_webhook_endpoint;
+
+	public function __construct( IncomingWebhookEndpoint $incoming_webhook_endpoint ) {
+		$this->incoming_webhook_endpoint = $incoming_webhook_endpoint;
+	}
+
+	/**
+	 * Whether the given webhook belongs to this install.
+	 *
+	 * A webhook is considered ours when either:
+	 * - its id matches the one we previously stored (provably ours regardless of the
+	 *   host it currently uses, so a domain migration or NGROK_HOST rotation still
+	 *   recognizes our former webhook instead of leaking it), or
+	 * - its URL identity (host + path) equals this install's incoming endpoint.
+	 *
+	 * @param Webhook $webhook The webhook to check.
+	 */
+	public function is_own( Webhook $webhook ): bool {
+		$stored_id = $this->stored_id();
+		if ( $stored_id !== '' && $webhook->id() === $stored_id ) {
+			return true;
+		}
+
+		return $this->points_here( $webhook );
+	}
+
+	/**
+	 * Whether the given webhook currently delivers to this install.
+	 *
+	 * Unlike is_own(), the stored webhook id is ignored: a webhook we registered
+	 * ourselves but which still points at a former domain does not deliver here.
+	 *
+	 * @param Webhook $webhook The webhook to check.
+	 */
+	public function points_here( Webhook $webhook ): bool {
+		$own_identity = $this->own_identity();
+
+		return $own_identity !== '' && $own_identity === $this->identity( $webhook->url() );
+	}
+
+	/**
+	 * Returns the webhook this install registered, out of the given list.
+	 *
+	 * @param Webhook[] $webhooks The webhooks configured on the PayPal REST app.
+	 */
+	public function find_own( array $webhooks ): ?Webhook {
+		foreach ( $webhooks as $webhook ) {
+			if ( $webhook instanceof Webhook && $this->is_own( $webhook ) ) {
+				return $webhook;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Builds a host+path identity for a webhook URL, used to compare webhooks
+	 * independently of scheme, port, query string or a trailing slash.
+	 *
+	 * The path is included so that same-host installs (e.g. example.com/shop and
+	 * example.com/staging, or subdirectory multisite) are told apart.
+	 *
+	 * @param string $url The webhook URL.
+	 * @return string The lower-cased host followed by the path as-is (paths are case-sensitive),
+	 *                or an empty string when the host cannot be parsed.
+	 */
+	public function identity( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+		$path = is_string( $path ) ? rtrim( $path, '/' ) : '';
+
+		return strtolower( $host ) . $path;
+	}
+
+	/**
+	 * This install's own webhook identity, or an empty string when its URL cannot be parsed.
+	 */
+	public function own_identity(): string {
+		return $this->identity( $this->own_url() );
+	}
+
+	/**
+	 * The webhook URL this install registers with PayPal.
+	 */
+	public function own_url(): string {
+		return $this->incoming_webhook_endpoint->url();
+	}
+
+	/**
+	 * The id of the webhook this install registered, or an empty string.
+	 *
+	 * Read fresh on every call, it can be updated mid-request.
+	 */
+	private function stored_id(): string {
+		return (string) ( ( (array) get_option( WebhookRegistrar::KEY, array() ) )['id'] ?? '' );
+	}
+}

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -6,7 +6,6 @@ namespace WooCommerce\PayPalCommerce\Webhooks;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
@@ -32,6 +31,8 @@ class WebhookRegistrar {
 
 	private LoggerInterface $logger;
 
+	private OwnWebhookResolver $own_webhook_resolver;
+
 	public function __construct(
 		WebhookFactory $webhook_factory,
 		WebhookEndpoint $endpoint,
@@ -39,7 +40,8 @@ class WebhookRegistrar {
 		WebhookEventStorage $last_webhook_event_storage,
 		WebhookSimulation $webhook_simulation,
 		WebhookOrchestrator $webhook_orchestrator,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		OwnWebhookResolver $own_webhook_resolver
 	) {
 
 		$this->webhook_factory            = $webhook_factory;
@@ -49,6 +51,7 @@ class WebhookRegistrar {
 		$this->webhook_simulation         = $webhook_simulation;
 		$this->webhook_orchestrator       = $webhook_orchestrator;
 		$this->logger                     = $logger;
+		$this->own_webhook_resolver       = $own_webhook_resolver;
 	}
 
 	/**
@@ -122,13 +125,10 @@ class WebhookRegistrar {
 	 * the primary site's webhook. See GitHub issue #4604.
 	 */
 	private function do_unregister(): void {
-		$stored_id    = (string) ( ( (array) get_option( self::KEY, array() ) )['id'] ?? '' );
-		$own_identity = $this->webhook_identity( $this->incoming_webhook_endpoint->url() );
-
 		try {
 			$webhooks = $this->endpoint->list();
 			foreach ( $webhooks as $webhook ) {
-				if ( ! $this->is_own_webhook( $webhook, $own_identity, $stored_id ) ) {
+				if ( ! $this->own_webhook_resolver->is_own( $webhook ) ) {
 					$this->logger->warning(
 						"Skipping deletion of webhook {$webhook->id()} ({$webhook->url()}): it belongs to a different site and is not managed by this install."
 					);
@@ -148,53 +148,5 @@ class WebhookRegistrar {
 		delete_option( self::KEY );
 		$this->last_webhook_event_storage->clear();
 		$this->logger->info( 'Webhooks deleted.' );
-	}
-
-	/**
-	 * Whether the given webhook belongs to this site and may be deleted.
-	 *
-	 * A webhook is considered ours when either:
-	 * - its id matches the one we previously stored (provably ours regardless of the
-	 *   host it currently uses, so a domain migration or NGROK_HOST rotation still
-	 *   cleans up our former webhook instead of leaking it), or
-	 * - its URL identity (host + path) equals this install's incoming endpoint. The
-	 *   path is included so that same-host installs (e.g. example.com/shop and
-	 *   example.com/staging, or subdirectory multisite) do not delete each other's
-	 *   webhooks. The host comparison honours the NGROK_HOST development override.
-	 *
-	 * A webhook whose URL cannot be parsed (empty identity) is left in place.
-	 *
-	 * @param Webhook $webhook      The webhook to check.
-	 * @param string  $own_identity This install's incoming endpoint identity (host + path).
-	 * @param string  $stored_id    The id of the webhook this install previously registered.
-	 * @return bool
-	 */
-	private function is_own_webhook( Webhook $webhook, string $own_identity, string $stored_id ): bool {
-		if ( '' !== $stored_id && $webhook->id() === $stored_id ) {
-			return true;
-		}
-
-		$webhook_identity = $this->webhook_identity( $webhook->url() );
-
-		return '' !== $own_identity && $own_identity === $webhook_identity;
-	}
-
-	/**
-	 * Builds a host+path identity for a webhook URL, used to compare webhooks
-	 * independently of scheme, port, query string or a trailing slash.
-	 *
-	 * @param string $url The webhook URL.
-	 * @return string The lower-cased host and path, or an empty string when the host cannot be parsed.
-	 */
-	private function webhook_identity( string $url ): string {
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( ! is_string( $host ) || '' === $host ) {
-			return '';
-		}
-
-		$path = wp_parse_url( $url, PHP_URL_PATH );
-		$path = is_string( $path ) ? rtrim( $path, '/' ) : '';
-
-		return strtolower( $host ) . $path;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: paypal, woocommerce, automattic, syde
 Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.5
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 4.1.2
+Stable tag: 4.1.3
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -160,6 +160,9 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 ⚠️ Major Update — This release includes significant changes. Please back up your site before updating.
 
 == Changelog ==
+
+= 4.1.3 - XXXX-XX-XX =
+* TBD
 
 = 4.1.2 - 2026-08-04 =
 * Enhancement - Advanced onboarding options for onboarding wizard #4496

--- a/readme.txt
+++ b/readme.txt
@@ -162,7 +162,24 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 == Changelog ==
 
 = 4.1.3 - XXXX-XX-XX =
-* TBD
+* Enhancement - PayPal JS SDK v6 is now the default for new store setups, moving PayPal buttons, Apple Pay, Google Pay, Advanced Card Fields, Fastlane, Pay Later messaging and vaulting subscriptions onto the new integration; existing stores remain on SDK v5 with this version #4641
+* Enhancement - Add filter hooks to customize the payment method title and allow payment method icons #4586
+* Enhancement - Clearer, customer-friendly decline messages for 3D Secure rejections #4573
+* Enhancement - First-party WooCommerce plugin detection for product customizations #4552
+* Enhancement - Allow Pay Later to remain available when vaulting is enabled #4611
+* Enhancement - Improve manual-renewal-only subscription scenarios #4621
+* Enhancement - Exclude connection details from Blueprint exports by default #4647
+* Fix - Apple Pay shown under the PayPal gateway when a vaulting subscription is in the cart #4546
+* Fix - Prevent Vault API calls made with an empty customer ID #4567
+* Fix - Keep recoverable PAYER_ACTION_REQUIRED orders from failing prematurely #4569
+* Fix - Retain the shopper's checkout data when returning from PayPal on mobile #4649
+* Fix - PayPal gateway missing on Block Checkout when WooCommerce Subscriptions automatic renewals are enabled #4659
+* Fix - Webhook registration hitting the wrong API host right after onboarding #4669
+* Fix - Give the Pay upon Invoice phone field its own ID #4666
+* Fix - Stop polling the merchant-integrations endpoint on every cron run #4640
+* Fix - Skip WooCommerce Inbox note registration during AJAX requests #4607
+* Fix - Remove the orphaned reCAPTCHA Inbox note and align its enabled checks #4634
+* Fix - Prevent Advanced Card Fields submission when Blocks checkout fields are invalid (author @marcofucito) #4435
 
 = 4.1.2 - 2026-08-04 =
 * Enhancement - Advanced onboarding options for onboarding wizard #4496

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,8 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Skip WooCommerce Inbox note registration during AJAX requests #4607
 * Fix - Remove the orphaned reCAPTCHA Inbox note and align its enabled checks #4634
 * Fix - Prevent Advanced Card Fields submission when Blocks checkout fields are invalid (author @marcofucito) #4435
+* Fix - Show the product button on variable products with no preselected attributes #4691
+* Fix - Fix negative tax_total when a discount is not reported by WooCommerce #4690
 
 = 4.1.2 - 2026-08-04 =
 * Enhancement - Advanced onboarding options for onboarding wizard #4496

--- a/tests/PHPUnit/ApiClient/Authentication/ResolvingBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/ResolvingBearerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ApiHostResolver;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\ApiClient\Authentication\ResolvingBearer
+ */
+class ResolvingBearerTest extends TestCase
+{
+    /**
+     * Builds a Cache stub whose get() returns an already-valid, non-expired
+     * cached token JSON, so PayPalBearer::bearer() short-circuits on its
+     * cache hit and never performs a real HTTP request.
+     */
+    private function cache_with_valid_token(string $access_token): Cache
+    {
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('get')
+            ->andReturn('{"access_token":"' . $access_token . '","expires_in":100, "created":' . time() . '}');
+
+        return $cache;
+    }
+
+    private function host_resolver(): ApiHostResolver
+    {
+        $host_resolver = Mockery::mock(ApiHostResolver::class);
+        $host_resolver->shouldReceive('host')->andReturn('https://example.com');
+
+        return $host_resolver;
+    }
+
+    private function logger(): LoggerInterface
+    {
+        return Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
+    }
+
+    /**
+     * GIVEN a merchant who has not completed onboarding
+     * WHEN the current bearer is resolved
+     * THEN the placeholder ConnectBearer token is returned instead of a real PayPal token
+     */
+    public function test_bearer_reflects_disconnected_state(): void
+    {
+        $connection_state = new ConnectionState(false, new Environment(false));
+
+        $testee = new ResolvingBearer(
+            $connection_state,
+            $this->cache_with_valid_token('paypal-token'),
+            $this->host_resolver(),
+            'key',
+            'secret',
+            $this->logger(),
+            null,
+            Mockery::mock(TokenRateLimiter::class)
+        );
+
+        $this->assertSame('token', $testee->bearer()->token());
+    }
+
+    /**
+     * GIVEN a merchant who has completed onboarding and has a valid cached PayPal token
+     * WHEN the current bearer is resolved
+     * THEN the cached PayPal token is returned instead of the ConnectBearer placeholder
+     */
+    public function test_bearer_reflects_connected_state(): void
+    {
+        $connection_state = new ConnectionState(true, new Environment(false));
+
+        $testee = new ResolvingBearer(
+            $connection_state,
+            $this->cache_with_valid_token('paypal-token'),
+            $this->host_resolver(),
+            'key',
+            'secret',
+            $this->logger(),
+            null,
+            Mockery::mock(TokenRateLimiter::class)
+        );
+
+        $this->assertSame('paypal-token', $testee->bearer()->token());
+    }
+
+    /**
+     * GIVEN a merchant who is not yet connected, resolved once before onboarding completes
+     * WHEN the merchant's connection state switches to connected mid-request, as
+     * ConnectionState::connect() does right after onboarding finishes
+     * AND the bearer is resolved again on the same resolver instance
+     * THEN the second resolution reflects the new connection state instead of returning a
+     * bearer cached from before the switch
+     */
+    public function test_bearer_reflects_connection_state_changes_mid_request_without_caching(): void
+    {
+        $connection_state = new ConnectionState(false, new Environment(false));
+
+        $testee = new ResolvingBearer(
+            $connection_state,
+            $this->cache_with_valid_token('paypal-token'),
+            $this->host_resolver(),
+            'key',
+            'secret',
+            $this->logger(),
+            null,
+            Mockery::mock(TokenRateLimiter::class)
+        );
+
+        $bearer_before_connect = $testee->bearer();
+
+        $connection_state->connect(false);
+
+        $bearer_after_connect = $testee->bearer();
+
+        $this->assertSame('token', $bearer_before_connect->token());
+        $this->assertSame('paypal-token', $bearer_after_connect->token());
+        $this->assertNotSame($bearer_before_connect->token(), $bearer_after_connect->token());
+    }
+}

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -1210,6 +1210,78 @@ class OrderEndpointTest extends TestCase
         $testee->create([$purchaseUnit], ExperienceContext::SHIPPING_PREFERENCE_GET_FROM_FILE, $payer);
     }
 
+    /**
+     * GIVEN a purchase unit whose shipping node only carries options
+     * WHEN an order is created with a non-GET_FROM_FILE shipping preference
+     * THEN the shipping node left empty by stripping the options is not sent
+     */
+    public function testCreateUnsetsEmptyShippingNodeLeftAfterRemovingOptions()
+    {
+        expect('wp_json_encode')->andReturnUsing('json_encode');
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+        $rawResponse = [
+            'body' => '{"success":true}',
+            'headers' => $headers,
+        ];
+        $host = 'https://example.com/';
+        $token = Mockery::mock(Token::class);
+        $token->expects('token')->andReturn('bearer');
+        $bearer = Mockery::mock(Bearer::class);
+        $bearer->expects('bearer')->andReturn($token);
+        $orderFactory = Mockery::mock(OrderFactory::class);
+        $expectedOrder = Mockery::mock(Order::class);
+        $orderFactory->expects('from_paypal_response')->andReturn($expectedOrder);
+        $patchCollectionFactory = Mockery::mock(PatchCollectionFactory::class);
+        $intent = 'CAPTURE';
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+        $logger->shouldReceive('debug');
+        $subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+
+        $fraudnet = Mockery::mock(FraudNet::class);
+
+        $testee = new OrderEndpoint(
+            $host,
+            $bearer,
+            $orderFactory,
+            $patchCollectionFactory,
+            $intent,
+            $logger,
+            $subscription_helper,
+            false,
+            $fraudnet
+        );
+
+        $purchaseUnit = Mockery::mock(PurchaseUnit::class, ['contains_physical_goods' => true]);
+        $purchaseUnit
+            ->expects('to_array')
+            ->andReturn([
+                'shipping' => [
+                    'options' => [['id' => 'flat_rate']],
+                ],
+            ]);
+        $purchaseUnit->shouldReceive('shipping')->andReturn($this->shipping);
+
+        $capturedBody = null;
+        expect('wp_remote_get')
+            ->andReturnUsing(function ($url, $args) use ($rawResponse, &$capturedBody) {
+                $capturedBody = json_decode($args['body'], true);
+                return $rawResponse;
+            });
+        expect('is_wp_error')->with($rawResponse)->andReturn(false);
+        expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(201);
+
+        $payer = Mockery::mock(Payer::class);
+        $payer->expects('email_address')->andReturn('');
+
+        $testee->create([$purchaseUnit], ExperienceContext::SHIPPING_PREFERENCE_SET_PROVIDED_ADDRESS, $payer);
+
+        $this->assertArrayNotHasKey('shipping', $capturedBody['purchase_units'][0]);
+    }
+
     public function testCaptureDeclinedWithFraudResponseCodeThrowsDetailedMessage(): void
     {
         expect('wp_json_encode')->andReturnUsing('json_encode');

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -515,6 +515,92 @@ class AmountFactoryTest extends TestCase
 	}
 
 	/**
+	 * A plain order with no fees, on the non-free-trial path, carrying only the totals
+	 * the tax reconciliation reads.
+	 */
+	private function orderWithTotals(
+		float $subtotal,
+		float $tax,
+		float $shipping,
+		float $discount,
+		float $total
+	): \WC_Order {
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
+		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
+		$order->shouldReceive( 'get_total' )->andReturn( $total );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+
+		return $order;
+	}
+
+	/**
+	 * An unreported discount (a plugin calling set_total() directly, or an order read
+	 * before get_total_discount() populates) used to push the whole gap into tax and
+	 * drive it negative, which PayPal rejects on Level 2 card data.
+	 *
+	 * @dataProvider dataUnreportedDiscountCases
+	 */
+	public function testFromWcOrderRestoresTaxAndBooksUnreportedDiscount(
+		float $subtotal,
+		float $tax,
+		float $shipping,
+		float $reported_discount,
+		float $wc_total,
+		string $expected_tax,
+		string $expected_discount
+	): void {
+		$order = $this->orderWithTotals( $subtotal, $tax, $shipping, $reported_discount, $wc_total );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( $expected_tax, $breakdown->tax_total()->value_str() );
+		$this->assertSame( $expected_discount, $breakdown->discount()->value_str() );
+
+		$sum = (float) $breakdown->item_total()->value_str()
+			+ (float) $breakdown->shipping()->value_str()
+			+ (float) $breakdown->tax_total()->value_str()
+			- (float) $breakdown->discount()->value_str();
+		$this->assertSame(
+			number_format( $wc_total, 2, '.', '' ),
+			number_format( $sum, 2, '.', '' )
+		);
+	}
+
+	public function dataUnreportedDiscountCases(): array
+	{
+		return [
+			// Rows 1 and 2 must produce the same split: reported or not, the breakdown
+			// PayPal receives is identical.
+			'unreported_discount_smaller_than_tax'      => [ 100.0, 19.0, 0.0, 0.0, 69.0, '19.00', '50.00' ],
+			'reported_discount_matches_unreported_case' => [ 100.0, 19.0, 0.0, 50.0, 69.0, '19.00', '50.00' ],
+			'zero_tax_whole_item_total_discounted'      => [ 45.01, 0.0, 0.0, 0.0, 0.01, '0.00', '45.00' ],
+		];
+	}
+
+	/**
+	 * Guards the behaviour that predates the fallback.
+	 */
+	public function testFromWcOrderSmallRoundingDeltaStaysInTaxNotDiscount(): void
+	{
+		// 16.54 is one cent under the component sum of 16.55.
+		$order = $this->orderWithTotals( 13.90, 2.65, 0.0, 0.0, 16.54 );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( '2.64', $breakdown->tax_total()->value_str() );
+		$this->assertNull( $breakdown->discount() );
+	}
+
+	/**
 	 * A manually created order with a negative fee
 	 * must not be undercharged on the PayPal side. The negative fee is surfaced as
 	 * a discount AND filtered out of the items sent to PayPal, so it must not also

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -462,17 +462,7 @@ class AmountFactoryTest extends TestCase
 		float $discount,
 		float $wc_total
 	): void {
-		$order = Mockery::mock( \WC_Order::class );
-		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
-		$order->shouldReceive( 'get_total_fees' )->andReturn( $fees );
-		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
-		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
-		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
-		$order->shouldReceive( 'get_total' )->andReturn( $wc_total );
-		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
-		$order->shouldReceive( 'get_meta' )->andReturn( null );
-		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
-		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+		$order = $this->orderWithTotals( $subtotal, $tax, $shipping, $discount, $wc_total, $fees );
 
 		$result    = $this->testee->from_wc_order( $order );
 		$breakdown = $result->breakdown();
@@ -515,19 +505,20 @@ class AmountFactoryTest extends TestCase
 	}
 
 	/**
-	 * A plain order with no fees, on the non-free-trial path, carrying only the totals
-	 * the tax reconciliation reads.
+	 * An order on the non-free-trial path, carrying only the totals the tax
+	 * reconciliation reads.
 	 */
 	private function orderWithTotals(
 		float $subtotal,
 		float $tax,
 		float $shipping,
 		float $discount,
-		float $total
+		float $total,
+		float $fees = 0.0
 	): \WC_Order {
 		$order = Mockery::mock( \WC_Order::class );
 		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
-		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( $fees );
 		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
 		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
 		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
@@ -541,9 +532,8 @@ class AmountFactoryTest extends TestCase
 	}
 
 	/**
-	 * An unreported discount (a plugin calling set_total() directly, or an order read
-	 * before get_total_discount() populates) used to push the whole gap into tax and
-	 * drive it negative, which PayPal rejects on Level 2 card data.
+	 * An unreported discount (set_total() called directly, or an order read before
+	 * get_total_discount() populates) used to push the whole gap into tax.
 	 *
 	 * @dataProvider dataUnreportedDiscountCases
 	 */
@@ -577,11 +567,12 @@ class AmountFactoryTest extends TestCase
 	public function dataUnreportedDiscountCases(): array
 	{
 		return [
-			// Rows 1 and 2 must produce the same split: reported or not, the breakdown
-			// PayPal receives is identical.
+			// Rows 1 and 2 must produce the same split, reported or not.
 			'unreported_discount_smaller_than_tax'      => [ 100.0, 19.0, 0.0, 0.0, 69.0, '19.00', '50.00' ],
 			'reported_discount_matches_unreported_case' => [ 100.0, 19.0, 0.0, 50.0, 69.0, '19.00', '50.00' ],
 			'zero_tax_whole_item_total_discounted'      => [ 45.01, 0.0, 0.0, 0.0, 0.01, '0.00', '45.00' ],
+			// A negative fee can make WC report negative tax.
+			'negative_wc_tax_is_floored_at_zero'       => [ 100.0, -5.0, 0.0, 0.0, 60.0, '0.00', '40.00' ],
 		];
 	}
 
@@ -590,7 +581,7 @@ class AmountFactoryTest extends TestCase
 	 */
 	public function testFromWcOrderSmallRoundingDeltaStaysInTaxNotDiscount(): void
 	{
-		// 16.54 is one cent under the component sum of 16.55.
+		// The delta_minus_one case above, asserted on the split rather than the invariant.
 		$order = $this->orderWithTotals( 13.90, 2.65, 0.0, 0.0, 16.54 );
 
 		$result    = $this->testee->from_wc_order( $order );

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ShippingOption;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelEligibility;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelHelper;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
@@ -273,6 +274,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$address->shouldReceive('country_code')->andReturn('');
 		$shipping = Mockery::mock(Shipping::class);
 		$shipping->shouldReceive('address')->andReturn($address);
+		$shipping->shouldReceive('options')->andReturn([]);
 
 		$shipping_factory = Mockery::mock(ShippingFactory::class);
 		$shipping_factory->expects('from_wc_customer')->andReturn($shipping);
@@ -369,6 +371,82 @@ class PurchaseUnitFactoryTest extends TestCase
 
 		$unit = $testee->from_wc_cart($wc_cart);
 		$this->assertEquals($shipping, $unit->shipping());
+	}
+
+	/**
+	 * GIVEN a cart customer with an unusable shipping address whose shipping node
+	 *       carries shipping options
+	 * WHEN the purchase unit is built for the cart
+	 * THEN the shipping node is kept with a null address
+	 * AND the shipping name and options survive unchanged
+	 */
+	public function test_wc_cart_shipping_kept_with_null_address_when_unusable_address_has_options()
+	{
+		$wc_customer = Mockery::mock(\WC_Customer::class);
+		expect('WC')->andReturn((object) ['customer' => $wc_customer, 'session' => null]);
+
+		$wc_cart = Mockery::mock(\WC_Cart::class);
+		$amount = Mockery::mock(Amount::class);
+
+		$address = $this->create_address_mock('DE', '12345', '', 'Berlin');
+		$option = new ShippingOption('flat_rate', 'Flat rate', true, new Money(5.0, 'USD'), ShippingOption::TYPE_SHIPPING);
+
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping->shouldReceive('address')->andReturn($address);
+		$shipping->shouldReceive('options')->andReturn([$option]);
+		$shipping->shouldReceive('name')->andReturn('Jane Doe');
+
+		$shipping_factory = Mockery::mock(ShippingFactory::class);
+		$shipping_factory->expects('from_wc_customer')->with($wc_customer, false)->andReturn($shipping);
+
+		$testee = $this->create_testee(
+			$this->create_amount_factory_mock($amount, 'from_wc_cart', $wc_cart),
+			$this->create_item_factory_mock([$this->item], 'from_wc_cart', $wc_cart),
+			$shipping_factory,
+			null,
+			null,
+			$this->create_payment_level_eligibility_mock('', false)
+		);
+
+		$unit = $testee->from_wc_cart($wc_cart);
+
+		$result_shipping = $unit->shipping();
+		$this->assertInstanceOf(Shipping::class, $result_shipping);
+		$this->assertNull($result_shipping->address());
+		$this->assertSame([$option], $result_shipping->options());
+		$this->assertEquals('Jane Doe', $result_shipping->name());
+	}
+
+	/**
+	 * GIVEN a cart customer with an unusable shipping address and no shipping options
+	 * WHEN the purchase unit is built for the cart
+	 * THEN the shipping node is dropped
+	 */
+	public function test_wc_cart_shipping_dropped_when_unusable_address_has_no_options()
+	{
+		$wc_customer = Mockery::mock(\WC_Customer::class);
+		expect('WC')->andReturn((object) ['customer' => $wc_customer, 'session' => null]);
+
+		$wc_cart = Mockery::mock(\WC_Cart::class);
+		$amount = Mockery::mock(Amount::class);
+
+		$address = $this->create_address_mock('DE', '12345', '', 'Berlin');
+		$shipping = $this->create_shipping_mock($address);
+
+		$shipping_factory = Mockery::mock(ShippingFactory::class);
+		$shipping_factory->expects('from_wc_customer')->with($wc_customer, false)->andReturn($shipping);
+
+		$testee = $this->create_testee(
+			$this->create_amount_factory_mock($amount, 'from_wc_cart', $wc_cart),
+			$this->create_item_factory_mock([$this->item], 'from_wc_cart', $wc_cart),
+			$shipping_factory,
+			null,
+			null,
+			$this->create_payment_level_eligibility_mock('', false)
+		);
+
+		$unit = $testee->from_wc_cart($wc_cart);
+		$this->assertNull($unit->shipping());
 	}
 
 	public function test_from_paypal_response_default()
@@ -994,6 +1072,7 @@ class PurchaseUnitFactoryTest extends TestCase
 	{
 		$shipping = Mockery::mock(Shipping::class);
 		$shipping->shouldReceive('address')->zeroOrMoreTimes()->andReturn($address);
+		$shipping->shouldReceive('options')->zeroOrMoreTimes()->andReturn([]);
 		return $shipping;
 	}
 

--- a/tests/PHPUnit/ApiClient/Factory/ShippingPreferenceFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ShippingPreferenceFactoryTest.php
@@ -8,6 +8,7 @@ use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Product;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Address;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
@@ -29,6 +30,10 @@ class ShippingPreferenceFactoryTest extends TestCase
 	}
 
     /**
+     * GIVEN a purchase unit, cart/order state, context and funding source
+     * WHEN the shipping preference for the PayPal order is derived
+     * THEN the matching ExperienceContext shipping preference is returned
+     *
      * @dataProvider forStateData
      */
     public function testFromState(
@@ -47,7 +52,7 @@ class ShippingPreferenceFactoryTest extends TestCase
     public function forStateData()
     {
 		yield [
-			$this->createPurchaseUnit(true, Mockery::mock(Shipping::class)),
+			$this->createPurchaseUnit(true, $this->createShippingWithAddress()),
 			'checkout',
 			$this->createCart(true),
 			'',
@@ -55,7 +60,7 @@ class ShippingPreferenceFactoryTest extends TestCase
 			ExperienceContext::SHIPPING_PREFERENCE_SET_PROVIDED_ADDRESS,
 		];
 		yield [
-			$this->createPurchaseUnit(false, Mockery::mock(Shipping::class)),
+			$this->createPurchaseUnit(false, $this->createShippingWithAddress()),
 			'checkout',
 			$this->createCart(false),
 			'',
@@ -71,7 +76,7 @@ class ShippingPreferenceFactoryTest extends TestCase
 			ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING,
 		];
 		yield [
-			$this->createPurchaseUnit(true, Mockery::mock(Shipping::class)),
+			$this->createPurchaseUnit(true, $this->createShippingWithAddress()),
 			'checkout',
 			$this->createCart(true),
 			'card',
@@ -95,7 +100,7 @@ class ShippingPreferenceFactoryTest extends TestCase
 			ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING
 		];
 		yield [
-			$this->createPurchaseUnit(true, Mockery::mock(Shipping::class)),
+			$this->createPurchaseUnit(true, $this->createShippingWithAddress()),
 			'pay-now',
 			null,
 			'venmo',
@@ -103,7 +108,7 @@ class ShippingPreferenceFactoryTest extends TestCase
 			ExperienceContext::SHIPPING_PREFERENCE_SET_PROVIDED_ADDRESS
 		];
 		yield [
-			$this->createPurchaseUnit(true, Mockery::mock(Shipping::class)),
+			$this->createPurchaseUnit(true, $this->createShippingWithAddress()),
 			'pay-now',
 			null,
 			'card',
@@ -118,6 +123,39 @@ class ShippingPreferenceFactoryTest extends TestCase
 			$this->createWcOrder(false),
 			ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING,
 		];
+
+		yield 'checkout with options-only shipping node falls back to no shipping' => [
+			$this->createPurchaseUnit(true, $this->createShippingWithoutAddress()),
+			'checkout',
+			$this->createCart(true),
+			'',
+			null,
+			ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING,
+		];
+		yield 'pay-now with options-only shipping node falls back to no shipping' => [
+			$this->createPurchaseUnit(true, $this->createShippingWithoutAddress()),
+			'pay-now',
+			null,
+			'venmo',
+			$this->createWcOrder(true),
+			ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING,
+		];
+		yield 'card funding source with options-only shipping node falls back to no shipping' => [
+			$this->createPurchaseUnit(true, $this->createShippingWithoutAddress()),
+			'product',
+			$this->createCart(true),
+			'card',
+			null,
+			ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING,
+		];
+		yield 'product context returns get-from-file regardless of shipping address presence' => [
+			$this->createPurchaseUnit(true, $this->createShippingWithoutAddress()),
+			'product',
+			$this->createCart(true),
+			'',
+			null,
+			ExperienceContext::SHIPPING_PREFERENCE_GET_FROM_FILE,
+		];
     }
 
 	private function createPurchaseUnit(bool $containsPhysicalGoods, ?Shipping $shipping): PurchaseUnit {
@@ -125,6 +163,18 @@ class ShippingPreferenceFactoryTest extends TestCase
 		$pu->shouldReceive('contains_physical_goods')->andReturn($containsPhysicalGoods);
 		$pu->shouldReceive('shipping')->andReturn($shipping);
 		return $pu;
+	}
+
+	private function createShippingWithAddress(): Shipping {
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping->shouldReceive('address')->andReturn(Mockery::mock(Address::class));
+		return $shipping;
+	}
+
+	private function createShippingWithoutAddress(): Shipping {
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping->shouldReceive('address')->andReturn(null);
+		return $shipping;
 	}
 
 	private function createCart(bool $needsShipping): WC_Cart {

--- a/tests/PHPUnit/Blocks/PayPalPaymentMethodTest.php
+++ b/tests/PHPUnit/Blocks/PayPalPaymentMethodTest.php
@@ -1,0 +1,213 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Blocks;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use function Brain\Monkey\Functions\when;
+
+class PayPalPaymentMethodTest extends TestCase
+{
+    private $asset_getter;
+    private $smart_button;
+    private $plugin_settings;
+    private $settings_status;
+    private $gateway;
+    private $cancellation_view;
+    private $session_handler;
+    private $subscription_helper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->asset_getter        = Mockery::mock(AssetGetter::class);
+        $this->smart_button        = Mockery::mock(SmartButtonInterface::class);
+        $this->plugin_settings     = Mockery::mock(SettingsProvider::class);
+        $this->settings_status     = Mockery::mock(SettingsStatus::class);
+        $this->gateway             = Mockery::mock(PayPalGateway::class);
+        $this->cancellation_view   = Mockery::mock(CancelView::class);
+        $this->session_handler     = Mockery::mock(SessionHandler::class);
+        $this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
+
+        $this->gateway->id          = PayPalGateway::ID;
+        $this->gateway->title       = 'PayPal';
+        $this->gateway->icon        = 'https://example.test/paypal.svg';
+        $this->gateway->supports    = array('products');
+        $this->gateway->shouldReceive('get_description')->andReturn('Pay with PayPal');
+
+        $this->session_handler->shouldReceive('funding_source')->andReturn('paypal');
+
+        when('wp_create_nonce')->justReturn('nonce');
+
+        $cart = Mockery::mock(\WC_Cart::class);
+        $cart->shouldReceive('needs_shipping')->andReturn(false);
+        $wc = Mockery::mock();
+        $wc->cart = $cart;
+        when('WC')->justReturn($wc);
+    }
+
+    /**
+     * @param array<string, mixed> $script_data
+     */
+    private function createTestee(
+        array $script_data,
+        bool $add_place_order_method,
+        bool $use_place_order
+    ): PayPalPaymentMethod {
+        $this->smart_button->shouldReceive('script_data')->andReturn($script_data);
+
+        return new PayPalPaymentMethod(
+            $this->asset_getter,
+            '1.0.0',
+            $this->smart_button,
+            $this->plugin_settings,
+            $this->settings_status,
+            $this->gateway,
+            false,
+            $this->cancellation_view,
+            $this->session_handler,
+            $this->subscription_helper,
+            $add_place_order_method,
+            $use_place_order,
+            'Place order',
+            'Pay with PayPal',
+            array()
+        );
+    }
+
+    /**
+     * GIVEN a subscription cart, a "Place order" method, and whether a vault token can be
+     *      saved or manual renewals are accepted
+     * WHEN get_payment_method_data() is called
+     * THEN the standard "Place order" row is only enabled when a vault token can be saved
+     *      or manual renewals are accepted for the subscription
+     * AND under SDK v6, where the v5 smart button script data is empty, the row's smart
+     *      buttons stay disabled since the v6 express button covers that surface
+     *
+     * @dataProvider place_order_enabled_provider
+     */
+    public function test_place_order_enabled(
+        array $script_data,
+        bool $cart_contains_subscription,
+        bool $can_save_vault_token,
+        bool $accept_manual_renewals,
+        bool $add_place_order_method,
+        bool $use_place_order,
+        bool $expected,
+        bool $assert_smart_buttons_disabled
+    ): void {
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn($accept_manual_renewals);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn($can_save_vault_token);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+
+        $testee = $this->createTestee($script_data, $add_place_order_method, $use_place_order);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertSame($expected, $data['placeOrderEnabled']);
+
+        if ($assert_smart_buttons_disabled) {
+            $this->assertFalse($data['smartButtonsEnabled']);
+        }
+    }
+
+    public function place_order_enabled_provider(): array
+    {
+        return array(
+            'sdk v6, subscription cart, vaulting on, automatic renewals' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => true,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v6, subscription cart, vaulting off, automatic renewals' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => false,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v6, subscription cart, vaulting off, manual renewals accepted' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => true,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v6, no subscription in cart' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => false,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+            'sdk v5, subscription cart, vaulting on' => array(
+                'script_data'                    => array(
+                    'context'              => 'checkout-block',
+                    'can_save_vault_token' => true,
+                ),
+                'cart_contains_subscription'      => true,
+                'can_save_vault_token'            => true,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => true,
+                'use_place_order'                 => false,
+                'expected'                        => true,
+                'assert_smart_buttons_disabled'   => false,
+            ),
+            'place-order method filtered off' => array(
+                'script_data'                    => array(),
+                'cart_contains_subscription'      => false,
+                'can_save_vault_token'            => false,
+                'accept_manual_renewals'          => false,
+                'add_place_order_method'          => false,
+                'use_place_order'                 => false,
+                'expected'                        => false,
+                'assert_smart_buttons_disabled'   => true,
+            ),
+        );
+    }
+
+    /**
+     * GIVEN a gateway whose supported features vary by mode (e.g. vaulting adds
+     *      "tokenization")
+     * WHEN get_payment_method_data() is called
+     * THEN the block declares exactly those features to WooCommerce Blocks
+     */
+    public function test_supported_features_come_from_the_gateway(): void
+    {
+        $this->gateway->supports = array('products', 'subscriptions', 'tokenization');
+
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false);
+        $this->subscription_helper->shouldReceive('accept_manual_renewals')->andReturn(false);
+        $this->plugin_settings->shouldReceive('can_save_vault_token')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+
+        $testee = $this->createTestee(array(), true, false);
+        $data   = $testee->get_payment_method_data();
+
+        $this->assertSame(array('products', 'subscriptions', 'tokenization'), $data['supportedFeatures']);
+    }
+}

--- a/tests/PHPUnit/OrderEndpoints/Helper/WooCommerceOrderCreatorTest.php
+++ b/tests/PHPUnit/OrderEndpoints/Helper/WooCommerceOrderCreatorTest.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use function Brain\Monkey\Functions\expect;
 
@@ -160,5 +161,70 @@ class WooCommerceOrderCreatorTest extends TestCase {
 		$method->invoke( $sut, $wc_order, $cart_data, null, null );
 
 		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * GIVEN a PayPal order with no payer or shipping information
+	 * AND an empty cart carrying a known cart hash
+	 * WHEN create_from_paypal_order() builds the WC order
+	 * THEN the resulting WC order's cart hash is set to the cart's hash
+	 *      so the PayPal subscription replay guard can compare it later
+	 */
+	public function test_create_from_paypal_order_sets_cart_hash_from_cart_data(): void {
+		$cart_data = new CartData( array(), array(), false, 0, 'expected-cart-hash' );
+
+		$order = Mockery::mock( Order::class );
+		$order->shouldReceive( 'payer' )->andReturn( null );
+		$order->shouldReceive( 'purchase_units' )->andReturn( array() );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'set_payment_method' )->once()->with( PayPalGateway::ID );
+		$wc_order->shouldReceive( 'calculate_totals' )->twice();
+		$wc_order->shouldReceive( 'set_cart_hash' )->once()->with( 'expected-cart-hash' );
+		$wc_order->shouldReceive( 'save' )->once();
+
+		expect( 'wc_create_order' )->once()->andReturn( $wc_order );
+
+		$current_user     = new \stdClass();
+		$current_user->ID = 0;
+		expect( 'wp_get_current_user' )->once()->andReturn( $current_user );
+
+		$wc_customer_holder           = new \stdClass();
+		$wc_customer_holder->customer = null;
+		expect( 'WC' )->once()->andReturn( $wc_customer_holder );
+
+		expect( 'apply_filters' )
+			->once()
+			->with(
+				'woocommerce_paypal_payments_order_creator_get_shipping',
+				null,
+				$order,
+				null
+			)
+			->andReturn( null );
+
+		expect( 'do_action' )
+			->once()
+			->with(
+				'woocommerce_paypal_payments_woocommerce_order_created_from_cart',
+				$wc_order,
+				$cart_data
+			);
+
+		$session_handler = Mockery::mock( SessionHandler::class );
+		$session_handler->shouldReceive( 'funding_source' )->once()->andReturn( null );
+
+		$sut = new WooCommerceOrderCreator(
+			Mockery::mock( FundingSourceRenderer::class ),
+			$session_handler,
+			Mockery::mock( SubscriptionHelper::class ),
+			Mockery::mock( CartDataFactory::class ),
+			Mockery::mock( ShippingFactory::class ),
+			Mockery::mock( PayerFactory::class )
+		);
+
+		$result = $sut->create_from_paypal_order( $order, $cart_data );
+
+		$this->assertSame( $wc_order, $result );
 	}
 }

--- a/tests/PHPUnit/OrderEndpoints/Helper/WooCommerceOrderCreatorTest.php
+++ b/tests/PHPUnit/OrderEndpoints/Helper/WooCommerceOrderCreatorTest.php
@@ -5,10 +5,12 @@ namespace WooCommerce\PayPalCommerce\OrderEndpoints\Helper;
 
 use Mockery;
 use ReflectionMethod;
+use WC_Customer;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
@@ -226,5 +228,143 @@ class WooCommerceOrderCreatorTest extends TestCase {
 		$result = $sut->create_from_paypal_order( $order, $cart_data );
 
 		$this->assertSame( $wc_order, $result );
+	}
+
+	/**
+	 * GIVEN shipping is not required and PayPal returned no purchase-unit shipping
+	 * AND the PayPal payer carries only an email address (no billing address)
+	 * AND the logged-in WooCommerce customer has a saved billing address
+	 * WHEN configure_addresses() is invoked via reflection
+	 * THEN the order's billing address is set from the customer's saved billing
+	 *      fields instead of being left empty
+	 * AND no shipping address is set
+	 */
+	public function test_configure_addresses_falls_back_to_customer_billing_when_payer_has_no_address(): void {
+		$payer = Mockery::mock( Payer::class );
+		$payer->shouldReceive( 'address' )->andReturn( null );
+		$payer->shouldReceive( 'name' )->andReturn( null );
+		$payer->shouldReceive( 'phone' )->andReturn( null );
+		$payer->shouldReceive( 'email_address' )->andReturn( 'payer@example.com' );
+
+		$wc_customer = Mockery::mock( WC_Customer::class );
+		$wc_customer->shouldReceive( 'get_email' )->andReturn( 'john@example.com' );
+		$wc_customer->shouldReceive( 'get_billing_address_1' )->andReturn( '123 Main St' );
+		$wc_customer->shouldReceive( 'get_billing_address_2' )->andReturn( '' );
+		$wc_customer->shouldReceive( 'get_billing_first_name' )->andReturn( 'John' );
+		$wc_customer->shouldReceive( 'get_billing_last_name' )->andReturn( 'Doe' );
+		$wc_customer->shouldReceive( 'get_billing_city' )->andReturn( 'NYC' );
+		$wc_customer->shouldReceive( 'get_billing_state' )->andReturn( 'NY' );
+		$wc_customer->shouldReceive( 'get_billing_postcode' )->andReturn( '10001' );
+		$wc_customer->shouldReceive( 'get_billing_country' )->andReturn( 'US' );
+		$wc_customer->shouldReceive( 'get_billing_email' )->andReturn( 'john@example.com' );
+		$wc_customer->shouldReceive( 'get_billing_phone' )->andReturn( '5551234' );
+
+		$wc_customer_holder           = new \stdClass();
+		$wc_customer_holder->customer = $wc_customer;
+		expect( 'WC' )->andReturn( $wc_customer_holder );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'set_billing_address' )
+			->once()
+			->with(
+				array(
+					'email'      => 'john@example.com',
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+					'address_1'  => '123 Main St',
+					'address_2'  => '',
+					'city'       => 'NYC',
+					'state'      => 'NY',
+					'postcode'   => '10001',
+					'country'    => 'US',
+					'phone'      => '5551234',
+				)
+			);
+		$wc_order->shouldReceive( 'set_shipping_address' )->never();
+		$wc_order->shouldReceive( 'calculate_totals' )->once();
+
+		$sut = new WooCommerceOrderCreator(
+			Mockery::mock( FundingSourceRenderer::class ),
+			Mockery::mock( SessionHandler::class ),
+			Mockery::mock( SubscriptionHelper::class ),
+			Mockery::mock( CartDataFactory::class ),
+			Mockery::mock( ShippingFactory::class ),
+			Mockery::mock( PayerFactory::class )
+		);
+
+		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'configure_addresses' );
+		$method->setAccessible( true );
+
+		$method->invoke( $sut, $wc_order, $payer, null, false );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * GIVEN shipping is not required
+	 * AND the PayPal payer already carries a valid billing address
+	 * AND the logged-in WooCommerce customer also has a saved billing address
+	 * WHEN configure_addresses() is invoked via reflection
+	 * THEN the order's billing address is set from the PayPal payer's address
+	 * AND the customer's saved billing address is not used to overwrite it
+	 */
+	public function test_configure_addresses_keeps_payer_billing_address_when_present(): void {
+		$address = Mockery::mock( \WooCommerce\PayPalCommerce\ApiClient\Entity\Address::class );
+		$address->shouldReceive( 'address_line_1' )->andReturn( '456 Payer Ave' );
+		$address->shouldReceive( 'address_line_2' )->andReturn( '' );
+		$address->shouldReceive( 'admin_area_2' )->andReturn( 'LA' );
+		$address->shouldReceive( 'admin_area_1' )->andReturn( 'CA' );
+		$address->shouldReceive( 'postal_code' )->andReturn( '90001' );
+		$address->shouldReceive( 'country_code' )->andReturn( 'US' );
+
+		$payer = Mockery::mock( Payer::class );
+		$payer->shouldReceive( 'address' )->andReturn( $address );
+		$payer->shouldReceive( 'name' )->andReturn( null );
+		$payer->shouldReceive( 'phone' )->andReturn( null );
+		$payer->shouldReceive( 'email_address' )->andReturn( 'payer@example.com' );
+
+		$wc_customer = Mockery::mock( WC_Customer::class );
+		$wc_customer->shouldReceive( 'get_email' )->andReturn( '' );
+		$wc_customer->shouldReceive( 'get_billing_address_1' )->never();
+
+		$wc_customer_holder           = new \stdClass();
+		$wc_customer_holder->customer = $wc_customer;
+		expect( 'WC' )->andReturn( $wc_customer_holder );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'set_billing_address' )
+			->once()
+			->with(
+				array(
+					'email'      => 'payer@example.com',
+					'first_name' => '',
+					'last_name'  => '',
+					'address_1'  => '456 Payer Ave',
+					'address_2'  => '',
+					'city'       => 'LA',
+					'state'      => 'CA',
+					'postcode'   => '90001',
+					'country'    => 'US',
+					'phone'      => '',
+				)
+			);
+		$wc_order->shouldReceive( 'set_shipping_address' )->never();
+		$wc_order->shouldReceive( 'calculate_totals' )->once();
+
+		$sut = new WooCommerceOrderCreator(
+			Mockery::mock( FundingSourceRenderer::class ),
+			Mockery::mock( SessionHandler::class ),
+			Mockery::mock( SubscriptionHelper::class ),
+			Mockery::mock( CartDataFactory::class ),
+			Mockery::mock( ShippingFactory::class ),
+			Mockery::mock( PayerFactory::class )
+		);
+
+		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'configure_addresses' );
+		$method->setAccessible( true );
+
+		$method->invoke( $sut, $wc_order, $payer, null, false );
+
+		$this->addToAssertionCount( 1 );
 	}
 }

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -888,6 +888,8 @@ class SdkV6ManagerTest extends TestCase
         $this->context->shouldReceive('location')->andReturn($location);
         $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
         $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        // Off, so the hand-over to v5 is not what vetoes the claim here.
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')->andReturn(false);
         $this->messages_eligibility->shouldReceive('is_enabled_for_location')->andReturn(true);
 
         $testee = $this->createTestee();
@@ -954,6 +956,10 @@ class SdkV6ManagerTest extends TestCase
         $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
             ->with('custom_placement')
             ->andReturn(true);
+        // Off for the page's own location, so the hand-over to v5 does not apply.
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->with($location)
+            ->andReturn(false);
         // No block present, so has_paylater_block() resolves false and
         // messages_settings_location() falls back to the empty location, not
         // 'custom_placement' - the eligibility lookup below reflects that.
@@ -968,6 +974,56 @@ class SdkV6ManagerTest extends TestCase
         $testee = $this->createTestee();
 
         $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN no v6 page context (home or shop), the mini-cart smart-button location
+     *       disabled so nothing else would claim the page, and v5 Pay Later messaging
+     *       enabled for the resolved page location
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN it loads, claiming the page so the v5 stack stands down there — v6 owns
+     *      messaging wherever it is active, and withholds the message on home and shop
+     *      until it has a hook of its own rather than letting v5 draw it
+     * AND with messaging disabled for that same location nothing claims the page, so it
+     *     does not load — the claim is made only where v5 would otherwise have drawn a
+     *     banner
+     *
+     * @dataProvider homeShopMessagingClaimProvider
+     */
+    public function testShouldLoadOnCurrentPageClaimsHomeAndShopWhereV5WouldOtherwiseRenderAMessage(
+        string $location,
+        bool $messaging_enabled,
+        bool $expected
+    ): void {
+        $this->context->shouldReceive('context')->andReturn('');
+        $this->context->shouldReceive('location')->andReturn($location);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        // Off, so the sitewide fallback cannot claim the page and the messaging
+        // decision below is the only thing that can.
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
+            ->andReturn(false);
+        // Catch-all so an incidental call for 'custom_placement' (reachable through
+        // messages_settings_location()'s has_paylater_block() check) does not throw.
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->andReturn(false)
+            ->byDefault();
+        $this->settings_status->shouldReceive('is_pay_later_messaging_enabled_for_location')
+            ->with($location)
+            ->andReturn($messaging_enabled);
+
+        $testee = $this->createTestee();
+
+        $this->assertSame($expected, $testee->should_load_on_current_page());
+    }
+
+    public function homeShopMessagingClaimProvider(): array
+    {
+        return [
+            'home page is claimed when v5 has a message there' => ['home', true, true],
+            'shop page is claimed when v5 has a message there' => ['shop', true, true],
+            'home page is left alone when v5 has no message'   => ['home', false, false],
+            'shop page is left alone when v5 has no message'   => ['shop', false, false],
+        ];
     }
 
     /**

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -328,6 +328,46 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
+     * GIVEN a subscription cart on a free trial ($0 today), which therefore needs no
+     *       one-time payment
+     * WHEN determining which locations should render on the current page
+     * THEN the checkout still renders, because it must offer the PayPal
+     *      save-without-purchase button for the vaulted token backing the future
+     *      recurring payment
+     * AND the cart and mini-cart stay suppressed regardless of the free-trial flag,
+     *     since neither has a form to submit that vaulted token from
+     * AND a $0 cart that is NOT a free trial (e.g. a full-value coupon) keeps the
+     *     checkout suppressed too, same as before the fix
+     *
+     * @dataProvider free_trial_checkout_provider
+     */
+    public function testDetermineRenderPlacesCheckoutOnFreeTrialCart(bool $needs_payment, bool $is_free_trial_cart, bool $expected_checkout): void
+    {
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(true);
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn($is_free_trial_cart);
+
+        $cart = Mockery::mock();
+        $cart->shouldReceive('needs_payment')->andReturn($needs_payment);
+        when('WC')->justReturn((object) ['cart' => $cart]);
+
+        $testee = $this->createTestee();
+        $result = $testee->determine_render_places();
+
+        $this->assertSame($expected_checkout, $result['checkout']);
+        $this->assertSame($needs_payment, $result['cart']);
+        $this->assertSame($needs_payment, $result['mini-cart']);
+    }
+
+    public function free_trial_checkout_provider(): array
+    {
+        return [
+            'free-trial cart needing no payment still enables checkout' => [false, true, true],
+            'zero-total non-free-trial cart keeps checkout suppressed'  => [false, false, false],
+            'ordinary cart needing payment enables checkout regardless of free trial' => [true, false, true],
+        ];
+    }
+
+    /**
      * GIVEN the mini-cart smart button location is enabled sitewide
      * WHEN checking whether the v6 SDK should load on a page with no matching page context
      *      (e.g. the shop or home page, where a block Mini-Cart may still appear)

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -1831,6 +1831,29 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
+     * GIVEN a checkout page where the mini-cart smart button location is also enabled
+     * WHEN the SDK bootstrap data is generated
+     * THEN button_styles carries a shorter height for the mini-cart entry, since the
+     *      mini-cart column is narrower than a page column and a full-height button
+     *      there renders oversized
+     * AND the checkout page's own entry keeps the full page-width button height, so the
+     *     two heights differ within the same payload rather than both falling back to
+     *     one hardcoded value
+     */
+    public function testScriptDataButtonStylesMiniCartHeightDiffersFromPageContext(): void
+    {
+        $this->stub_common_script_data_dependencies();
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')
+            ->with('mini-cart')->andReturn(true);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(SdkV6Manager::PAYMENT_BUTTON_HEIGHT, $data['button_styles']['checkout']['height']);
+        $this->assertSame(SdkV6Manager::MINI_CART_BUTTON_HEIGHT, $data['button_styles']['mini-cart']['height']);
+    }
+
+    /**
      * GIVEN the BCDC row is eligible to print (checkout, BCDC enabled, the
      *       gateway available, no subscription in the cart)
      * WHEN the card button wrapper is rendered

--- a/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
@@ -622,4 +622,54 @@ class SettingsProviderTest extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * GIVEN a merchant connection with or without a client ID, and vaulting ("Save PayPal
+	 *      and Venmo") on or off
+	 * WHEN can_save_vault_token() is called
+	 * THEN a vault token can only be saved when the merchant is connected (has a client ID)
+	 *      and vaulting is enabled
+	 *
+	 * @dataProvider can_save_vault_token_provider
+	 */
+	public function test_can_save_vault_token(
+		string $client_id,
+		bool $save_paypal_and_venmo,
+		bool $expected
+	): void {
+		$this->general_settings
+			->shouldReceive( 'get_merchant_data' )
+			->andReturn( new MerchantConnectionDTO( true, $client_id, '', '' ) );
+
+		$this->settings_model
+			->shouldReceive( 'get_save_paypal_and_venmo' )
+			->andReturn( $save_paypal_and_venmo );
+
+		$this->assertSame( $expected, $this->provider->can_save_vault_token() );
+	}
+
+	public function can_save_vault_token_provider(): array {
+		return [
+			'connected merchant, vaulting on'      => [
+				'client_id'             => 'client-id',
+				'save_paypal_and_venmo' => true,
+				'expected'              => true,
+			],
+			'connected merchant, vaulting off'     => [
+				'client_id'             => 'client-id',
+				'save_paypal_and_venmo' => false,
+				'expected'              => false,
+			],
+			'unconnected merchant, vaulting on'    => [
+				'client_id'             => '',
+				'save_paypal_and_venmo' => true,
+				'expected'              => false,
+			],
+			'unconnected merchant, vaulting off'   => [
+				'client_id'             => '',
+				'save_paypal_and_venmo' => false,
+				'expected'              => false,
+			],
+		];
+	}
 }

--- a/tests/PHPUnit/Settings/Endpoint/WebhookSettingsEndpointTest.php
+++ b/tests/PHPUnit/Settings/Endpoint/WebhookSettingsEndpointTest.php
@@ -1,0 +1,118 @@
+<?php
+declare( strict_types=1 );
+
+namespace PHPUnit\Settings\Endpoint;
+
+use Mockery;
+use WP_REST_Response;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\WebhookSettingsEndpoint;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Webhooks\IncomingWebhookEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
+use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Settings\Endpoint\WebhookSettingsEndpoint
+ */
+class WebhookSettingsEndpointTest extends TestCase {
+
+	/** @var WebhookEndpoint&Mockery\MockInterface */
+	private $webhook_endpoint;
+
+	/** @var WebhookRegistrar&Mockery\MockInterface */
+	private $webhook_registrar;
+
+	/** @var WebhookSimulation&Mockery\MockInterface */
+	private $webhook_simulation;
+
+	/** @var IncomingWebhookEndpoint&Mockery\MockInterface */
+	private $incoming_webhook_endpoint;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		when( 'rest_ensure_response' )->alias( static fn( $data ) => new WP_REST_Response( $data ) );
+		when( 'wp_parse_url' )->alias( 'parse_url' );
+		when( 'get_option' )->justReturn( [] );
+
+		$this->webhook_endpoint          = Mockery::mock( WebhookEndpoint::class );
+		$this->webhook_registrar         = Mockery::mock( WebhookRegistrar::class );
+		$this->webhook_simulation        = Mockery::mock( WebhookSimulation::class );
+		$this->incoming_webhook_endpoint = Mockery::mock( IncomingWebhookEndpoint::class );
+
+		$this->incoming_webhook_endpoint->shouldReceive( 'url' )
+			->andReturn( 'https://mysite.com/wp-json/paypal/v1/incoming' );
+	}
+
+	private function createEndpoint(): WebhookSettingsEndpoint {
+		return new WebhookSettingsEndpoint(
+			$this->webhook_endpoint,
+			$this->webhook_registrar,
+			$this->webhook_simulation,
+			new OwnWebhookResolver( $this->incoming_webhook_endpoint )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal account with a foreign site's webhook listed FIRST and this
+	 * site's own webhook listed SECOND
+	 * WHEN fetching webhook data
+	 * THEN this site's own webhook URL and lower-cased event names are returned
+	 *
+	 * Regression case for PCP-6885: fetching list()[0] would have surfaced the
+	 * foreign webhook instead of this install's own one.
+	 */
+	public function test_get_webhooks_returns_own_webhook_when_foreign_webhook_is_listed_first(): void {
+		$foreign_webhook = new Webhook( 'https://other-clone.com/wp-json/paypal/v1/incoming', [ (object) [ 'name' => 'PAYMENT.CAPTURE.COMPLETED' ] ], 'FOREIGN' );
+		$own_webhook     = new Webhook(
+			'https://mysite.com/wp-json/paypal/v1/incoming',
+			[ (object) [ 'name' => 'CHECKOUT.ORDER.APPROVED' ] ],
+			'OWN'
+		);
+
+		$this->webhook_endpoint->shouldReceive( 'list' )->andReturn( [ $foreign_webhook, $own_webhook ] );
+
+		$response = $this->createEndpoint()->get_webhooks();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'https://mysite.com/wp-json/paypal/v1/incoming', $data['data']['url'] );
+		$this->assertSame( [ 'checkout.order.approved' ], $data['data']['events'] );
+	}
+
+	/**
+	 * GIVEN a PayPal account whose only registered webhooks belong to other sites
+	 * WHEN fetching webhook data
+	 * THEN a failure response is returned reporting no webhooks were found
+	 */
+	public function test_get_webhooks_reports_failure_when_only_foreign_webhooks_exist(): void {
+		$foreign_webhook = new Webhook( 'https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN' );
+
+		$this->webhook_endpoint->shouldReceive( 'list' )->andReturn( [ $foreign_webhook ] );
+
+		$response = $this->createEndpoint()->get_webhooks();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['success'] );
+		$this->assertSame( 'No webhooks found.', $data['message'] );
+	}
+
+	/**
+	 * GIVEN the PayPal webhook list request fails
+	 * WHEN fetching webhook data
+	 * THEN a failure response is returned instead of erroring out
+	 */
+	public function test_get_webhooks_reports_failure_when_listing_webhooks_throws(): void {
+		$this->webhook_endpoint->shouldReceive( 'list' )->andThrow( new RuntimeException( 'API unavailable' ) );
+
+		$response = $this->createEndpoint()->get_webhooks();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['success'] );
+	}
+}

--- a/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
+++ b/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
@@ -9,6 +9,8 @@ use ReflectionMethod;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Webhooks\IncomingWebhookEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -24,6 +26,7 @@ class StatusReportModuleTest extends TestCase
 		parent::setUp();
 
 		when('wp_parse_url')->alias('parse_url');
+		when('get_option')->justReturn([]);
 
 		if (!defined('MINUTE_IN_SECONDS')) {
 			define('MINUTE_IN_SECONDS', 60);
@@ -32,12 +35,20 @@ class StatusReportModuleTest extends TestCase
 		$this->sut = new StatusReportModule();
 	}
 
-	private function webhook_delivery_host_status(array $registered_webhooks): string
+	private function createResolver(string $own_url = 'https://mysite.com/wp-json/paypal/v1/incoming'): OwnWebhookResolver
+	{
+		$incoming_webhook_endpoint = Mockery::mock(IncomingWebhookEndpoint::class);
+		$incoming_webhook_endpoint->shouldReceive('url')->andReturn($own_url);
+
+		return new OwnWebhookResolver($incoming_webhook_endpoint);
+	}
+
+	private function webhook_delivery_host_status(array $registered_webhooks, ?OwnWebhookResolver $resolver = null): string
 	{
 		$method = new ReflectionMethod(StatusReportModule::class, 'webhook_delivery_host_status');
 		$method->setAccessible(true);
 
-		return $method->invoke($this->sut, $registered_webhooks);
+		return $method->invoke($this->sut, $registered_webhooks, $resolver ?? $this->createResolver());
 	}
 
 	private function registered_webhooks(ContainerInterface $c, bool $is_connected): array
@@ -56,8 +67,6 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_yes_when_a_registered_webhook_matches_this_site(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([
 			new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
 			new Webhook('https://MySite.com/wp-json/paypal/v1/incoming', [], 'OWN'),
@@ -73,14 +82,15 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_reports_foreign_hosts_when_no_registered_webhook_matches_this_site(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([
 			new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
 		]);
 
 		$this->assertStringContainsString('<mark class="error">', $result);
-		$this->assertStringContainsString('Delivered to other-clone.com (this site: mysite.com)', $result);
+		$this->assertStringContainsString(
+			'Delivered to other-clone.com/wp-json/paypal/v1/incoming (this site: mysite.com/wp-json/paypal/v1/incoming)',
+			$result
+		);
 	}
 
 	/**
@@ -91,8 +101,6 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_dash_when_list_contains_only_non_webhook_items(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([new \stdClass(), 'a-string']);
 
 		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
@@ -105,8 +113,6 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_dash_when_webhooks_have_unparseable_hosts(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([
 			new Webhook('not a url', [], 'BROKEN'),
 			new Webhook('', [], 'EMPTY'),
@@ -122,11 +128,33 @@ class StatusReportModuleTest extends TestCase
 	 */
 	public function test_returns_dash_for_empty_webhook_list(): void
 	{
-		when('home_url')->justReturn('https://mysite.com');
-
 		$result = $this->webhook_delivery_host_status([]);
 
 		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN two sibling installs registered under different subdirectories of the same host
+	 * (e.g. example.com/shop and example.com/staging)
+	 * WHEN determining the webhook delivery host status
+	 * THEN the sibling's webhook is treated as foreign and the row reports the mismatch,
+	 * not a match, since host-only comparison used to conflate the two installs
+	 */
+	public function test_reports_foreign_when_sibling_subdirectory_install_shares_host(): void
+	{
+		$resolver = $this->createResolver('https://example.com/shop/wp-json/paypal/v1/incoming');
+
+		$sibling_webhook = new Webhook('https://example.com/staging/wp-json/paypal/v1/incoming', [], 'SIBLING');
+
+		$result = $this->webhook_delivery_host_status([$sibling_webhook], $resolver);
+
+		$this->assertStringContainsString('<mark class="error">', $result);
+
+		// Host-only reporting rendered this as the nonsensical "example.com (this site: example.com)".
+		$this->assertStringContainsString(
+			'Delivered to example.com/staging/wp-json/paypal/v1/incoming (this site: example.com/shop/wp-json/paypal/v1/incoming)',
+			$result
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Checkout/DisableGatewaysTest.php
+++ b/tests/PHPUnit/WcGateway/Checkout/DisableGatewaysTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Checkout;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * GIVEN scenarios only exercise the subscription-cart-processable branch of the handler; all
+ * other collaborators are stubbed to their "do nothing" outcome so that branch is isolated.
+ */
+class DisableGatewaysTest extends TestCase {
+
+	private SettingsProvider $settings_provider;
+	private SettingsStatus $settings_status;
+	private SubscriptionHelper $subscription_helper;
+	private Context $context;
+	private CardPaymentsConfiguration $card_configuration;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		when( 'WC' )->justReturn( (object) array( 'payment_gateways' => null ) );
+
+		$this->settings_provider = Mockery::mock( SettingsProvider::class );
+		$this->settings_provider->allows( 'merchant_data' )->andReturn(
+			new MerchantConnectionDTO( false, 'client-id-123', '', '' )
+		);
+
+		$this->settings_status = Mockery::mock( SettingsStatus::class );
+		$this->settings_status->allows( 'is_smart_button_enabled_for_location' )->andReturn( true );
+
+		$this->subscription_helper = Mockery::mock( SubscriptionHelper::class );
+		$this->subscription_helper->allows( 'cart_contains_paypal_subscription_product' )->andReturn( false );
+
+		$this->context = Mockery::mock( Context::class );
+		$this->context->allows( 'is_paypal_continuation' )->andReturn( false );
+
+		$this->card_configuration = Mockery::mock( CardPaymentsConfiguration::class );
+		$this->card_configuration->allows( 'use_acdc' )->andReturn( false );
+	}
+
+	/**
+	 * GIVEN the classic checkout is showing the PayPal gateway
+	 * AND the cart contains a subscription that cannot be processed (e.g. vaulting is disabled
+	 *     and the product has no linked PayPal plan)
+	 * WHEN DisableGateways::handler() filters the available payment methods
+	 * THEN the PayPal gateway is removed instead of being shown with a disabled button
+	 */
+	public function test_handler_hides_paypal_gateway_when_subscription_cart_not_processable(): void {
+		$this->subscription_helper->allows( 'subscription_cart_processable' )
+			->with( $this->settings_provider )
+			->andReturn( false );
+
+		$handler = $this->create_handler();
+
+		$methods = $handler->handler( array( PayPalGateway::ID => 'paypal-gateway' ) );
+
+		$this->assertArrayNotHasKey( PayPalGateway::ID, $methods );
+	}
+
+	/**
+	 * GIVEN the classic checkout is showing the PayPal gateway
+	 * AND the cart's subscription can be processed by PayPal (e.g. a linked plan exists or
+	 *     vaulting is available)
+	 * WHEN DisableGateways::handler() filters the available payment methods
+	 * THEN the PayPal gateway remains available
+	 */
+	public function test_handler_keeps_paypal_gateway_when_subscription_cart_is_processable(): void {
+		$this->subscription_helper->allows( 'subscription_cart_processable' )
+			->with( $this->settings_provider )
+			->andReturn( true );
+
+		$handler = $this->create_handler();
+
+		$methods = $handler->handler( array( PayPalGateway::ID => 'paypal-gateway' ) );
+
+		$this->assertArrayHasKey( PayPalGateway::ID, $methods );
+	}
+
+	private function create_handler(): DisableGateways {
+		return new DisableGateways(
+			$this->settings_provider,
+			$this->settings_status,
+			$this->subscription_helper,
+			$this->context,
+			$this->card_configuration,
+			'US'
+		);
+	}
+}

--- a/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
@@ -6,12 +6,20 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
 use Mockery;
 use Psr\Log\NullLogger;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataTransientStorage;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Endpoint\CartEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Cart;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\CartResponse;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\CartTotals;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Money as StoreApiMoney;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Factory\ShippingRate;
 use WP_REST_Request;
+
+use function Brain\Monkey\Functions\when;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\WcGateway\Endpoint\ShippingCallbackEndpoint
@@ -30,6 +38,8 @@ class ShippingCallbackEndpointTest extends TestCase
 		$this->cart_endpoint     = Mockery::mock( CartEndpoint::class );
 		$this->amount_factory    = Mockery::mock( AmountFactory::class );
 		$this->cart_data_storage = Mockery::mock( CartDataTransientStorage::class );
+
+		when( 'wp_json_encode' )->alias( 'json_encode' );
 
 		$this->sut = new ShippingCallbackEndpoint(
 			$this->cart_endpoint,
@@ -122,5 +132,279 @@ class ShippingCallbackEndpointTest extends TestCase
 
 			$this->assertFalse( $result, 'Expected false for params: ' . json_encode( $params ) );
 		}
+	}
+
+	/**
+	 * GIVEN a PayPal shipping callback with a full address and a purchase unit reference
+	 * WHEN handle_request() processes it and the Store API returns a shipping rate
+	 * THEN the response is a 200 carrying the PayPal order id, the given reference_id
+	 *      and the shipping options converted from the Store API rate
+	 * AND the address forwarded to update_customer() never carries address_line_1/2,
+	 *      which are PayPal field names the Store API does not understand
+	 */
+	public function test_handle_request_returns_success_payload_on_happy_path(): void
+	{
+		$this->stub_wc_states( [ 'US' => [ 'CA' => 'California', 'NY' => 'New York' ] ] );
+
+		$request = $this->build_request(
+			[
+				'id'              => '5O190127TN364715T',
+				'purchase_units'  => [ [ 'reference_id' => 'PUI-1' ] ],
+				'shipping_address' => [
+					'country_code' => 'US',
+					'admin_area_1' => 'CA',
+					'admin_area_2' => 'Beverly Hills',
+					'postal_code'  => '90210',
+					'address_line_1' => '1 Hollywood Blvd',
+					'address_line_2' => 'Suite 1',
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => 'US',
+						'state'    => 'CA',
+						'city'     => 'Beverly Hills',
+						'postcode' => '90210',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->cart_endpoint->shouldNotReceive( 'select_shipping_rate' );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [ 'currency_code' => 'USD', 'value' => '5.00' ] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( '5O190127TN364715T', $data['id'] );
+		$this->assertSame( 'PUI-1', $data['purchase_units'][0]['reference_id'] );
+		$this->assertSame( 'flat_rate:1', $data['purchase_units'][0]['shipping_options'][0]['id'] );
+	}
+
+	/**
+	 * GIVEN a purchase unit that carries admin_area_1 "CA" for country_code "IE" (the state
+	 *       value that used to crash the callback because Ireland has no such state)
+	 * WHEN handle_request() converts the address for the Store API
+	 * THEN the unrecognised state is dropped rather than forwarded, and the request still
+	 *      succeeds instead of surfacing the Store API's invalid_state rejection as a fatal
+	 */
+	public function test_handle_request_drops_unknown_state_instead_of_failing(): void
+	{
+		$this->stub_wc_states( [ 'IE' => [ 'CW' => 'Carlow', 'CO' => 'Cork' ] ] );
+
+		$request = $this->build_request(
+			[
+				'id'               => '5O190127TN364715T',
+				'shipping_address' => [
+					'country_code' => 'IE',
+					'admin_area_1' => 'CA',
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => 'IE',
+						'state'    => '',
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a state value that matches the full name of a WooCommerce state for the country
+	 * WHEN handle_request() converts the address for the Store API
+	 * THEN the state is converted to its WooCommerce code before being forwarded
+	 *
+	 * @dataProvider state_conversion_provider
+	 */
+	public function test_handle_request_converts_state_for_wc(
+		array $states,
+		string $country,
+		string $admin_area_1,
+		string $expected_state
+	): void
+	{
+		$this->stub_wc_states( [ $country => $states ] );
+
+		$request = $this->build_request(
+			[
+				'id'               => '5O190127TN364715T',
+				'shipping_address' => [
+					'country_code' => $country,
+					'admin_area_1' => $admin_area_1,
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => $country,
+						'state'    => $expected_state,
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function state_conversion_provider(): array
+	{
+		return [
+			'state code is upper-cased and passed through'  => [ [ 'CA' => 'California', 'NY' => 'New York' ], 'US', 'ca', 'CA' ],
+			'state name is converted to its code'           => [ [ 'CA' => 'California', 'NY' => 'New York' ], 'US', 'California', 'CA' ],
+			'state name is matched case-insensitively'      => [ [ 'CA' => 'California', 'NY' => 'New York' ], 'US', 'california', 'CA' ],
+		];
+	}
+
+	/**
+	 * GIVEN a country that has no WooCommerce state list (e.g. Germany)
+	 * WHEN handle_request() converts the address for the Store API
+	 * THEN the state value is forwarded unchanged, since there is nothing to validate it against
+	 */
+	public function test_handle_request_leaves_state_untouched_when_country_has_no_state_list(): void
+	{
+		$this->stub_wc_states( [ 'DE' => [] ] );
+
+		$request = $this->build_request(
+			[
+				'id'               => '5O190127TN364715T',
+				'shipping_address' => [
+					'country_code' => 'DE',
+					'admin_area_1' => 'Bayern',
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => 'DE',
+						'state'    => 'Bayern',
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Builds a WP_REST_Request stub carrying the given decoded body params and a fixed
+	 * cart_token, the way the PayPal shipping callback sends them.
+	 */
+	private function build_request( array $params ): WP_REST_Request
+	{
+		$params['cart_token'] = 'wc-cart-token';
+
+		$request = new WP_REST_Request();
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		$request->set_body( (string) json_encode( $params ) );
+
+		return $request;
+	}
+
+	/**
+	 * Stubs WC()->countries->get_states() with a fixed map of country code to state list.
+	 */
+	private function stub_wc_states( array $states_by_country ): void
+	{
+		when( 'wc_strtoupper' )->alias(
+			static function ( string $value ): string {
+				return strtoupper( $value );
+			}
+		);
+
+		$countries = Mockery::mock();
+		$countries->shouldReceive( 'get_states' )
+			->andReturnUsing(
+				static function ( string $country ) use ( $states_by_country ) {
+					return $states_by_country[ $country ] ?? array();
+				}
+			);
+
+		$wc            = Mockery::mock();
+		$wc->countries = $countries;
+
+		when( 'WC' )->justReturn( $wc );
+	}
+
+	/**
+	 * Builds a Store API CartResponse carrying the given shipping rates.
+	 */
+	private function cart_response_with_rates( array $shipping_rates ): CartResponse
+	{
+		$cart = new Cart( Mockery::mock( CartTotals::class ), $shipping_rates );
+
+		return new CartResponse( $cart, 'wc-cart-token' );
+	}
+
+	/**
+	 * Builds a Store API ShippingRate with the given rate id, name and price in cents.
+	 */
+	private function shipping_rate( string $rate_id, string $name, int $price_cents ): ShippingRate
+	{
+		return new ShippingRate(
+			$rate_id,
+			$name,
+			true,
+			new StoreApiMoney( (string) $price_cents, 'USD', 2 ),
+			new StoreApiMoney( '0', 'USD', 2 )
+		);
 	}
 }

--- a/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
+use Exception;
 use Mockery;
 use Psr\Log\NullLogger;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
@@ -406,6 +407,89 @@ class ShippingCallbackEndpointTest extends TestCase
 
 		$data = $response->get_data();
 		$this->assertSame( 'default', $data['purchase_units'][0]['reference_id'] );
+	}
+
+	/**
+	 * GIVEN the Store API rejects the customer address update (e.g. an invalid address field)
+	 * WHEN handle_request() calls update_customer()
+	 * THEN the exception does not escape as a fatal; a 422 ADDRESS_ERROR response is returned
+	 */
+	public function test_handle_request_returns_422_when_update_customer_fails(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andThrow( new Exception( 'cart/update-customer request return error: rest_invalid_param' ) );
+
+		$this->cart_endpoint->shouldNotReceive( 'select_shipping_rate' );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 'ADDRESS_ERROR', $response->get_data()['details'][0]['issue'] );
+	}
+
+	/**
+	 * GIVEN the Store API accepted the address but returned no shipping rates for it
+	 * WHEN handle_request() inspects the cart response
+	 * THEN a 422 ADDRESS_ERROR response is returned and no shipping rate is selected
+	 */
+	public function test_handle_request_returns_422_when_no_shipping_rates_found(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andReturn( $this->cart_response_with_rates( [] ) );
+
+		$this->cart_endpoint->shouldNotReceive( 'select_shipping_rate' );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 'ADDRESS_ERROR', $response->get_data()['details'][0]['issue'] );
+	}
+
+	/**
+	 * GIVEN the buyer picked a shipping option that the Store API then rejects
+	 * WHEN handle_request() calls select_shipping_rate()
+	 * THEN the exception does not escape as a fatal; a 422 METHOD_UNAVAILABLE response is returned
+	 */
+	public function test_handle_request_returns_422_when_select_shipping_rate_fails(): void
+	{
+		$request = $this->build_request(
+			[
+				'id'              => '5O190127TN364715T',
+				'shipping_option' => [ 'id' => 'flat_rate:2' ],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->cart_endpoint
+			->shouldReceive( 'select_shipping_rate' )
+			->once()
+			->with( 'wc-cart-token', 0, 'flat_rate:2' )
+			->andThrow( new Exception( 'cart/select-shipping-rate request return error: rest_invalid_param' ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 'METHOD_UNAVAILABLE', $response->get_data()['details'][0]['issue'] );
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
@@ -343,6 +343,72 @@ class ShippingCallbackEndpointTest extends TestCase
 	}
 
 	/**
+	 * GIVEN a callback payload with no shipping_address at all
+	 * WHEN handle_request() builds the address for the Store API
+	 * THEN an address of empty fields is forwarded instead of a fatal on a missing array key
+	 */
+	public function test_handle_request_defaults_shipping_address_when_missing(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => '',
+						'state'    => '',
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a callback payload with no purchase_units entry
+	 * WHEN handle_request() builds the success response
+	 * THEN the purchase unit falls back to the reference_id "default"
+	 */
+	public function test_handle_request_defaults_reference_id_when_purchase_units_missing(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$data = $response->get_data();
+		$this->assertSame( 'default', $data['purchase_units'][0]['reference_id'] );
+	}
+
+	/**
 	 * Builds a WP_REST_Request stub carrying the given decoded body params and a fixed
 	 * cart_token, the way the PayPal shipping callback sends them.
 	 */

--- a/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
+++ b/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
@@ -7,6 +7,7 @@ use Mockery;
 use WC_Order;
 use WC_Subscription;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use function Brain\Monkey\Filters\expectApplied;
@@ -310,5 +311,135 @@ class SubscriptionHelperTest extends TestCase
 		$helper->shouldReceive('cart_contains_renewal')->andReturn($cart_contains_renewal);
 
 		return $helper;
+	}
+
+	/**
+	 * GIVEN the cart does not contain a subscription
+	 * WHEN subscription_cart_processable() is called
+	 * THEN it returns true without resolving the subscription mode or checking button eligibility,
+	 *      since a non-subscription cart is always processable
+	 */
+	public function test_subscription_cart_processable_returns_true_when_cart_has_no_subscription(): void {
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+
+		$helper = Mockery::mock( SubscriptionHelper::class )->makePartial();
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( false );
+		$helper->shouldNotReceive( 'resolve_subscription_mode' );
+		$helper->shouldNotReceive( 'paypal_subscription_button_allowed' );
+
+		$this->assertTrue( $helper->subscription_cart_processable( $settings_provider ) );
+	}
+
+	/**
+	 * GIVEN a subscription is in the cart
+	 * WHEN subscription_cart_processable() is called
+	 * THEN it resolves whether PayPal Subscriptions mode applies and whether a vault token can be
+	 *      saved, then defers the final decision to paypal_subscription_button_allowed()
+	 * AND a vault token can only be saved when both a connected merchant (client_id) and
+	 *     "Save PayPal and Venmo" are present - one without the other keeps it un-savable
+	 *
+	 * @dataProvider subscription_cart_processable_wiring_provider
+	 */
+	public function test_subscription_cart_processable_wires_mode_and_vault_token_signals(
+		string $resolved_mode,
+		bool $save_paypal_and_venmo,
+		string $client_id,
+		bool $expected_is_paypal_subscription,
+		bool $expected_can_save_vault_token,
+		bool $button_allowed_result
+	): void {
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->allows( 'save_paypal_and_venmo' )->andReturn( $save_paypal_and_venmo );
+		$settings_provider->allows( 'merchant_data' )->andReturn(
+			new MerchantConnectionDTO( false, $client_id, '', '' )
+		);
+
+		$helper = Mockery::mock( SubscriptionHelper::class )->makePartial();
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( true );
+		$helper->shouldReceive( 'resolve_subscription_mode' )
+			->with( $settings_provider )
+			->andReturn( $resolved_mode );
+		$helper->shouldReceive( 'paypal_subscription_button_allowed' )
+			->with( $expected_is_paypal_subscription, $expected_can_save_vault_token )
+			->andReturn( $button_allowed_result );
+
+		$this->assertSame(
+			$button_allowed_result,
+			$helper->subscription_cart_processable( $settings_provider )
+		);
+	}
+
+	public function subscription_cart_processable_wiring_provider(): array {
+		return array(
+			'vaulting mode with vaulting enabled and connected merchant allows the button' => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING,
+				true,
+				'client-id-123',
+				false,
+				true,
+				true,
+			),
+			'subscriptions API mode with a PayPal plan allows the button'                  => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS,
+				false,
+				'',
+				true,
+				false,
+				true,
+			),
+			'subscriptions API mode without a plan and vaulting disabled hides the button' => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS,
+				false,
+				'',
+				true,
+				false,
+				false,
+			),
+			'manual-renewal-only subscription allows the button'                           => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_DISABLED,
+				false,
+				'',
+				false,
+				false,
+				true,
+			),
+			'vaulting enabled but no connected merchant keeps the vault token un-savable'   => array(
+				SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING,
+				true,
+				'',
+				false,
+				false,
+				false,
+			),
+		);
+	}
+
+	/**
+	 * GIVEN a subscription requiring a PayPal plan is in the cart
+	 * AND no PayPal plan is linked to the product
+	 * AND vaulting ("Save PayPal and Venmo") is disabled
+	 * WHEN subscription_cart_processable() runs end-to-end (mode resolution and button
+	 *      eligibility are not stubbed)
+	 * THEN it returns false, so the PayPal gateway is hidden instead of shown disabled
+	 */
+	public function test_subscription_cart_processable_end_to_end_hides_gateway_when_vaulting_disabled_and_no_plan(): void {
+		expectApplied( 'woocommerce_paypal_payments_subscription_mode_disabled' )
+			->once()
+			->with( false )
+			->andReturn( false );
+
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->allows( 'save_paypal_and_venmo' )->andReturn( false );
+		$settings_provider->allows( 'merchant_data' )->andReturn(
+			new MerchantConnectionDTO( false, '', '', '' )
+		);
+
+		$helper = Mockery::mock( SubscriptionHelper::class )->makePartial();
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( true );
+		$helper->shouldReceive( 'plugin_is_active' )->andReturn( true );
+		$helper->shouldReceive( 'accept_manual_renewals' )->andReturn( false );
+		$helper->shouldReceive( 'checkout_subscription_product_allowed' )->andReturn( false );
+
+		$this->assertFalse( $helper->subscription_cart_processable( $settings_provider ) );
 	}
 }

--- a/tests/PHPUnit/Webhooks/OwnWebhookResolverTest.php
+++ b/tests/PHPUnit/Webhooks/OwnWebhookResolverTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Webhooks\OwnWebhookResolver
+ */
+class OwnWebhookResolverTest extends TestCase
+{
+	/** @var IncomingWebhookEndpoint&Mockery\MockInterface */
+	private $incoming_webhook_endpoint;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		when('wp_parse_url')->alias('parse_url');
+
+		// Default: no webhook was previously stored for this install; individual
+		// tests override this when exercising the stored-id matching path.
+		when('get_option')->justReturn([]);
+
+		$this->incoming_webhook_endpoint = Mockery::mock(IncomingWebhookEndpoint::class);
+	}
+
+	private function createResolver(): OwnWebhookResolver
+	{
+		return new OwnWebhookResolver($this->incoming_webhook_endpoint);
+	}
+
+	/**
+	 * GIVEN webhook URLs that only differ by host case, a trailing slash, a port, a
+	 * query string, or the scheme
+	 * WHEN computing their identity
+	 * THEN all variants normalize to the same identity
+	 *
+	 * @dataProvider identity_normalization_provider
+	 */
+	public function test_identity_normalizes_url_variants(string $url): void
+	{
+		$this->assertSame(
+			'mysite.com/wp-json/paypal/v1/incoming',
+			$this->createResolver()->identity($url)
+		);
+	}
+
+	public function identity_normalization_provider(): array
+	{
+		return [
+			'plain'                => ['https://mysite.com/wp-json/paypal/v1/incoming'],
+			'host case differs'    => ['https://MySite.com/wp-json/paypal/v1/incoming'],
+			'trailing slash'       => ['https://mysite.com/wp-json/paypal/v1/incoming/'],
+			'port is ignored'      => ['https://mysite.com:8080/wp-json/paypal/v1/incoming'],
+			'query string ignored' => ['https://mysite.com/wp-json/paypal/v1/incoming?token=abc'],
+			'scheme is ignored'    => ['http://mysite.com/wp-json/paypal/v1/incoming'],
+		];
+	}
+
+	/**
+	 * GIVEN a URL that cannot be parsed into a host
+	 * WHEN computing its identity
+	 * THEN an empty string is returned
+	 *
+	 * @dataProvider unparseable_url_provider
+	 */
+	public function test_identity_returns_empty_string_for_unparseable_url(string $url): void
+	{
+		$resolver = $this->createResolver();
+
+		$this->assertSame('', $resolver->identity($url));
+	}
+
+	public function unparseable_url_provider(): array
+	{
+		return [
+			'not a valid URL' => ['not-a-valid-url'],
+			'empty string'    => [''],
+		];
+	}
+
+	/**
+	 * GIVEN this install previously stored a webhook id, and the webhook's host has since
+	 * changed (e.g. an NGROK_HOST rotation or domain migration)
+	 * WHEN checking whether a webhook with that stored id belongs to this install
+	 * THEN it is recognized as ours despite the host mismatch
+	 */
+	public function test_is_own_true_when_stored_id_matches_despite_host_change(): void
+	{
+		when('get_option')->justReturn([
+			'id'  => 'STORED_ID',
+			'url' => 'https://old-host.com/wp-json/paypal/v1/incoming',
+		]);
+
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://new-host.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://old-host.com/wp-json/paypal/v1/incoming', [], 'STORED_ID');
+
+		$this->assertTrue($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN no webhook id was previously stored for this install
+	 * WHEN checking whether a webhook whose URL matches this install's incoming endpoint host+path belongs to it
+	 * THEN it is recognized as ours
+	 */
+	public function test_is_own_true_on_url_identity_match_with_no_stored_id(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'SOME_ID');
+
+		$this->assertTrue($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a webhook registered on the same host as this install but under a different path
+	 * (e.g. sibling subdirectory installs)
+	 * WHEN checking whether it belongs to this install
+	 * THEN it is treated as foreign
+	 */
+	public function test_is_own_false_for_same_host_different_path(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://example.com/shop/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://example.com/staging/wp-json/paypal/v1/incoming', [], 'SIBLING');
+
+		$this->assertFalse($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a webhook registered for a completely different host
+	 * WHEN checking whether it belongs to this install
+	 * THEN it is treated as foreign
+	 */
+	public function test_is_own_false_for_foreign_host(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+
+		$this->assertFalse($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a webhook whose URL has no parseable host
+	 * WHEN checking whether it belongs to this install
+	 * THEN it is treated as foreign
+	 */
+	public function test_is_own_false_for_unparseable_webhook_url(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('not-a-valid-url', [], 'BROKEN');
+
+		$this->assertFalse($this->createResolver()->is_own($webhook));
+	}
+
+	/**
+	 * GIVEN a foreign webhook is listed FIRST and this install's own webhook is listed SECOND
+	 * WHEN finding this install's own webhook in the list
+	 * THEN the own webhook is still returned regardless of its position
+	 *
+	 * Regression case for PCP-6885: the previous code took list()[0], so a foreign
+	 * webhook returned first on the PayPal app hid the own webhook entirely.
+	 */
+	public function test_find_own_returns_own_webhook_when_foreign_webhook_is_listed_first(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$foreign_webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+		$own_webhook     = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+
+		$found = $this->createResolver()->find_own([$foreign_webhook, $own_webhook]);
+
+		$this->assertNotNull($found);
+		$this->assertSame('OWN', $found->id());
+	}
+
+	/**
+	 * GIVEN a list of webhooks none of which belong to this install
+	 * WHEN finding this install's own webhook
+	 * THEN null is returned
+	 */
+	public function test_find_own_returns_null_when_no_webhook_matches(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$foreign_webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+
+		$this->assertNull($this->createResolver()->find_own([$foreign_webhook]));
+	}
+
+	/**
+	 * GIVEN no webhooks are registered on PayPal's side
+	 * WHEN finding this install's own webhook
+	 * THEN null is returned
+	 */
+	public function test_find_own_returns_null_for_empty_list(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$this->assertNull($this->createResolver()->find_own([]));
+	}
+
+	/**
+	 * GIVEN a webhook list contaminated with non-Webhook values
+	 * WHEN finding this install's own webhook
+	 * THEN the malformed entries are skipped and the actual own webhook is still found
+	 */
+	public function test_find_own_skips_non_webhook_values(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$own_webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+
+		$found = $this->createResolver()->find_own([new \stdClass(), 'a-string', $own_webhook]);
+
+		$this->assertNotNull($found);
+		$this->assertSame('OWN', $found->id());
+	}
+}

--- a/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
+++ b/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
@@ -74,7 +74,8 @@ class WebhookRegistrarTest extends TestCase
 			$this->last_webhook_event_storage,
 			$this->webhook_simulation,
 			$this->webhook_orchestrator,
-			$this->logger
+			$this->logger,
+			new OwnWebhookResolver($this->incoming_webhook_endpoint)
 		);
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ const modulesAssets = {
 		'js/checkout-block.js',
 		'js/boot-add-payment-method.js',
 		'css/gateway.scss',
+		'css/checkout-block.scss',
 	],
 	'ppcp-settings': [ 'js/index.js', 'css/styles.scss' ],
 	'ppcp-wc-gateway': [

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     4.1.2
+ * Version:     4.1.3
  * Author:      PayPal
  * Author URI:  https://paypal.com/
  * License:     GPL-2.0
@@ -11,7 +11,7 @@
  * Requires Plugins: woocommerce
  * Requires at least: 6.5
  * WC requires at least: 9.6
- * WC tested up to: 10.9
+ * WC tested up to: 11.0
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -25,7 +25,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2026-07-22' );
+define( 'PAYPAL_INTEGRATION_DATE', '2026-09-02' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
*Changelog:* `Fix - Express PayPal buttons now complete the order instead of redirecting to the checkout page #4699`

# Description

## 🐛 The problem

With the Pay Now experience on SDK v6, the PayPal button on product and cart pages sent the buyer to the WooCommerce checkout page instead of completing the order right after approval.

## 💡 Why it happens

Before approval, PayPal gives us no usable buyer address. The plugin took that as "no shipping details at all" and discarded the **shipping methods** along with the address. An order without shipping methods cannot be completed in the popup, so PayPal falls back to the redirect.

## ✅ The fix

An unusable address no longer costs the shipping methods. They are sent on their own, and the places that decide the shipping preference and assemble the request treat "methods, but no address yet" as a normal state.

## 🔍 What to review

Shipping details without an address are new to this plugin. Everything downstream reads the address back from PayPal's response, so the only path worth a second look is the one that patches an existing PayPal order.

No signature, hook or script handle changed.

## 🧪 How to verify

(testable in incognito window to start with an uninitialized session)

1. Enable the Pay Now experience with SDK v6, then add a physical product to the cart as a guest.
2. Click the PayPal button on the product page and on the cart page and approve in the popup: the order finishes without a stop at the checkout page.
3. On classic checkout with a complete address in the form, place an order through the PayPal button: shipping stays the address that was entered.
