### PR TITLE
Add QIT workflow

### DIFF
--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -1,0 +1,44 @@
+name: QIT
+
+on:
+  workflow_run:
+    workflows: [ 'Build and distribute' ]
+    types: [ completed ]
+    branches: [ 'dev/develop', 'dev/release/**' ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build plugin package
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@f414e0b4da6c51adeee419cdd5fbbf299ae0167e # pinning PR #290
+    secrets:
+      GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
+      GITHUB_USER_NAME: ${{ secrets.DEPLOYBOT_USER }}
+      GITHUB_USER_SSH_KEY: ${{ secrets.DEPLOYBOT_SSH_PRIVATE_KEY }}
+      GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
+      NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_GITHUB_TOKEN_PACKAGES }}
+    with:
+      PACKAGE_NAME: 'woocommerce-paypal-payments'
+      PACKAGE_VERSION: ${{ inputs.PACKAGE_VERSION }}
+      NODE_VERSION: 22
+
+  qit:
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ['phpcompatibility', 'validation', 'activation', 'woo-api', 'security', 'malware']
+    uses: inpsyde/reusable-workflows/.github/workflows/woo-qit.yml@f414e0b4da6c51adeee419cdd5fbbf299ae0167e
+    needs: build
+    secrets:
+      WOO_PARTNER_USER: ${{ secrets.WOO_PARTNER_USER }}
+      WOO_PARTNER_SECRET: ${{ secrets.WOO_PARTNER_SECRET }}
+    with:
+      ARTIFACT_NAME: ${{ needs.build.outputs.artifact }}
+      QIT_TEST: ${{ matrix.test }}


### PR DESCRIPTION
Added the QIT workflow so that it can be run manually (after this PR is merged) in any `dev/` branch, similarly to the build workflow. And also it will run automatically in the `dev/develop` and `dev/release/*` branches after the build is completed, similarly to our e2e tests.

I think for now it makes sense to limit automatic runs to just these branches to avoid spamming Woo with too many requests (not sure if there is some kind of rate limiting), and also while some old unfixed errors remain it would be annoying to see it on every push and PR (but even after they are fixed, some of the checks are not related to any changes in the plugin, such as its checks if support for latest WC and WP versions is declared, and features like HPOS).

Currently it executes these QIT test suites, most of them are used by the new excellence badge (probably except `phpcompatibility` and `woo-api`): `phpcompatibility`, `validation`, `activation`, `woo-api`, `security`, `malware`.

I also tried to add

- `plugin-check` (for wp .org) but it was reporting 300+ errors, most of them seem to be about not escaping exceptions or missing `! defined( 'ABSPATH' )`, maybe we should revisit it later. https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/34571725574/job/103175645528
- `woo-e2e` but it got cancelled by the 5 minute timeout, then I tried to run it locally to see how much time it takes but it got stuck on "installing Playwright browsers" for an hour. So for now I removed it, not sure if it actually would be useful. 

A run example: https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/34576318668