### PR TITLE
Stop cart simulation discarding a concurrent add to cart

### DIFF
--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -61,6 +61,10 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 			return;
 		}
 
+		// Nothing here is meant to outlive the response, and persisting the
+		// session would discard a concurrent add-to-cart.
+		$this->prevent_session_persistence();
+
 		$result       = $this->cart_simulator->simulate( $products );
 		$total        = $result['total'];
 		$shipping_fee = $result['shipping_fee'];

--- a/modules/ppcp-order-endpoints/src/Endpoint/AbstractCartEndpoint.php
+++ b/modules/ppcp-order-endpoints/src/Endpoint/AbstractCartEndpoint.php
@@ -181,4 +181,27 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	protected function remove_cart_items(): void {
 		$this->cart_products->remove_cart_items();
 	}
+
+	/**
+	 * Stops WooCommerce writing the session at the end of this request.
+	 *
+	 * Calculating totals writes shipping rates into the live session, and
+	 * save_data() then replaces the whole row on shutdown from the snapshot this
+	 * request began with, discarding an add-to-cart that completed in between.
+	 *
+	 * Only for requests with nothing to persist: the write happens on shutdown,
+	 * so this cannot be re-enabled once the work is done.
+	 */
+	protected function prevent_session_persistence(): void {
+		if ( ! function_exists( 'WC' ) ) {
+			return;
+		}
+
+		$session = WC()->session;
+		if ( ! $session instanceof \WC_Session ) {
+			return;
+		}
+
+		remove_action( 'shutdown', array( $session, 'save_data' ), 20 );
+	}
 }

--- a/modules/ppcp-sdk-v6/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-sdk-v6/src/Endpoint/SimulateCartEndpoint.php
@@ -72,6 +72,10 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 			return;
 		}
 
