### PR TITLE
Withhold the v6 flag from Mexican merchants at onboarding

### DIFF
--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -21,7 +21,6 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\CartQuoteEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
-use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
@@ -119,13 +118,6 @@ return array(
 		};
 	},
 
-	'sdk-v6.merchant-country-support'   => static function ( ContainerInterface $container ): MerchantCountrySupport {
-		$settings_provider = $container->get( 'settings.settings-provider' );
-		assert( $settings_provider instanceof SettingsProvider );
-
-		return new MerchantCountrySupport( $settings_provider->merchant_country() );
-	},
-
 	'sdk-v6.card-field-styles'          => static function (): CardFieldStyles {
 		return new CardFieldStyles();
 	},
@@ -186,8 +178,7 @@ return array(
 			$container->get( 'sdk-v6.google-pay-config' ),
 			$container->get( 'sdk-v6.apple-pay-config' ),
 			$container->get( 'sdk-v6.fastlane-config' ),
-			$container->get( 'sdk-v6.card-field-styles' ),
-			$container->get( 'sdk-v6.merchant-country-support' )
+			$container->get( 'sdk-v6.card-field-styles' )
 		);
 	},
 
@@ -207,8 +198,7 @@ return array(
 				&& $container->get( 'save-payment-methods.eligible' )
 				&& $settings_provider->save_card_details(),
 			$settings_provider,
-			$container->get( 'sdk-v6.card-field-styles' ),
-			$container->get( 'sdk-v6.merchant-country-support' )
+			$container->get( 'sdk-v6.card-field-styles' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
@@ -22,7 +22,6 @@ use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
-use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -47,7 +46,6 @@ class AddPaymentMethodManager {
 	private SettingsProvider $settings_provider;
 
 	private CardFieldStyles $card_field_styles;
-	private MerchantCountrySupport $merchant_country_support;
 
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -57,18 +55,16 @@ class AddPaymentMethodManager {
 		bool $paypal_vaulting_enabled,
 		bool $card_vaulting_enabled,
 		SettingsProvider $settings_provider,
-		CardFieldStyles $card_field_styles,
-		MerchantCountrySupport $merchant_country_support
+		CardFieldStyles $card_field_styles
 	) {
-		$this->asset_getter             = $asset_getter;
-		$this->version                  = $version;
-		$this->environment              = $environment;
-		$this->context                  = $context;
-		$this->paypal_vaulting_enabled  = $paypal_vaulting_enabled;
-		$this->card_vaulting_enabled    = $card_vaulting_enabled;
-		$this->settings_provider        = $settings_provider;
-		$this->card_field_styles        = $card_field_styles;
-		$this->merchant_country_support = $merchant_country_support;
+		$this->asset_getter            = $asset_getter;
+		$this->version                 = $version;
+		$this->environment             = $environment;
+		$this->context                 = $context;
+		$this->paypal_vaulting_enabled = $paypal_vaulting_enabled;
+		$this->card_vaulting_enabled   = $card_vaulting_enabled;
+		$this->settings_provider       = $settings_provider;
+		$this->card_field_styles       = $card_field_styles;
 	}
 
 	/**
@@ -120,8 +116,7 @@ class AddPaymentMethodManager {
 	 * Whether the v6 save surfaces load on the current page.
 	 */
 	public function should_load_on_current_page(): bool {
-		return $this->merchant_country_support->is_supported()
-			&& is_user_logged_in()
+		return is_user_logged_in()
 			&& ( $this->paypal_vaulting_enabled || $this->card_vaulting_enabled )
 			&& $this->context->is_add_payment_method_page();
 	}

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -34,7 +34,6 @@ use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
-use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
@@ -115,7 +114,6 @@ class SdkV6Manager {
 	private MessageStyleMapper $message_style_mapper;
 	private MessagesEligibility $messages_eligibility;
 	private string $merchant_country;
-	private MerchantCountrySupport $merchant_country_support;
 
 	/**
 	 * Card brand icons ({type, title, url}); empty when "Show logos" is off.
@@ -194,8 +192,7 @@ class SdkV6Manager {
 		GooglePayConfig $google_pay_config,
 		ApplePayConfig $apple_pay_config,
 		FastlaneConfig $fastlane_config,
-		CardFieldStyles $card_field_styles,
-		MerchantCountrySupport $merchant_country_support
+		CardFieldStyles $card_field_styles
 	) {
 		$this->asset_getter                = $asset_getter;
 		$this->version                     = $version;
@@ -220,7 +217,6 @@ class SdkV6Manager {
 		$this->apple_pay_config            = $apple_pay_config;
 		$this->fastlane_config             = $fastlane_config;
 		$this->card_field_styles           = $card_field_styles;
-		$this->merchant_country_support    = $merchant_country_support;
 
 		$this->placements = array(
 			new MethodPlacement(
@@ -556,10 +552,6 @@ class SdkV6Manager {
 	 * The uncached answer for should_load_on_current_page().
 	 */
 	private function resolve_should_load(): bool {
-		if ( ! $this->merchant_country_support->is_supported() ) {
-			return false;
-		}
-
 		// Native PayPal Subscriptions (subscriptions_api mode) have no v6 path: v6
 		// can only carry a subscription by vaulting, which that mode disables. Hand
 		// the whole page back to the v5 stack, which creates the subscription via

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -21,10 +21,12 @@ use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\CartQuoteEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedShippingRate;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedQuote;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RecordedTaxBasis;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -225,6 +227,21 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 				add_action( 'wp_enqueue_scripts', $suppress_v5_methods, 5 );
 				add_action( 'enqueue_block_editor_assets', $suppress_v5_methods, 5 );
 			}
+		);
+
+		// Priority 20: the country is resolved by the priority 10 handler.
+		add_action(
+			'woocommerce_paypal_payments_authenticated_merchant',
+			static function () use ( $c ) {
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
+
+				$support = new MerchantCountrySupport( $settings_provider->merchant_country() );
+				if ( ! $support->is_supported() ) {
+					update_option( 'woocommerce-ppcp-sdk-v6-eligible', 'no' );
+				}
+			},
+			20
 		);
 
 		return true;

--- a/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
@@ -11,7 +11,6 @@ use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
-use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -41,8 +40,7 @@ class AddPaymentMethodManagerTest extends TestCase
 
     private function createTestee(
         bool $paypal_vaulting_enabled = false,
-        bool $card_vaulting_enabled = false,
-        string $merchant_country = 'US'
+        bool $card_vaulting_enabled = false
     ): AddPaymentMethodManager {
         return new AddPaymentMethodManager(
             $this->asset_getter,
@@ -52,8 +50,7 @@ class AddPaymentMethodManagerTest extends TestCase
             $paypal_vaulting_enabled,
             $card_vaulting_enabled,
             $this->settings_provider,
-            $this->card_field_styles,
-            new MerchantCountrySupport($merchant_country)
+            $this->card_field_styles
         );
     }
 

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -16,7 +16,6 @@ use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
-use WooCommerce\PayPalCommerce\SdkV6\Helper\MerchantCountrySupport;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessagesEligibility;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\MessageStyleMapper;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
@@ -208,8 +207,7 @@ class SdkV6ManagerTest extends TestCase
 	        $this->google_pay_config,
 	        $this->apple_pay_config,
 	        $this->fastlane_config,
-	        $this->card_field_styles,
-	        new MerchantCountrySupport($merchant_country)
+	        $this->card_field_styles
         );
     }
 


### PR DESCRIPTION
### Description

Mexican merchants are served the v5 stack.

On merchant authentication, an unsupported country sets `woocommerce-ppcp-sdk-v6-eligible` to `no`, so the v6 module never registers. Priority 20, because the country is resolved by the priority 10 handler.

Also reverts #4697 - the runtime gate this replaces.

New onboardings only; already-connected Mexican merchants keep v6.

**BC:** `woocommerce_paypal_payments_sdk_v6_unsupported_countries` still works,
but is consulted at authentication instead of per page load, so it no longer
affects connected stores. 