+		// Nothing here is meant to outlive the response, and persisting the
+		// session would discard a concurrent add-to-cart.
+		$this->prevent_session_persistence();
+
 		$result = $this->cart_simulator->simulate( $products );
 
 		wp_send_json_success(

--- a/tests/PHPUnit/Button/Endpoint/SimulateCartEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/SimulateCartEndpointTest.php
@@ -1,0 +1,232 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Endpoint;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\Button\Assets\SmartButton;
+use WooCommerce\PayPalCommerce\Button\Helper\IsolatedCartSimulator;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\OrderEndpoints\Helper\CartProductsHelper;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class SimulateCartEndpointTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * @var SmartButton&Mockery\MockInterface
+	 */
+	private $smart_button;
+
+	/**
+	 * @var RequestData&Mockery\MockInterface
+	 */
+	private $request_data;
+
+	/**
+	 * @var CartProductsHelper&Mockery\MockInterface
+	 */
+	private $cart_products;
+
+	/**
+	 * @var IsolatedCartSimulator&Mockery\MockInterface
+	 */
+	private $cart_simulator;
+
+	private SimulateCartEndpoint $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->smart_button   = Mockery::mock( SmartButton::class );
+		$this->request_data   = Mockery::mock( RequestData::class );
+		$this->cart_products  = Mockery::mock( CartProductsHelper::class );
+		$this->cart_simulator = Mockery::mock( IsolatedCartSimulator::class );
+		$logger               = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+
+		$this->sut = new SimulateCartEndpoint(
+			$this->smart_button,
+			$this->request_data,
+			$this->cart_products,
+			$this->cart_simulator,
+			$logger
+		);
+	}
+
+	private function stub_posted_products( array $products ): void {
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( SimulateCartEndpoint::nonce() )
+			->andReturn( array( 'products' => $products ) );
+
+		$this->cart_products->shouldReceive( 'products_from_data' )
+			->andReturn( $products );
+	}
+
+	/**
+	 * Stubs WC() with no session, so prevent_session_persistence() takes its
+	 * no-op path. Explicit because another test file may already have defined
+	 * WC(), which would otherwise decide this test's outcome.
+	 */
+	private function stub_wc_without_session(): void {
+		$wc          = Mockery::mock( 'WooCommerce' );
+		$wc->session = null;
+		when( 'WC' )->justReturn( $wc );
+	}
+
+	private function stub_smart_button_flags( array $context_data ): void {
+		$this->smart_button->shouldReceive( 'is_pay_later_button_enabled_for_location' )
+			->with( 'product', $context_data )
+			->andReturn( true );
+		$this->smart_button->shouldReceive( 'is_pay_later_messaging_enabled_for_location' )
+			->with( 'product', $context_data )
+			->andReturn( true );
+		$this->smart_button->shouldReceive( 'is_button_disabled' )
+			->with( 'product', $context_data )
+			->andReturn( false );
+	}
+
+	/**
+	 * GIVEN a posted product for which the merchant has cart simulation enabled
+	 * WHEN the request is handled
+	 * THEN the response contains the simulated total, shipping fee, and the shop's pay
+	 * later and button-state flags
+	 */
+	public function test_responds_with_simulated_totals_and_button_state(): void {
+		$this->stub_wc_without_session();
+		when( 'apply_filters' )->justReturn( true );
+		when( 'wc_get_base_location' )->justReturn( array( 'country' => 'US' ) );
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$posted_products = array( array( 'product' => 'a-product', 'quantity' => 2 ) );
+		$this->stub_posted_products( $posted_products );
+
+		$this->cart_simulator->shouldReceive( 'simulate' )
+			->once()
+			->with( $posted_products )
+			->andReturn( array( 'total' => 19.99, 'shipping_fee' => 4.5 ) );
+
+		$this->stub_smart_button_flags(
+			array(
+				'product'     => 'a-product',
+				'order_total' => 19.99,
+			)
+		);
+
+		expect( 'wp_send_json_success' )
+			->once()
+			->with(
+				array(
+					'total'         => 19.99,
+					'shipping_fee'  => 4.5,
+					'currency_code' => 'USD',
+					'country_code'  => 'US',
+					'funding'       => array(
+						'paylater' => array(
+							'enabled' => true,
+						),
+					),
+					'button'        => array(
+						'is_disabled' => false,
+					),
+					'messages'      => array(
+						'is_hidden' => false,
+					),
+				)
+			);
+
+		$this->sut->handle_request();
+	}
+
+	/**
+	 * GIVEN a WooCommerce session with WC_Session_Handler::save_data registered on the
+	 * shutdown hook - the mechanism that overwrites the whole session row from a stale
+	 * snapshot and can wipe a concurrent shopper's cart
+	 * WHEN a simulate-cart request is handled
+	 * THEN that shutdown persistence is removed before the simulation runs, so this
+	 * read-only request has nothing left to write back to the session
+	 */
+	public function test_removes_session_persistence_before_simulating(): void {
+		when( 'apply_filters' )->justReturn( true );
+		when( 'wc_get_base_location' )->justReturn( array( 'country' => 'US' ) );
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		when( 'wp_send_json_success' )->justReturn( null );
+
+		$session  = Mockery::mock( \WC_Session::class );
+		$callback = array( $session, 'save_data' );
+		add_action( 'shutdown', $callback, 20 );
+
+		$wc          = Mockery::mock();
+		$wc->session = $session;
+		when( 'WC' )->justReturn( $wc );
+
+		$posted_products = array( array( 'product' => 'a-product', 'quantity' => 1 ) );
+		$this->stub_posted_products( $posted_products );
+
+		$this->cart_simulator->shouldReceive( 'simulate' )
+			->once()
+			->andReturn( array( 'total' => 19.99, 'shipping_fee' => 0.0 ) );
+
+		$this->stub_smart_button_flags(
+			array(
+				'product'     => 'a-product',
+				'order_total' => 19.99,
+			)
+		);
+
+		$this->sut->handle_request();
+
+		$this->assertFalse( has_action( 'shutdown', $callback, 20 ) );
+	}
+
+	/**
+	 * GIVEN the merchant has switched cart simulation off via the
+	 * woocommerce_paypal_payments_simulate_cart_enabled filter
+	 * WHEN the request is handled
+	 * THEN no cart is simulated and an error response is sent
+	 */
+	public function test_skips_simulation_when_disabled_by_filter(): void {
+		$this->stub_wc_without_session();
+		expect( 'apply_filters' )
+			->once()
+			->with( 'woocommerce_paypal_payments_simulate_cart_enabled', true )
+			->andReturn( false );
+
+		// The endpoint does not return after sending the disabled-error response, so
+		// execution falls through; these stubs keep that fall-through from failing on
+		// posted data, while proving cart simulation is never actually performed.
+		$this->request_data->shouldReceive( 'read_request' )->andReturn( array() );
+		$this->cart_products->shouldReceive( 'products_from_data' )->andReturn( null );
+
+		$this->cart_simulator->shouldReceive( 'simulate' )->never();
+
+		expect( 'wp_send_json_error' )->atLeast()->once();
+
+		$this->sut->handle_request();
+	}
+
+	/**
+	 * GIVEN no usable products were posted
+	 * WHEN the request is handled
+	 * THEN no cart is simulated and an error response is sent
+	 */
+	public function test_skips_simulation_when_no_products_are_posted(): void {
+		$this->stub_wc_without_session();
+		when( 'apply_filters' )->justReturn( true );
+
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( SimulateCartEndpoint::nonce() )
+			->andReturn( array() );
+
+		$this->cart_products->shouldReceive( 'products_from_data' )->andReturn( null );
+
+		$this->cart_simulator->shouldReceive( 'simulate' )->never();
+
+		expect( 'wp_send_json_error' )->atLeast()->once();
+
+		$this->sut->handle_request();
+	}
+}

--- a/tests/PHPUnit/OrderEndpoints/Endpoint/AbstractCartEndpointTest.php
+++ b/tests/PHPUnit/OrderEndpoints/Endpoint/AbstractCartEndpointTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * A concrete cart endpoint exposing prevent_session_persistence() for direct testing,
+ * since the method it verifies is protected and AbstractCartEndpoint itself is abstract.
+ */
+class TestableCartEndpoint extends AbstractCartEndpoint {
+
+	protected function handle_data(): void {}
+
+	public function prevent_session_persistence(): void {
+		parent::prevent_session_persistence();
+	}
+}
+
+class AbstractCartEndpointTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	private TestableCartEndpoint $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new TestableCartEndpoint();
+	}
+
+	/**
+	 * GIVEN a live WooCommerce session with WC_Session_Handler::save_data registered
+	 * on the shutdown hook, the mechanism that would otherwise overwrite the whole
+	 * session row with a stale snapshot
+	 * WHEN prevent_session_persistence() is called
+	 * THEN that shutdown persistence is removed, so nothing this request wrote to the
+	 * session overwrites a concurrent request's changes
+	 */
+	public function test_removes_the_session_save_data_shutdown_hook(): void {
+		$session  = Mockery::mock( \WC_Session::class );
+		$callback = array( $session, 'save_data' );
+		add_action( 'shutdown', $callback, 20 );
+
+		$wc          = Mockery::mock();
+		$wc->session = $session;
+		when( 'WC' )->justReturn( $wc );
+
+		$this->sut->prevent_session_persistence();
+
+		$this->assertFalse( has_action( 'shutdown', $callback, 20 ) );
+	}
+
+	/**
+	 * GIVEN WooCommerce has no usable session object for this request - either because
+	 * WC()->session was never initialized, or because it holds something other than a
+	 * WC_Session (contexts like cron or a webhook do not guarantee session state)
+	 * WHEN prevent_session_persistence() is called
+	 * THEN nothing is removed and no error is raised
+	 *
+	 * @dataProvider missing_session_provider
+	 */
+	public function test_does_nothing_when_no_usable_session_is_present( $session ): void {
+		$wc          = Mockery::mock();
+		$wc->session = $session;
+		when( 'WC' )->justReturn( $wc );
+
+		$unrelated_session = Mockery::mock( \WC_Session::class );
+		$callback          = array( $unrelated_session, 'save_data' );
+		add_action( 'shutdown', $callback, 20 );
+
+		$this->sut->prevent_session_persistence();
+
+		$this->assertTrue( has_action( 'shutdown', $callback, 20 ) );
+	}
+
+	public function missing_session_provider(): array {
+		return array(
+			'session property was never initialized' => array( null ),
+			'session property is not a WC_Session'   => array( new \stdClass() ),
+		);
+	}
+
+}

--- a/tests/PHPUnit/SdkV6/Endpoint/SimulateCartEndpointTest.php
+++ b/tests/PHPUnit/SdkV6/Endpoint/SimulateCartEndpointTest.php
@@ -60,6 +60,16 @@ class SimulateCartEndpointTest extends TestCase {
 	}
 
 	/**
+	 * Stubs WC() with no session, so prevent_session_persistence() takes its
+	 * no-op path and the test stays about the endpoint's own behaviour.
+	 */
+	private function stub_wc_without_session(): void {
+		$wc          = Mockery::mock( 'WooCommerce' );
+		$wc->session = null;
+		when( 'WC' )->justReturn( $wc );
+	}
+
+	/**
 	 * GIVEN a posted product for which the merchant has cart simulation enabled
 	 * WHEN the request is handled
 	 * THEN the response contains only the simulated total and the shop's currency code,
@@ -71,6 +81,7 @@ class SimulateCartEndpointTest extends TestCase {
 		when( 'wc_get_price_decimals' )->justReturn( 2 );
 		when( 'wc_format_decimal' )->justReturn( '19.99' );
 		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		$this->stub_wc_without_session();
 
 		$posted_products = array( array( 'product' => 'a-product', 'quantity' => 2 ) );
 		$this->stub_posted_products( $posted_products );
@@ -104,6 +115,41 @@ class SimulateCartEndpointTest extends TestCase {
 		when( 'wc_format_decimal' )->justReturn( '19.99' );
 		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
 		when( 'wp_send_json_success' )->justReturn( null );
+		$this->stub_wc_without_session();
+
+		$posted_products = array( array( 'product' => 'a-product', 'quantity' => 1 ) );
+		$this->stub_posted_products( $posted_products );
+
+		// The only source of a total: nothing reads WC()->cart.
+		$this->cart_simulator->shouldReceive( 'simulate' )
+			->once()
+			->andReturn( array( 'total' => 19.99, 'shipping_fee' => 0.0 ) );
+
+		$this->sut->handle_request();
+	}
+
+	/**
+	 * GIVEN a WooCommerce session with WC_Session_Handler::save_data registered on the
+	 * shutdown hook - the mechanism that overwrites the whole session row from a stale
+	 * snapshot and can wipe a concurrent shopper's cart
+	 * WHEN a simulate-cart request is handled
+	 * THEN that shutdown persistence is removed before the simulation runs, so this
+	 * read-only request has nothing left to write back to the session
+	 */
+	public function test_removes_session_persistence_before_simulating(): void {
+		when( 'apply_filters' )->justReturn( true );
+		when( 'wc_get_price_decimals' )->justReturn( 2 );
+		when( 'wc_format_decimal' )->justReturn( '19.99' );
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		when( 'wp_send_json_success' )->justReturn( null );
+
+		$session  = Mockery::mock( \WC_Session::class );
+		$callback = array( $session, 'save_data' );
+		add_action( 'shutdown', $callback, 20 );
+
+		$wc          = Mockery::mock();
+		$wc->session = $session;
+		when( 'WC' )->justReturn( $wc );
 
 		$posted_products = array( array( 'product' => 'a-product', 'quantity' => 1 ) );
 		$this->stub_posted_products( $posted_products );
@@ -112,9 +158,9 @@ class SimulateCartEndpointTest extends TestCase {
 			->once()
 			->andReturn( array( 'total' => 19.99, 'shipping_fee' => 0.0 ) );
 
-		expect( 'WC' )->never();
-
 		$this->sut->handle_request();
+
+		$this->assertFalse( has_action( 'shutdown', $callback, 20 ) );
 	}
 
 	/**


### PR DESCRIPTION
A merchant reported add-to-cart intermittently doing nothing: the success notice appears, then the cart is empty. `?wc-ajax=ppc-simulate-cart` races the add-to-cart POST and wins.

## Why it happens

1. Simulating a cart calls `calculate_totals()`, and WooCommerce writes shipping rates straight into the live session (`WC_Shipping::calculate_shipping_for_package()`). The simulator's isolation disables the *cart's* session hooks, so it cannot prevent this.
2. That marks the real session dirty.
3. `WC_Session_Handler::save_data()`, on `shutdown` at priority 20, replaces the **whole** session row from the snapshot the request began with. There is no per-key merge.
4. An add-to-cart that completes in between is inside the row the simulate request then overwrites, so the item disappears.

Confirmed locally: before `simulate()` the session had no `shipping_for_package_0`; afterwards it did.

## Fix

A simulate request has nothing to persist, so it opts out of the shutdown write:

```php
remove_action( 'shutdown', array( $session, 'save_data' ), 20 );
```

Added as `AbstractCartEndpoint::prevent_session_persistence()` and called by both `SimulateCartEndpoint`s. `ChangeCartEndpoint` deliberately does not call it: it mutates the cart and must persist.

It also stops simulation leaving shipping rates for a cart the shopper does not have in their session.

## Scope

This removes the plugin's trigger, not the underlying weakness. `save_data()` is a whole-row, last-writer-wins write, so any concurrent request that dirties the session can still discard a cart.

The reported secondary issue, simulation firing when no PayPal button rendered, is not addressed here. It narrows the window rather than closing it and belongs in its own change.

## Backward compatibility

No impact. One added protected method on an abstract class; no signature, hook, or response-shape changes.

## Test steps

Needs a simple product and a shipping method that applies everywhere (e.g. flat rate).

1. Add `usleep( 2000000 )` to an `wc_ajax_ppc-simulate-cart` callback at priority 1, so the simulation finishes after the add-to-cart POST.
2. On the product page, fire a simulate request shortly after clicking add to cart (change quantity or a variation, then add, or trigger it directly).
3. Open the cart. Before: empty. After: the item is there.

Verifying without the delay: check `wp_woocommerce_sessions` for the customer, and confirm a simulate request no longer rewrites the row.
